### PR TITLE
Remove unnecessary f-string definition to make tests pass

### DIFF
--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -93,7 +93,7 @@ async def test_brightness(dev):
     assert "Setting brightness" in res.output
 
     res = await runner.invoke(brightness, obj=dev)
-    assert f"Brightness: 12" in res.output
+    assert "Brightness: 12" in res.output
 
 
 async def test_temperature(dev):


### PR DESCRIPTION
Flake8 does not error out on my local install (nor did it do for the pre-merge CI checks), I'm not sure why though.