### PR TITLE
Move child socket handling to its own SmartStripPlug class

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -2,8 +2,8 @@
 import asyncio
 import json
 import logging
-import re
 from pprint import pformat as pf
+import re
 
 import click
 
@@ -112,7 +112,7 @@ def dump_discover(ctx, scrub):
                     if key in ["latitude_i", "longitude_i"]:
                         val = 0
                     else:
-                        val = re.sub("\w", "0", val)
+                        val = re.sub(r"\w", "0", val)
                     dev["system"]["get_sysinfo"][key] = val
 
         model = dev["system"]["get_sysinfo"]["model"]

--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -71,8 +71,8 @@ class SmartBulb(SmartDevice):
 
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
 
-    def __init__(self, host: str, *, child_id: str = None, cache_ttl: int = 3) -> None:
-        SmartDevice.__init__(self, host=host, child_id=child_id, cache_ttl=cache_ttl)
+    def __init__(self, host: str, *, cache_ttl: int = 3) -> None:
+        SmartDevice.__init__(self, host=host, cache_ttl=cache_ttl)
         self.emeter_type = "smartlife.iot.common.emeter"
         self._device_type = DeviceType.Bulb
         self._light_state = None

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -35,8 +35,8 @@ class SmartPlug(SmartDevice):
     and should be handled by the user of the library.
     """
 
-    def __init__(self, host: str, *, child_id: str = None, cache_ttl: int = 3) -> None:
-        SmartDevice.__init__(self, host, child_id=child_id, cache_ttl=cache_ttl)
+    def __init__(self, host: str, *, cache_ttl: int = 3) -> None:
+        SmartDevice.__init__(self, host, cache_ttl=cache_ttl)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug
 
@@ -83,20 +83,6 @@ class SmartPlug(SmartDevice):
 
     @property  # type: ignore
     @requires_update
-    def alias(self) -> str:
-        """Return device name (alias).
-
-        :return: Device name aka alias.
-        :rtype: str
-        """
-        if self.is_child_device:
-            info = self._get_child_info()
-            return info["alias"]
-        else:
-            return super().alias
-
-    @property  # type: ignore
-    @requires_update
     def is_dimmable(self):
         """Whether the switch supports brightness changes.
 
@@ -125,10 +111,6 @@ class SmartPlug(SmartDevice):
 
         :return: True if device is on, False otherwise
         """
-        if self.is_child_device:
-            info = self._get_child_info()
-            return info["state"]
-
         sys_info = self.sys_info
         return bool(sys_info["relay_state"])
 
@@ -176,12 +158,7 @@ class SmartPlug(SmartDevice):
         :return: datetime for on since
         :rtype: datetime
         """
-        sys_info = self.sys_info
-        if self.is_child_device:
-            info = self._get_child_info()
-            on_time = info["on_time"]
-        else:
-            on_time = sys_info["on_time"]
+        on_time = self.sys_info["on_time"]
 
         return datetime.datetime.now() - datetime.timedelta(seconds=on_time)
 

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -52,7 +52,7 @@ dimmable = pytest.mark.parametrize(
     "dev", filter_model("dimmable", DIMMABLE), indirect=True
 )
 non_dimmable = pytest.mark.parametrize(
-    "dev", filter_model("non-dimmable", ALL_DEVICES - DIMMABLE), indirect=True
+    "dev", filter_model("non-dimmable", ALL_DEVICES - DIMMABLE - STRIPS), indirect=True
 )
 
 variable_temp = pytest.mark.parametrize(


### PR DESCRIPTION
* All child device handling is moved out from the main smartdevice class, which simplifies the code.
* This will also cleanup the constructors as only the subdevices require the ID and the parent reference.
* SmartStripPlug offers SmartPlug like interface, but does not allow individual updates
  * Trying to update() on the children will cause a warning.