### PR TITLE
Remove requires_update decorator, simplify bulb on/off handling

### DIFF
--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -626,11 +626,5 @@ class SmartDevice:
         return False
 
     def __repr__(self):
-        return "<{} model {} at {} ({}), is_on: {} - dev specific: {}>".format(
-            self.__class__.__name__,
-            self.model,
-            self.host,
-            self.alias,
-            self.is_on,
-            self.state_information,
-        )
+        return f"<{self._device_type} at {self.host} - update() needed>"
+        return f"<{self._device_type} model {self.model} at {self.host} ({self.alias}), is_on: {self.is_on} - dev specific: {self.state_information}>"

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -626,5 +626,6 @@ class SmartDevice:
         return False
 
     def __repr__(self):
-        return f"<{self._device_type} at {self.host} - update() needed>"
+        if self._sys_info is None:
+            return f"<{self._device_type} at {self.host} - update() needed>"
         return f"<{self._device_type} model {self.model} at {self.host} ({self.alias}), is_on: {self.is_on} - dev specific: {self.state_information}>"

--- a/kasa/smartdimmer.py
+++ b/kasa/smartdimmer.py
@@ -2,7 +2,6 @@
 from typing import Any, Dict
 
 from kasa import DeviceType, SmartDeviceException
-from kasa.smartdevice import requires_update
 from kasa.smartplug import SmartPlug
 
 
@@ -29,7 +28,6 @@ class SmartDimmer(SmartPlug):
         self._device_type = DeviceType.Dimmer
 
     @property  # type: ignore
-    @requires_update
     def brightness(self) -> int:
         """Return current brightness on dimmers.
 
@@ -44,7 +42,6 @@ class SmartDimmer(SmartPlug):
         sys_info = self.sys_info
         return int(sys_info["brightness"])
 
-    @requires_update
     async def set_brightness(self, value: int):
         """Set the new dimmer brightness level.
 
@@ -70,7 +67,6 @@ class SmartDimmer(SmartPlug):
             raise ValueError("Brightness value %s is not valid." % value)
 
     @property  # type: ignore
-    @requires_update
     def is_dimmable(self):
         """Whether the switch supports brightness changes.
 
@@ -81,7 +77,6 @@ class SmartDimmer(SmartPlug):
         return "brightness" in sys_info
 
     @property  # type: ignore
-    @requires_update
     def state_information(self) -> Dict[str, Any]:
         """Return switch-specific state information.
 

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict
 
-from kasa.smartdevice import DeviceType, SmartDevice, requires_update
+from kasa.smartdevice import DeviceType, SmartDevice
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,7 +35,6 @@ class SmartPlug(SmartDevice):
         self._device_type = DeviceType.Plug
 
     @property  # type: ignore
-    @requires_update
     def is_on(self) -> bool:
         """Return whether device is on.
 
@@ -61,7 +60,6 @@ class SmartPlug(SmartDevice):
         await self.update()
 
     @property  # type: ignore
-    @requires_update
     def led(self) -> bool:
         """Return the state of the led.
 
@@ -81,7 +79,6 @@ class SmartPlug(SmartDevice):
         await self.update()
 
     @property  # type: ignore
-    @requires_update
     def state_information(self) -> Dict[str, Any]:
         """Return switch-specific state information.
 

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -7,12 +7,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import Any, DefaultDict, Dict, List, Optional
 
-from kasa.smartdevice import (
-    DeviceType,
-    SmartDevice,
-    SmartDeviceException,
-    requires_update,
-)
+from kasa.smartdevice import DeviceType, SmartDevice, SmartDeviceException
 from kasa.smartplug import SmartPlug
 
 _LOGGER = logging.getLogger(__name__)
@@ -52,7 +47,6 @@ class SmartStrip(SmartDevice):
         self.plugs: List[SmartStripPlug] = []
 
     @property  # type: ignore
-    @requires_update
     def is_on(self) -> bool:
         """Return if any of the outlets are on."""
         for plug in self.plugs:
@@ -62,10 +56,7 @@ class SmartStrip(SmartDevice):
         return False
 
     async def update(self):
-        """Update some of the attributes.
-
-        Needed for methods that are decorated with `requires_update`.
-        """
+        """Update some of the attributes."""
         await super().update()
 
         # Initialize the child devices during the first update.
@@ -110,7 +101,6 @@ class SmartStrip(SmartDevice):
         return self.plugs[index]
 
     @property  # type: ignore
-    @requires_update
     def on_since(self) -> Optional[datetime]:
         """Return the maximum on-time of all outlets."""
         if self.is_off:
@@ -119,7 +109,6 @@ class SmartStrip(SmartDevice):
         return max(plug.on_since for plug in self.plugs if plug.on_since is not None)
 
     @property  # type: ignore
-    @requires_update
     def led(self) -> bool:
         """Return the state of the led.
 
