### PR TITLE
Optimize I/O access

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,13 @@ The commands are straightforward, so feel free to check `--help` for instruction
 # Library usage
 
 The property accesses use the data obtained before by awaiting `update()`.
-The values are cached until the next update call.
-Each method changing the state of the device will automatically update the cached state.
+The values are cached until the next update call. In practice this means that property accesses do no I/O and are dependent, while I/O producing methods need to be awaited.
 
-Errors are raised as `SmartDeviceException` instances for the user to handle.
+Methods changing the state of the device do not invalidate the cache (i.e., there is no implicit `update()`).
+You can assume that the operation has succeeded if no exception is raised.
+These methods will return the device response, which can be useful for some use cases.
+
+Errors are raised as `SmartDeviceException` instances for the library user to handle.
 
 ## Discovering devices
 
@@ -160,6 +163,13 @@ await plug.turn_on()
 ```
 
 ## Getting emeter status (if applicable)
+The `update()` call will automatically fetch the following emeter information:
+* Current consumption (accessed through `emeter_realtime` property)
+* Today's consumption (`emeter_today`)
+* This month's consumption (`emeter_this_month`)
+
+You can also request this information separately:
+
 ```python
 print("Current consumption: %s" % await plug.get_emeter_realtime())
 print("Per day: %s" % await plug.get_emeter_daily(year=2016, month=12))
@@ -182,6 +192,7 @@ asyncio.run(bulb.update())
 
 if bulb.is_dimmable:
     asyncio.run(bulb.set_brightness(100))
+    asyncio.run(bulb.update())
     print(bulb.brightness)
 ```
 
@@ -189,6 +200,7 @@ if bulb.is_dimmable:
 ```python
 if bulb.is_variable_color_temp:
     await bulb.set_color_temp(3000)
+    await bulb.update()
     print(bulb.color_temp)
 ```
 
@@ -199,6 +211,7 @@ Hue is given in degrees (0-360) and saturation and value in percentage.
 ```python
 if bulb.is_color:
     await bulb.set_hsv(180, 100, 100) # set to cyan
