### PR TITLE
async++, small powerstrip improvements

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -399,12 +399,12 @@ async def on(dev: SmartDevice, index, name):
             click.echo("Index and name are only for power strips!")
             return
         dev = cast(SmartStrip, dev)
-        if index:
+        if index is not None:
             await dev.turn_on_by_index(index)
         elif name:
             await dev.turn_on_by_name(name)
     else:
-        click.echo("Turning on %s" % dev)
+        click.echo("Turning on %s" % dev.alias)
         await dev.turn_on()
 
 
@@ -420,12 +420,12 @@ async def off(dev, index, name):
             click.echo("Index and name are only for power strips!")
             return
         dev = cast(SmartStrip, dev)
-        if index:
+        if index is not None:
             await dev.turn_off_by_index(index)
         elif name:
             await dev.turn_off_by_name(name)
     else:
-        click.echo("Turning on %s" % dev)
+        click.echo("Turning off %s" % dev.alias)
         await dev.turn_off()
 
 

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -34,7 +34,7 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     required=False,
     help="The broadcast address to be used for discovery.",
 )
-@click.option("-d", "--debug", default=False)
+@click.option("-d", "--debug", default=False, is_flag=True)
 @click.option("--bulb", default=False, is_flag=True)
 @click.option("--plug", default=False, is_flag=True)
 @click.option("--strip", default=False, is_flag=True)

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -317,7 +317,8 @@ async def emeter(dev, year, month, erase):
 
     if isinstance(emeter_status, list):
         for plug in emeter_status:
-            click.echo("Plug %d: %s" % (emeter_status.index(plug) + 1, plug))
+            index = emeter_status.index(plug) + 1
+            click.echo(f"Plug {index}: {plug}")
     else:
         click.echo(str(emeter_status))
 
@@ -416,7 +417,7 @@ async def on(dev: SmartDevice, index, name):
         elif name:
             dev = dev.get_plug_by_name(name)
 
-    click.echo("Turning on %s" % dev.alias)
+    click.echo(f"Turning on {dev.alias}")
     await dev.turn_on()
 
 
@@ -437,7 +438,7 @@ async def off(dev, index, name):
         elif name:
             dev = dev.get_plug_by_name(name)
 
-    click.echo("Turning off %s" % dev.alias)
+    click.echo(f"Turning off {dev.alias}")
     await dev.turn_off()
 
 

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -13,6 +13,7 @@ import asyncio
 import json
 import logging
 import struct
+from pprint import pformat as pf
 from typing import Any, Dict, Union
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,9 +68,10 @@ class TPLinkSmartHomeProtocol:
                 await writer.wait_closed()
 
         response = TPLinkSmartHomeProtocol.decrypt(buffer[4:])
-        _LOGGER.debug("< (%i) %s", len(response), response)
+        json_payload = json.loads(response)
+        _LOGGER.debug("< (%i) %s", len(response), pf(json_payload))
 
-        return json.loads(response)
+        return json_payload
 
     @staticmethod
     def encrypt(request: str) -> bytes:

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -122,7 +122,7 @@ class SmartDevice:
 
         self.protocol = TPLinkSmartHomeProtocol()
         self.emeter_type = "emeter"
-        _LOGGER.debug("Initializing %s", self.host)
+        _LOGGER.debug("Initializing %s of type %s", self.host, type(self))
         self._device_type = DeviceType.Unknown
         self._sys_info: Optional[Dict] = None
 

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -93,6 +93,38 @@ class SmartStrip(SmartDevice):
         await self._query_helper("system", "set_relay_state", {"state": 0})
         await self.update()
 
+    async def turn_on_by_name(self, name):
+        """Turn on the child plug with the given name."""
+        for p in self.plugs:
+            if p.alias == name:
+                return await p.turn_on()
+
+        raise SmartDeviceException(f"Unable to find child with name {name}")
+
+    async def turn_on_by_index(self, index: int):
+        """Turn on the child plug with the given index."""
+        if index + 1 > len(self.plugs):
+            raise SmartDeviceException(f"This device has only {len(self.plugs)} plugs")
+
+        plug = list(self.plugs)[index]
+        await plug.turn_on()
+
+    async def turn_off_by_name(self, name: str):
+        """Turn off the child plug with the given name."""
+        for p in self.plugs:
+            if p.alias == name:
+                return await p.turn_off()
+
+        raise SmartDeviceException(f"Unable to find child with name {name}")
+
+    async def turn_off_by_index(self, index: int):
+        """Turn off the child plug with the given index."""
+        if index + 1 > len(self.plugs):
+            raise SmartDeviceException(f"This device has only {len(self.plugs)} plugs")
+
+        plug = list(self.plugs)[index]
+        await plug.turn_off()
+
     @property  # type: ignore
     @requires_update
     def on_since(self) -> datetime.datetime:

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -101,10 +101,16 @@ class SmartStrip(SmartDevice):
 
         raise SmartDeviceException(f"Unable to find child with name {name}")
 