@@ -139,7 +128,6 @@ class SmartStrip(SmartDevice):
         await self.update()
 
     @property  # type: ignore
-    @requires_update
     def state_information(self) -> Dict[str, Any]:
         """Return strip-specific state information.
 
@@ -180,7 +168,6 @@ class SmartStrip(SmartDevice):
         """
         return await super().set_alias(alias)
 
-    @requires_update
     async def get_emeter_daily(
         self, year: int = None, month: int = None, kwh: bool = True
     ) -> Dict:
@@ -203,7 +190,6 @@ class SmartStrip(SmartDevice):
                 emeter_daily[day] += value
         return emeter_daily
 
-    @requires_update
     async def get_emeter_monthly(self, year: int = None, kwh: bool = True) -> Dict:
         """Retrieve monthly statistics for a given year.
 
@@ -220,7 +206,6 @@ class SmartStrip(SmartDevice):
                 emeter_monthly[month] += value
         return emeter_monthly
 
-    @requires_update
     async def erase_emeter_stats(self):
         """Erase energy meter statistics for all plugs.
 
@@ -264,7 +249,6 @@ class SmartStripPlug(SmartPlug):
         )
 
     @property  # type: ignore
-    @requires_update
     def is_on(self) -> bool:
         """Return whether device is on.
 
@@ -274,7 +258,6 @@ class SmartStripPlug(SmartPlug):
         return info["state"]
 
     @property  # type: ignore
-    @requires_update
     def led(self) -> bool:
         """Return the state of the led.
 
@@ -286,13 +269,11 @@ class SmartStripPlug(SmartPlug):
         return False
 
     @property  # type: ignore
-    @requires_update
     def has_emeter(self) -> bool:
         """Children have no emeter to my knowledge."""
         return False
 
     @property  # type: ignore
-    @requires_update
     def device_id(self) -> str:
         """Return unique ID for the socket.
 
@@ -301,7 +282,6 @@ class SmartStripPlug(SmartPlug):
         return f"{self.mac}_{self.child_id}"
 
     @property  # type: ignore
-    @requires_update
     def alias(self) -> str:
         """Return device name (alias).
 
@@ -312,14 +292,12 @@ class SmartStripPlug(SmartPlug):
         return info["alias"]
 
     @property  # type: ignore
-    @requires_update
     def next_action(self) -> Dict:
         """Return next scheduled(?) action."""
         info = self._get_child_info()
         return info["next_action"]
 
     @property  # type: ignore
-    @requires_update
     def on_since(self) -> Optional[datetime]:
         """Return pretty-printed on-time.
 
@@ -335,7 +313,6 @@ class SmartStripPlug(SmartPlug):
         return datetime.now() - timedelta(seconds=on_time)
 
     @property  # type: ignore
-    @requires_update
     def model(self) -> str:
         """Return device model for a child socket.
 

--- a/kasa/tests/test_fixtures.py
+++ b/kasa/tests/test_fixtures.py
@@ -274,13 +274,19 @@ async def test_mac(dev):
 
 @non_variable_temp
 async def test_temperature_on_nonsupporting(dev):
-    assert dev.valid_temperature_range == (0, 0)
-
-    # TODO test when device does not support temperature range
+    with pytest.raises(SmartDeviceException):
+        _ = dev.valid_temperature_range
     with pytest.raises(SmartDeviceException):
         await dev.set_color_temp(2700)
     with pytest.raises(SmartDeviceException):
         print(dev.color_temp)
+
+
+@variable_temp
+async def test_missing_temperature_info(dev):
+    dev.sys_info["model"] = "MODEL_WITH_UNAVAILABLE_TEMP"
+    with pytest.raises(SmartDeviceException):
+        _ = dev.valid_temperature_range
 
 
 @variable_temp


### PR DESCRIPTION
All property accesses are based on the last update, so doing an update
is always needed to get the newest data.

Therefore I think this does not bring much to the table, and they were
out of sync (some functions, which require no update, also had it)

* valid_temperature_range now raises an exception if the bulb does not offer temperature control or when the range information is missing
* Improve handling of unknown bulb models
* `__repr__` for smartdevice does not crash anymore if the update has not been called, which can happen, e.g., in repl if the devices are obtained through discovery and you try to output found devices.