+    await bulb.update()
     print(bulb.hsv)
 ```
 

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -292,7 +292,7 @@ async def raw_command(dev: SmartDevice, module, command, parameters):
 @click.option("--year", type=click.DateTime(["%Y"]), default=None, required=False)
 @click.option("--month", type=click.DateTime(["%Y-%m"]), default=None, required=False)
 @click.option("--erase", is_flag=True)
-async def emeter(dev, year, month, erase):
+async def emeter(dev: SmartDevice, year, month, erase):
     """Query emeter for historical consumption."""
     click.echo(click.style("== Emeter ==", bold=True))
     await dev.update()
@@ -311,17 +311,21 @@ async def emeter(dev, year, month, erase):
     elif month:
         click.echo(f"== For month {month.month} of {month.year} ==")
         emeter_status = await dev.get_emeter_daily(year=month.year, month=month.month)
-
     else:
-        emeter_status = await dev.get_emeter_realtime()
-        click.echo("== Current State ==")
+        emeter_status = dev.emeter_realtime
 
     if isinstance(emeter_status, list):
         for plug in emeter_status:
             index = emeter_status.index(plug) + 1
             click.echo(f"Plug {index}: {plug}")
     else:
-        click.echo(str(emeter_status))
+        click.echo("Current: %s A" % emeter_status["current"])
+        click.echo("Voltage: %s V" % emeter_status["voltage"])
+        click.echo("Power: %s W" % emeter_status["power"])
+        click.echo("Total consumption: %s kWh" % emeter_status["total"])
+
+        click.echo("Today: %s kWh" % dev.emeter_today)
+        click.echo("This month: %s kWh" % dev.emeter_this_month)
 
 
 @cli.command()

--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -33,6 +33,7 @@ class SmartBulb(SmartDevice):
 
     # change state of bulb
     await p.turn_on()
+    await p.update()
     assert p.is_on
     await p.turn_off()
 
@@ -44,6 +45,7 @@ class SmartBulb(SmartDevice):
         print("we got color!")
         # set the color to an HSV tuple
         await p.set_hsv(180, 100, 100)
+        await p.update()
         # get the current HSV value
         print(p.hsv)
 
@@ -51,6 +53,7 @@ class SmartBulb(SmartDevice):
     if p.is_variable_color_temp:
         # set the color temperature in Kelvin
         await p.set_color_temp(3000)
+        await p.update()
 
         # get the current color temperature
         print(p.color_temp)
@@ -59,6 +62,7 @@ class SmartBulb(SmartDevice):
     if p.is_dimmable:
         # set the bulb to 50% brightness
         await p.set_brightness(50)
+        await p.update()
 
         # check the current brightness
         print(p.brightness)
@@ -154,7 +158,6 @@ class SmartBulb(SmartDevice):
         light_state = await self._query_helper(
             self.LIGHT_SERVICE, "transition_light_state", state
         )
-        await self.update()
         return light_state
 
     @property  # type: ignore

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -264,8 +264,7 @@ class SmartDevice:
         :param alias: New alias (name)
         :raises SmartDeviceException: on error
         """
-        await self._query_helper("system", "set_dev_alias", {"alias": alias})
-        await self.update()
+        return await self._query_helper("system", "set_dev_alias", {"alias": alias})
 
     async def get_icon(self) -> Dict:
         """Return device icon.
@@ -440,8 +439,7 @@ class SmartDevice:
         :param str mac: mac in hexadecimal with colons, e.g. 01:23:45:67:89:ab
         :raises SmartDeviceException: on error
         """
-        await self._query_helper("system", "set_mac_addr", {"mac": mac})
-        await self.update()
+        return await self._query_helper("system", "set_mac_addr", {"mac": mac})
 
     @property  # type: ignore
     @requires_update
@@ -600,8 +598,7 @@ class SmartDevice:
         if not self.has_emeter:
             raise SmartDeviceException("Device has no emeter")
 
-        await self._query_helper(self.emeter_type, "erase_emeter_stat", None)
-        await self.update()
+        return await self._query_helper(self.emeter_type, "erase_emeter_stat", None)
 
     @requires_update
     async def current_consumption(self) -> float:

--- a/kasa/smartdimmer.py
+++ b/kasa/smartdimmer.py
@@ -60,10 +60,9 @@ class SmartDimmer(SmartPlug):
         if not isinstance(value, int):
             raise ValueError("Brightness must be integer, " "not of %s.", type(value))
         elif 0 <= value <= 100:
-            await self._query_helper(
+            return await self._query_helper(
                 "smartlife.iot.dimmer", "set_brightness", {"brightness": value}
             )
-            await self.update()
         else:
             raise ValueError("Brightness value %s is not valid." % value)
 

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -50,16 +50,14 @@ class SmartPlug(SmartDevice):
 
         :raises SmartDeviceException: on error
         """
-        await self._query_helper("system", "set_relay_state", {"state": 1})
-        await self.update()
+        return await self._query_helper("system", "set_relay_state", {"state": 1})
 
     async def turn_off(self):
         """Turn the switch off.
 
         :raises SmartDeviceException: on error
         """
-        await self._query_helper("system", "set_relay_state", {"state": 0})
-        await self.update()
+        return await self._query_helper("system", "set_relay_state", {"state": 0})
 
     @property  # type: ignore
     @requires_update
@@ -78,8 +76,9 @@ class SmartPlug(SmartDevice):
         :param bool state: True to set led on, False to set led off
         :raises SmartDeviceException: on error
         """
-        await self._query_helper("system", "set_led_off", {"off": int(not state)})
-        await self.update()
+        return await self._query_helper(
+            "system", "set_led_off", {"off": int(not state)}
+        )
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -146,12 +146,11 @@ class SmartStrip(SmartDevice):
         :return: Strip information dict, keys in user-presentable form.
         :rtype: dict
         """
-        state: Dict[str, Any] = {"LED state": self.led}
-        for plug in self.plugs:
-            if plug.is_on:
-                state["Plug %s on since" % str(plug)] = self.on_since
-
-        return state
+        return {
+            "LED state": self.led,
+            "Childs count": len(self.plugs),
+            "On since": self.on_since,
+        }
 
     async def current_consumption(self) -> float:
         """Get the current power consumption in watts.
@@ -218,6 +217,7 @@ class SmartStrip(SmartDevice):
             plug_emeter_monthly = await plug.get_emeter_monthly(year=year, kwh=kwh)
             for month, value in plug_emeter_monthly:
                 emeter_monthly[month] += value
+
         return emeter_monthly
 
     @requires_update
@@ -245,7 +245,8 @@ class SmartStripPlug(SmartPlug):
 
         self.parent = parent
         self.child_id = child_id
-        self._sys_info = {**self.parent.sys_info, **self._get_child_info()}
+        self._last_update = parent._last_update
+        self._sys_info = parent._sys_info
 
     async def update(self):
         """Override the update to no-op and inform the user."""

--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -313,9 +313,7 @@ class FakeTransportProtocol(TPLinkSmartHomeProtocol):
 
     def transition_light_state(self, x, *args):
         _LOGGER.debug("Setting light state to %s", x)
-        light_state = self.proto["smartlife.iot.smartbulb.lightingservice"][
-            "get_light_state"
-        ]
+        light_state = self.proto["system"]["get_sysinfo"]["light_state"]
         # The required change depends on the light state,
         # exception being turning the bulb on and off
 
@@ -323,15 +321,11 @@ class FakeTransportProtocol(TPLinkSmartHomeProtocol):
             if x["on_off"] and not light_state["on_off"]:  # turning on
                 new_state = light_state["dft_on_state"]
                 new_state["on_off"] = 1
-                self.proto["smartlife.iot.smartbulb.lightingservice"][
-                    "get_light_state"
-                ] = new_state
+                self.proto["system"]["get_sysinfo"]["light_state"] = new_state
             elif not x["on_off"] and light_state["on_off"]:
                 new_state = {"dft_on_state": light_state, "on_off": 0}
 
-                self.proto["smartlife.iot.smartbulb.lightingservice"][
-                    "get_light_state"
-                ] = new_state
+                self.proto["system"]["get_sysinfo"]["light_state"] = new_state
 
             return
 
@@ -343,11 +337,9 @@ class FakeTransportProtocol(TPLinkSmartHomeProtocol):
             light_state[key] = x[key]
 
     def light_state(self, x, *args):
-        light_state = self.proto["smartlife.iot.smartbulb.lightingservice"][
-            "get_light_state"
-        ]
+        light_state = self.proto["system"]["get_sysinfo"]["light_state"]
         # Our tests have light state off, so we simply return the dft_on_state when device is on.
-        _LOGGER.info("reporting light state: %s", light_state)
+        _LOGGER.debug("reporting light state: %s", light_state)
         if light_state["on_off"]:
             return light_state["dft_on_state"]
         else:

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -66,7 +66,7 @@ async def test_emeter(dev: SmartDevice, mocker):
         assert "Device has no emeter" in res.output
         return
 
-    assert "Current State" in res.output
+    assert "== Emeter ==" in res.output
 
     monthly = mocker.patch.object(dev, "get_emeter_monthly")
     res = await runner.invoke(emeter, ["--year", "1900"], obj=dev)

--- a/kasa/tests/test_fixtures.py
+++ b/kasa/tests/test_fixtures.py
@@ -419,9 +419,11 @@ async def test_children_alias(dev):
     for plug in dev.plugs:
         original = plug.alias
         await plug.set_alias(alias=test_alias)
+        await dev.update()  # TODO: set_alias does not call parent's update()..
         assert plug.alias == test_alias
 
         await plug.set_alias(alias=original)
+        await dev.update()  # TODO: set_alias does not call parent's update()..
         assert plug.alias == original
 
 


### PR DESCRIPTION
A single update() will now fetch information from all interesting modules,
including the current device state and the emeter information.

In practice, this will allow dropping the number of I/O reqs per homeassistant update cycle to 1,
which is paramount at least for bulbs which are very picky about sequential accesses.
This can be further extend to other modules/methods, if needed.

This will also remove the implicit `update()` calls from device state changing methods such as `set_brightness()`. This allows executing multiple changes on a device without unnecessary I/O.

Currently fetched data:
* sysinfo
* realtime, today's and this months emeter stats

New properties:
* emeter_realtime: return the most recent emeter information, update()-version of get_emeter_realtime()
* emeter_today: returning today's energy consumption
* emeter_this_month: same for this month

Other changes:
* Accessing @requires_update properties will cause SmartDeviceException if the device has not ever been update()d
* Fix __repr__ for devices that haven't been updated
* Smartbulb uses now the state data from get_sysinfo instead of separately querying the bulb service
* SmartStrip's state_information no longer lists onsince for separate plugs
* The above mentioned properties are now printed out by cli
* Simplify is_on handling for bulbs

Closes #53, closes #61.