### PR TITLE
Fix PWD capitalization in development setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,5 +239,5 @@ The following assumes you have a working installation of Docker.
 Set up the environment and run the tests on demand.
 
 ```shell
-docker build . -t kasa && docker run -v $(PWD)/kasa/tests:/opt/python-kasa/kasa/tests kasa pytest
+docker build . -t kasa && docker run -v $(pwd)/kasa/tests:/opt/python-kasa/kasa/tests kasa pytest
 ```

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,5 @@ pytest-mock
 asyncclick
 voluptuous
 codecov
+wheel
+setuptools


### PR DESCRIPTION
I tried the development setup in bash & zsh, both did not handle capital PWD, changing it to lowercase worked.
```
bash: PWD: command not found
zsh: command not found: PWD
```