### PR TITLE
Adding KP303 to supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Python Library to control TPLink smart plugs/switches and smart bulbs.
   * HS110
 * Power Strips
   * HS300
+  * KP303
 * Wall switches
   * HS200
   * HS210

--- a/kasa/tests/fixtures/KP303(UK)_1.0.json
+++ b/kasa/tests/fixtures/KP303(UK)_1.0.json
@@ -1,0 +1,70 @@
+{
+    "emeter": {
+        "err_code": -1,
+        "err_msg": "module not support"
+    },
+    "smartlife.iot.common.emeter": {
+        "err_code": -1,
+        "err_msg": "module not support"
+    },
+    "smartlife.iot.dimmer": {
+        "err_code": -1,
+        "err_msg": "module not support"
+    },
+    "smartlife.iot.smartbulb.lightingservice": {
+        "err_code": -1,
+        "err_msg": "module not support"
+    },
+    "system": {
+        "get_sysinfo": {
+            "alias": "TP-LINK_Power Strip_CF69",
+            "child_num": 3,
+            "children": [
+                {
+                    "alias": "Plug 1",
+                    "id": "00",
+                    "next_action": {
+                        "type": -1
+                    },
+                    "on_time": 302,
+                    "state": 1
+                },
+                {
+                    "alias": "Plug 2",
+                    "id": "01",
+                    "next_action": {
+                        "type": -1
+                    },
+                    "on_time": 0,
+                    "state": 0
+                },
+                {
+                    "alias": "Plug 3",
+                    "id": "02",
+                    "next_action": {
+                        "type": -1
+                    },
+                    "on_time": 0,
+                    "state": 0
+                }
+            ],
+            "deviceId": "0000000000000000000000000000000000000000",
+            "err_code": 0,
+            "feature": "TIM",
+            "hwId": "00000000000000000000000000000000",
+            "hw_ver": "1.0",
+            "latitude_i": 0,
+            "led_off": 0,
+            "longitude_i": 0,
+            "mac": "00:00:00:00:00:00",
+            "mic_type": "IOT.SMARTPLUGSWITCH",
+            "model": "KP303(UK)",
+            "ntc_state": 0,
+            "oemId": "00000000000000000000000000000000",
+            "rssi": -63,
+            "status": "new",
+            "sw_ver": "1.0.3 Build 191105 Rel.113122",
+            "updating": 0
+        }
+    }
+}


### PR DESCRIPTION
Includes result of `kasa dump-discover` and updates readme to add KP303 as a supported device