+    def _verify_index(self, index: int):
+        """Check the bounds for index and raise on error."""
+        if index + 1 > len(self.plugs) or index < 0:
+            raise SmartDeviceException(
+                f"Invalid index {index}, device has {len(self.plugs)} plugs"
+            )
+
     async def turn_on_by_index(self, index: int):
         """Turn on the child plug with the given index."""
-        if index + 1 > len(self.plugs):
-            raise SmartDeviceException(f"This device has only {len(self.plugs)} plugs")
+        self._verify_index(index)
 
         plug = list(self.plugs)[index]
         await plug.turn_on()
@@ -119,8 +125,7 @@ class SmartStrip(SmartDevice):
 
     async def turn_off_by_index(self, index: int):
         """Turn off the child plug with the given index."""
-        if index + 1 > len(self.plugs):
-            raise SmartDeviceException(f"This device has only {len(self.plugs)} plugs")
+        self._verify_index(index)
 
         plug = list(self.plugs)[index]
         await plug.turn_off()
@@ -327,6 +332,13 @@ class SmartStripPlug(SmartPlug):
         """
         info = self._get_child_info()
         return info["alias"]
+
+    @property  # type: ignore
+    @requires_update
+    def next_action(self) -> Dict:
+        """Return next scheduled(?) action."""
+        info = self._get_child_info()
+        return info["next_action"]
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -253,6 +253,8 @@ class SmartStripPlug(SmartPlug):
     This allows you to use the sockets as they were SmartPlug objects.
     Instead of calling an update on any of these, you should call an update
     on the parent device before accessing the properties.
+
+    The plug inherits (most of) the system information from the parent.
     """
 
     def __init__(self, host: str, parent: "SmartStrip", child_id: str) -> None:
@@ -260,7 +262,7 @@ class SmartStripPlug(SmartPlug):
 
         self.parent = parent
         self.child_id = child_id
-        self._sys_info = self._get_child_info()
+        self._sys_info = {**self.parent.sys_info, **self._get_child_info()}
 
     async def update(self):
         """Override the update to no-op and inform the user."""
@@ -298,6 +300,12 @@ class SmartStripPlug(SmartPlug):
         :return: True if led is on, False otherwise
         :rtype: bool
         """
+        return False
+
+    @property  # type: ignore
+    @requires_update
+    def has_emeter(self) -> bool:
+        """Children have no emeter to my knowledge."""
         return False
 
     @property  # type: ignore

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -93,42 +93,21 @@ class SmartStrip(SmartDevice):
         await self._query_helper("system", "set_relay_state", {"state": 0})
         await self.update()
 
-    async def turn_on_by_name(self, name):
-        """Turn on the child plug with the given name."""
+    def get_plug_by_name(self, name: str) -> "SmartStripPlug":
+        """Return child plug for given name."""
         for p in self.plugs:
             if p.alias == name:
-                return await p.turn_on()
+                return p
 
-        raise SmartDeviceException(f"Unable to find child with name {name}")
+        raise SmartDeviceException(f"Device has no child with {name}")
 
-    def _verify_index(self, index: int):
-        """Check the bounds for index and raise on error."""
+    def get_plug_by_index(self, index: int) -> "SmartStripPlug":
+        """Return child plug for given index."""
         if index + 1 > len(self.plugs) or index < 0:
             raise SmartDeviceException(
                 f"Invalid index {index}, device has {len(self.plugs)} plugs"
             )
-
-    async def turn_on_by_index(self, index: int):
-        """Turn on the child plug with the given index."""
-        self._verify_index(index)
-
-        plug = list(self.plugs)[index]
-        await plug.turn_on()
-
-    async def turn_off_by_name(self, name: str):
-        """Turn off the child plug with the given name."""
-        for p in self.plugs:
-            if p.alias == name:
-                return await p.turn_off()
-
-        raise SmartDeviceException(f"Unable to find child with name {name}")
-
-    async def turn_off_by_index(self, index: int):
-        """Turn off the child plug with the given index."""
-        self._verify_index(index)
-
-        plug = list(self.plugs)[index]
-        await plug.turn_off()
+        return self.plugs[index]
 
     @property  # type: ignore
     @requires_update
@@ -144,8 +123,6 @@ class SmartStrip(SmartDevice):
         :return: True if led is on, False otherwise
         :rtype: bool
         """
