### PR TITLE
Remove unused save option and add scrubbing

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -2,6 +2,7 @@
 import asyncio
 import json
 import logging
+import re
 from pprint import pformat as pf
 
 import click
@@ -81,22 +82,42 @@ def cli(ctx, host, alias, target, debug, bulb, plug, strip):
 
 
 @cli.command()
-@click.option("--save")
+@click.option("--scrub", is_flag=True)
 @click.pass_context
-def dump_discover(ctx, save):
+def dump_discover(ctx, scrub):
     """Dump discovery information.
 
-    Useful for dumping into a file with `--save` to be added to the test suite.
+    Useful for dumping into a file to be added to the test suite.
     """
     target = ctx.parent.params["target"]
+    keys_to_scrub = [
+        "deviceId",
+        "fwId",
+        "hwId",
+        "oemId",
+        "mac",
+        "latitude_i",
+        "longitude_i",
+    ]
     devs = asyncio.run(Discover.discover(target=target, return_raw=True))
     for dev in devs.values():
+        if scrub:
+            for key in keys_to_scrub:
+                if key in dev["system"]["get_sysinfo"]:
+                    val = dev["system"]["get_sysinfo"][key]
+                    if key in ["latitude_i", "longitude_i"]:
+                        val = 0
+                    else:
+                        val = re.sub("\w", "0", val)
+                    dev["system"]["get_sysinfo"][key] = val
+
         model = dev["system"]["get_sysinfo"]["model"]
         hw_version = dev["system"]["get_sysinfo"]["hw_ver"]
         save_to = f"{model}_{hw_version}.json"
         click.echo("Saving info to %s" % save_to)
         with open(save_to, "w") as f:
             json.dump(dev, f, sort_keys=True, indent=4)
+            f.write("\n")
 
 
 @cli.command()

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -98,6 +98,8 @@ def dump_discover(ctx, scrub):
         "mac",
         "latitude_i",
         "longitude_i",
+        "latitude",
+        "longitude",
     ]
     devs = asyncio.run(Discover.discover(target=target, return_raw=True))
     if scrub:

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -82,7 +82,7 @@ def cli(ctx, host, alias, target, debug, bulb, plug, strip):
 
 
 @cli.command()
-@click.option("--scrub", is_flag=True)
+@click.option("--scrub/--no-scrub", default=True)
 @click.pass_context
 def dump_discover(ctx, scrub):
     """Dump discovery information.
@@ -100,6 +100,8 @@ def dump_discover(ctx, scrub):
         "longitude_i",
     ]
     devs = asyncio.run(Discover.discover(target=target, return_raw=True))
+    if scrub:
+        click.echo("Scrubbing personal data before writing")
     for dev in devs.values():
         if scrub:
             for key in keys_to_scrub:


### PR DESCRIPTION
This will remove the unused --save to allow dump_discover to save by default. This will also add a --scrub option to remove personal device details when saving the files.