### PR TITLE
Remove unnecessary cache

### DIFF
--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -71,8 +71,8 @@ class SmartBulb(SmartDevice):
 
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
 
-    def __init__(self, host: str, *, cache_ttl: int = 3) -> None:
-        SmartDevice.__init__(self, host=host, cache_ttl=cache_ttl)
+    def __init__(self, host: str) -> None:
+        super().__init__(host=host)
         self.emeter_type = "smartlife.iot.common.emeter"
         self._device_type = DeviceType.Bulb
         self._light_state = None

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -35,8 +35,8 @@ class SmartPlug(SmartDevice):
     and should be handled by the user of the library.
     """
 
-    def __init__(self, host: str, *, cache_ttl: int = 3) -> None:
-        SmartDevice.__init__(self, host, cache_ttl=cache_ttl)
+    def __init__(self, host: str) -> None:
+        super().__init__(host)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug
 

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -50,7 +50,7 @@ class SmartStrip(SmartDevice):
         return True
 
     def __init__(self, host: str, *, cache_ttl: int = 3) -> None:
-        SmartDevice.__init__(self, host=host, cache_ttl=cache_ttl)
+        super().__init__(host=host)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Strip
         self.plugs: List[SmartStripPlug] = []
@@ -78,12 +78,7 @@ class SmartStrip(SmartDevice):
             _LOGGER.debug("Initializing %s child sockets", len(children))
             for child in children:
                 self.plugs.append(
-                    SmartStripPlug(
-                        self.host,
-                        parent=self,
-                        child_id=child["id"],
-                        cache_ttl=self.cache_ttl.total_seconds(),
-                    )
+                    SmartStripPlug(self.host, parent=self, child_id=child["id"])
                 )
 
     async def turn_on(self):
@@ -232,10 +227,8 @@ class SmartStripPlug(SmartPlug):
     on the parent device before accessing the properties.
     """
 
-    def __init__(
-        self, host: str, parent: "SmartStrip", child_id: str, *, cache_ttl: int = 3
-    ) -> None:
-        super().__init__(host, cache_ttl=cache_ttl)
+    def __init__(self, host: str, parent: "SmartStrip", child_id: str) -> None:
+        super().__init__(host)
 
         self.parent = parent
         self.child_id = child_id

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -116,8 +116,7 @@ def dev(request):
     with open(file) as f:
         sysinfo = json.load(f)
         model = basename(file)
-        params = {"host": "123.123.123.123", "cache_ttl": 0}
-        p = device_for_file(model)(**params)
+        p = device_for_file(model)(host="123.123.123.123")
         p.protocol = FakeTransportProtocol(sysinfo)
         loop.run_until_complete(p.update())
         yield p

--- a/kasa/tests/test_fixtures.py
+++ b/kasa/tests/test_fixtures.py
@@ -471,40 +471,6 @@ async def test_all_binary_states(dev):
                 assert state == state_map[index]
 
 
-# def test_cache(dev):
-#     from datetime import timedelta
-
-#     dev.cache_ttl = timedelta(seconds=3)
-#     with patch.object(
-#         FakeTransportProtocol, "query", wraps=dev.protocol.query
-#     ) as query_mock:
-#         CHECK_COUNT = 1
-#         # Smartstrip calls sysinfo in its __init__ to request children, so
-#         # the even first get call here will get its results from the cache.
-#         if dev.is_strip:
-#             CHECK_COUNT = 0
-
-#         dev.sys_info
-#         assert query_mock.call_count == CHECK_COUNT
-#         dev.sys_info
-#         assert query_mock.call_count == CHECK_COUNT
-
-
-# def test_cache_invalidates(dev):
-#     from datetime import timedelta
-
-#     dev.cache_ttl = timedelta(seconds=0)
-
-#     with patch.object(
-#         FakeTransportProtocol, "query", wraps=dev.protocol.query
-#     ) as query_mock:
-#         dev.sys_info
-#         assert query_mock.call_count == 1
-#         dev.sys_info
-#         assert query_mock.call_count == 2
-#         # assert query_mock.called_once()
-
-
 async def test_representation(dev):
     import re
 


### PR DESCRIPTION
The cache was useful trick when the property accesses caused I/O,
which is unnecessary now as dev.update() does explicitly cache results until its called again.

Obsoletes #36.