### PR TITLE
Cleanup constructors by removing ioloop and protocol arguments

### DIFF
--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -2,7 +2,6 @@
 import re
 from typing import Any, Dict, Optional, Tuple
 
-from kasa.protocol import TPLinkSmartHomeProtocol
 from kasa.smartdevice import (
     DeviceType,
     SmartDevice,
@@ -72,23 +71,8 @@ class SmartBulb(SmartDevice):
 
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
 
-    def __init__(
-        self,
-        host: str,
-        protocol: TPLinkSmartHomeProtocol = None,
-        child_id: str = None,
-        cache_ttl: int = 3,
-        *,
-        ioloop=None,
-    ) -> None:
-        SmartDevice.__init__(
-            self,
-            host=host,
-            protocol=protocol,
-            child_id=child_id,
-            cache_ttl=cache_ttl,
-            ioloop=ioloop,
-        )
+    def __init__(self, host: str, *, child_id: str = None, cache_ttl: int = 3) -> None:
+        SmartDevice.__init__(self, host=host, child_id=child_id, cache_ttl=cache_ttl)
         self.emeter_type = "smartlife.iot.common.emeter"
         self._device_type = DeviceType.Bulb
         self._light_state = None

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -11,7 +11,6 @@ Stroetmann which is licensed under the Apache License, Version 2.0.
 You may obtain a copy of the license at
 http://www.apache.org/licenses/LICENSE-2.0
 """
-import asyncio
 import functools
 import inspect
 import logging
@@ -104,27 +103,15 @@ def requires_update(f):
 class SmartDevice:
     """Base class for all supported device types."""
 
-    STATE_ON = "ON"
-    STATE_OFF = "OFF"
-
-    def __init__(
-        self,
-        host: str,
-        protocol: Optional[TPLinkSmartHomeProtocol] = None,
-        child_id: str = None,
-        cache_ttl: int = 3,
-        *,
-        ioloop=None,
-    ) -> None:
+    def __init__(self, host: str, *, child_id: str = None, cache_ttl: int = 3) -> None:
         """Create a new SmartDevice instance.
 
         :param str host: host name or ip address on which the device listens
         :param child_id: optional child ID for context in a parent device
         """
         self.host = host
-        if protocol is None:  # pragma: no cover
-            protocol = TPLinkSmartHomeProtocol()
-        self.protocol = protocol
+
+        self.protocol = TPLinkSmartHomeProtocol()
         self.emeter_type = "emeter"
         self.child_id = child_id
         self.cache_ttl = timedelta(seconds=cache_ttl)
@@ -136,7 +123,6 @@ class SmartDevice:
         )
         self.cache = defaultdict(lambda: defaultdict(lambda: None))  # type: ignore
         self._device_type = DeviceType.Unknown
-        self.ioloop = ioloop or asyncio.get_event_loop()
         self._sys_info = None
 
     def _result_from_cache(self, target, cmd) -> Optional[Dict]:

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -3,7 +3,6 @@ import datetime
 import logging
 from typing import Any, Dict
 
-from kasa.protocol import TPLinkSmartHomeProtocol
 from kasa.smartdevice import (
     DeviceType,
     SmartDevice,
@@ -36,16 +35,8 @@ class SmartPlug(SmartDevice):
     and should be handled by the user of the library.
     """
 
-    def __init__(
-        self,
-        host: str,
-        protocol: "TPLinkSmartHomeProtocol" = None,
-        child_id: str = None,
-        cache_ttl: int = 3,
-        *,
-        ioloop=None,
-    ) -> None:
-        SmartDevice.__init__(self, host, protocol, child_id, cache_ttl, ioloop=ioloop)
+    def __init__(self, host: str, child_id: str = None, cache_ttl: int = 3) -> None:
+        SmartDevice.__init__(self, host, child_id=child_id, cache_ttl=cache_ttl)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug
 

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -35,7 +35,7 @@ class SmartPlug(SmartDevice):
     and should be handled by the user of the library.
     """
 
-    def __init__(self, host: str, child_id: str = None, cache_ttl: int = 3) -> None:
+    def __init__(self, host: str, *, child_id: str = None, cache_ttl: int = 3) -> None:
         SmartDevice.__init__(self, host, child_id=child_id, cache_ttl=cache_ttl)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -7,7 +7,6 @@ import logging
 from collections import defaultdict
 from typing import Any, DefaultDict, Dict, List
 
-from kasa.protocol import TPLinkSmartHomeProtocol
 from kasa.smartdevice import DeviceType, requires_update
 from kasa.smartplug import SmartPlug
 
@@ -41,14 +40,8 @@ class SmartStrip(SmartPlug):
     and should be handled by the user of the library.
     """
 
-    def __init__(
-        self,
-        host: str,
-        protocol: TPLinkSmartHomeProtocol = None,
-        cache_ttl: int = 3,
-        ioloop=None,
-    ) -> None:
-        SmartPlug.__init__(self, host=host, protocol=protocol, cache_ttl=cache_ttl)
+    def __init__(self, host: str, cache_ttl: int = 3) -> None:
+        SmartPlug.__init__(self, host=host, cache_ttl=cache_ttl)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Strip
         self.plugs: List[SmartPlug] = []
@@ -78,15 +71,10 @@ class SmartStrip(SmartPlug):
                 self.plugs.append(
                     SmartPlug(
                         self.host,
-                        self.protocol,
                         child_id=child["id"],
                         cache_ttl=self.cache_ttl.total_seconds(),
-                        ioloop=self.ioloop,
                     )
                 )
-
-        for plug in self.plugs:
-            await plug.update()
 
     async def turn_on(self):
         """Turn the strip on.

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -40,7 +40,7 @@ class SmartStrip(SmartPlug):
     and should be handled by the user of the library.
     """
 
-    def __init__(self, host: str, cache_ttl: int = 3) -> None:
+    def __init__(self, host: str, *, cache_ttl: int = 3) -> None:
         SmartPlug.__init__(self, host=host, cache_ttl=cache_ttl)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Strip


### PR DESCRIPTION
The tests are failing for multi-socket devices, the whole piece is much more convoluted than I thought and will require some heavy cleanup..

This will also force other arguments besides the host to be passed explicitly as a kwarg.