### PR TITLE
Ignore D202 where necessary

### DIFF
--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -595,7 +595,7 @@ class SmartDevice:
         """
         return self.mac
 
-    async def wifi_scan(self) -> List[WifiNetwork]:
+    async def wifi_scan(self) -> List[WifiNetwork]:  # noqa: D202
         """Scan for available wifi networks."""
 
         async def _scan(target):
@@ -614,7 +614,7 @@ class SmartDevice:
 
         return [WifiNetwork(**x) for x in info["ap_list"]]
 
-    async def wifi_join(self, ssid, password, keytype=3):
+    async def wifi_join(self, ssid, password, keytype=3):  # noqa: D202
         """Join the given wifi network.
 
         If joining the network fails, the device will return to AP mode after a while.


### PR DESCRIPTION
This is required as https://github.com/PyCQA/pydocstyle/pull/426 does not
fix the issue for async def'd inner functions, causing
```D202: No blank lines allowed after function docstring (found 1)```

The ignores can be removed when https://github.com/PyCQA/pydocstyle/issues/466 gets fixed.