### PR TITLE
Add device_id property, rename context to child_id

### DIFF
--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -76,7 +76,7 @@ class SmartBulb(SmartDevice):
         self,
         host: str,
         protocol: TPLinkSmartHomeProtocol = None,
-        context: str = None,
+        child_id: str = None,
         cache_ttl: int = 3,
         *,
         ioloop=None,
@@ -85,7 +85,7 @@ class SmartBulb(SmartDevice):
             self,
             host=host,
             protocol=protocol,
-            context=context,
+            child_id=child_id,
             cache_ttl=cache_ttl,
             ioloop=ioloop,
         )

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -40,12 +40,12 @@ class SmartPlug(SmartDevice):
         self,
         host: str,
         protocol: "TPLinkSmartHomeProtocol" = None,
-        context: str = None,
+        child_id: str = None,
         cache_ttl: int = 3,
         *,
         ioloop=None,
     ) -> None:
-        SmartDevice.__init__(self, host, protocol, context, cache_ttl, ioloop=ioloop)
+        SmartDevice.__init__(self, host, protocol, child_id, cache_ttl, ioloop=ioloop)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug
 
@@ -90,12 +90,6 @@ class SmartPlug(SmartDevice):
         else:
             raise ValueError("Brightness value %s is not valid." % value)
 
-    def _get_child_info(self):
-        for plug in self.sys_info["children"]:
-            if plug["id"] == self.context:
-                return plug
-        raise SmartDeviceException("Unable to find children %s")
-
     @property  # type: ignore
     @requires_update
     def alias(self) -> str:
@@ -104,7 +98,7 @@ class SmartPlug(SmartDevice):
         :return: Device name aka alias.
         :rtype: str
         """
-        if self.context:
+        if self.is_child_device:
             info = self._get_child_info()
             return info["alias"]
         else:
@@ -140,7 +134,7 @@ class SmartPlug(SmartDevice):
 
         :return: True if device is on, False otherwise
         """
-        if self.context:
+        if self.is_child_device:
             info = self._get_child_info()
             return info["state"]
 
@@ -192,7 +186,7 @@ class SmartPlug(SmartDevice):
         :rtype: datetime
         """
         sys_info = self.sys_info
-        if self.context:
+        if self.is_child_device:
             info = self._get_child_info()
             on_time = info["on_time"]
         else:

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -79,7 +79,7 @@ class SmartStrip(SmartPlug):
                     SmartPlug(
                         self.host,
                         self.protocol,
-                        context=child["id"],
+                        child_id=child["id"],
                         cache_ttl=self.cache_ttl.total_seconds(),
                         ioloop=self.ioloop,
                     )


### PR DESCRIPTION
For regular devices, device_id is the mac address and for child devices it is a combination of the mac address and the child_id.

This is simply a helper to simplify the downstream code for homeassistant.