-        # TODO this is a copypaste from smartplug,
-        # check if led value is per socket or per device..
         sys_info = self.sys_info
         return bool(1 - sys_info["led_off"])
 
@@ -155,8 +132,6 @@ class SmartStrip(SmartDevice):
         :param bool state: True to set led on, False to set led off
         :raises SmartDeviceException: on error
         """
-        # TODO this is a copypaste from smartplug,
-        # check if led value is per socket or per device..
         await self._query_helper("system", "set_led_off", {"off": int(not state)})
         await self.update()
 

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -92,13 +92,12 @@ def dev(request):
     Provides a device (given --ip) or parametrized fixture for the supported devices.
     The initial update is called automatically before returning the device.
     """
-    loop = asyncio.get_event_loop()
     file = request.param
 
     ip = request.config.getoption("--ip")
     if ip:
-        d = loop.run_until_complete(Discover.discover_single(ip))
-        loop.run_until_complete(d.update())
+        d = asyncio.run(Discover.discover_single(ip))
+        asyncio.run(d.update())
         print(d.model)
         if d.model in file:
             return d
@@ -125,7 +124,7 @@ def dev(request):
         model = basename(file)
         p = device_for_file(model)(host="123.123.123.123")
         p.protocol = FakeTransportProtocol(sysinfo)
-        loop.run_until_complete(p.update())
+        asyncio.run(p.update())
         yield p
 
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -1,25 +1,26 @@
-import asyncio
+import pytest
 
-from click.testing import CliRunner
-
+from asyncclick.testing import CliRunner
 from kasa import SmartDevice
 from kasa.cli import alias, brightness, emeter, raw_command, state, sysinfo
 
 from .conftest import handle_turn_on, turn_on
 
+pytestmark = pytest.mark.asyncio
 
-def test_sysinfo(dev):
+
+async def test_sysinfo(dev):
     runner = CliRunner()
-    res = runner.invoke(sysinfo, obj=dev)
+    res = await runner.invoke(sysinfo, obj=dev)
     assert "System info" in res.output
     assert dev.alias in res.output
 
 
 @turn_on
-def test_state(dev, turn_on):
-    asyncio.run(handle_turn_on(dev, turn_on))
+async def test_state(dev, turn_on):
+    await handle_turn_on(dev, turn_on)
     runner = CliRunner()
-    res = runner.invoke(state, obj=dev)
+    res = await runner.invoke(state, obj=dev)
     print(res.output)
 
     if dev.is_on:
@@ -31,36 +32,36 @@ def test_state(dev, turn_on):
         assert "Device has no emeter" in res.output
 
 
-def test_alias(dev):
+async def test_alias(dev):
     runner = CliRunner()
 
-    res = runner.invoke(alias, obj=dev)
+    res = await runner.invoke(alias, obj=dev)
     assert f"Alias: {dev.alias}" in res.output
 
     new_alias = "new alias"
-    res = runner.invoke(alias, [new_alias], obj=dev)
+    res = await runner.invoke(alias, [new_alias], obj=dev)
     assert f"Setting alias to {new_alias}" in res.output
 
-    res = runner.invoke(alias, obj=dev)
+    res = await runner.invoke(alias, obj=dev)
     assert f"Alias: {new_alias}" in res.output
 
 
-def test_raw_command(dev):
+async def test_raw_command(dev):
     runner = CliRunner()
-    res = runner.invoke(raw_command, ["system", "get_sysinfo"], obj=dev)
+    res = await runner.invoke(raw_command, ["system", "get_sysinfo"], obj=dev)
 
     assert res.exit_code == 0
     assert dev.alias in res.output
 
-    res = runner.invoke(raw_command, obj=dev)
+    res = await runner.invoke(raw_command, obj=dev)
     assert res.exit_code != 0
     assert "Usage" in res.output
 
 
-def test_emeter(dev: SmartDevice, mocker):
+async def test_emeter(dev: SmartDevice, mocker):
     runner = CliRunner()
 
-    res = runner.invoke(emeter, obj=dev)
+    res = await runner.invoke(emeter, obj=dev)
     if not dev.has_emeter:
         assert "Device has no emeter" in res.output
         return
