### PR TITLE
Allow 0 brightness for smartdimmer

### DIFF
--- a/kasa/smartdimmer.py
+++ b/kasa/smartdimmer.py
@@ -52,7 +52,7 @@ class SmartDimmer(SmartPlug):
         When setting brightness, if the light is not
         already on, it will be turned on automatically.
 
-        :param value: integer between 1 and 100
+        :param value: integer between 0 and 100
 
         """
         if not self.is_dimmable:
@@ -60,7 +60,7 @@ class SmartDimmer(SmartPlug):
 
         if not isinstance(value, int):
             raise ValueError("Brightness must be integer, " "not of %s.", type(value))
-        elif 0 < value <= 100:
+        elif 0 <= value <= 100:
             await self.turn_on()
             await self._query_helper(
                 "smartlife.iot.dimmer", "set_brightness", {"brightness": value}


### PR DESCRIPTION
According to https://github.com/home-assistant/core/pull/33909/files#diff-9a900d2f83693dd3e01d2894bf1c6bffR452
the dimmers will accept 0 brightness which differs from turning it off