@@ -68,52 +69,52 @@ def test_emeter(dev: SmartDevice, mocker):
     assert "Current State" in res.output
 
     monthly = mocker.patch.object(dev, "get_emeter_monthly")
-    res = runner.invoke(emeter, ["--year", "1900"], obj=dev)
+    res = await runner.invoke(emeter, ["--year", "1900"], obj=dev)
     assert "For year" in res.output
     monthly.assert_called()
 
     daily = mocker.patch.object(dev, "get_emeter_daily")
-    res = runner.invoke(emeter, ["--month", "1900-12"], obj=dev)
+    res = await runner.invoke(emeter, ["--month", "1900-12"], obj=dev)
     assert "For month" in res.output
     daily.assert_called()
 
 
-def test_brightness(dev):
+async def test_brightness(dev):
     runner = CliRunner()
-    res = runner.invoke(brightness, obj=dev)
+    res = await runner.invoke(brightness, obj=dev)
     if not dev.is_dimmable:
         assert "This device does not support brightness." in res.output
         return
 
-    res = runner.invoke(brightness, obj=dev)
+    res = await runner.invoke(brightness, obj=dev)
     assert f"Brightness: {dev.brightness}" in res.output
 
-    res = runner.invoke(brightness, ["12"], obj=dev)
+    res = await runner.invoke(brightness, ["12"], obj=dev)
     assert "Setting brightness" in res.output
 
-    res = runner.invoke(brightness, obj=dev)
+    res = await runner.invoke(brightness, obj=dev)
     assert f"Brightness: 12" in res.output
 
 
-def test_temperature(dev):
+async def test_temperature(dev):
     pass
 
 
-def test_hsv(dev):
+async def test_hsv(dev):
     pass
 
 
-def test_led(dev):
+async def test_led(dev):
     pass
 
 
-def test_on(dev):
+async def test_on(dev):
     pass
 
 
-def test_off(dev):
+async def test_off(dev):
     pass
 
 
-def test_reboot(dev):
+async def test_reboot(dev):
     pass

--- a/kasa/tests/test_fixtures.py
+++ b/kasa/tests/test_fixtures.py
@@ -425,6 +425,26 @@ async def test_children_on_since(dev):
         assert plug.on_since
 
 
+@strip
+async def test_get_plug_by_name(dev: SmartStrip):
+    name = dev.plugs[0].alias
+    assert dev.get_plug_by_name(name) == dev.plugs[0]
+
+    with pytest.raises(SmartDeviceException):
+        dev.get_plug_by_name("NONEXISTING NAME")
+
+
+@strip
+async def test_get_plug_by_index(dev: SmartStrip):
+    assert dev.get_plug_by_index(0) == dev.plugs[0]
+
+    with pytest.raises(SmartDeviceException):
+        dev.get_plug_by_index(-1)
+
+    with pytest.raises(SmartDeviceException):
+        dev.get_plug_by_index(len(dev.plugs))
+
+
 @pytest.mark.skip("this test will wear out your relays")
 async def test_all_binary_states(dev):
     # test every binary state

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-click
-click-datetime
+asyncclick
 pre-commit
 voluptuous

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -3,6 +3,6 @@ pytest-azurepipelines
 pytest-cov
 pytest-asyncio
 pytest-mock
-click  # needed for test_cli
+asyncclick
 voluptuous
 codecov

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="",
     license="GPLv3",
     packages=["kasa"],
-    install_requires=["click"],
+    install_requires=["asyncclick"],
     python_requires=">=3.7",
     entry_points={"console_scripts": ["kasa=kasa.cli:cli"]},
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = True
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = -r{toxinidir}/requirements_test.txt
 commands=
-    py.test --cov --cov-config=tox.ini kasa
+    pytest --cov --cov-config=tox.ini kasa
 
 [testenv:flake8]
 deps=


### PR DESCRIPTION
* use asyncclick instead of click, allows defining the commands with async def to avoid manual eventloop/asyncio.run handling
* improve powerstrip support:
  * new powerstrip api: `get_plug_by_{name,index}` methods
  * cli: fix on/off for powerstrip using the new apis
* add missing update()s for cli's hsv, led, temperature (fixes #43)
* prettyprint the received payloads when debug mode in use
* cli: debug mode can be activated now with `-d`
* powerstriplug now inherits its sysinfo from the parent for easier access (e.g., to mac address of the device).