### PR TITLE
Add transition support for SmartDimmer

### DIFF
--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -315,6 +315,15 @@ class FakeTransportProtocol(TPLinkSmartHomeProtocol):
         _LOGGER.debug("Setting brightness to %s", x)
         self.proto["system"]["get_sysinfo"]["brightness"] = x["brightness"]
 
+    def set_hs220_dimmer_transition(self, x, *args):
+        _LOGGER.debug("Setting dimmer transition to %s", x)
+        brightness = x["brightness"]
+        if brightness == 0:
+            self.proto["system"]["get_sysinfo"]["relay_state"] = 0
+        else:
+            self.proto["system"]["get_sysinfo"]["relay_state"] = 1
+            self.proto["system"]["get_sysinfo"]["brightness"] = x["brightness"]
+
     def transition_light_state(self, x, *args):
         _LOGGER.debug("Setting light state to %s", x)
         light_state = self.proto["system"]["get_sysinfo"]["light_state"]
@@ -392,7 +401,10 @@ class FakeTransportProtocol(TPLinkSmartHomeProtocol):
             "set_timezone": None,
         },
         # HS220 brightness, different setter and getter
-        "smartlife.iot.dimmer": {"set_brightness": set_hs220_brightness},
+        "smartlife.iot.dimmer": {
+            "set_brightness": set_hs220_brightness,
+            "set_dimmer_transition": set_hs220_dimmer_transition,
+        },
     }
 
     async def query(self, host, request, port=9999):

--- a/kasa/tests/test_dimmer.py
+++ b/kasa/tests/test_dimmer.py
@@ -1,0 +1,134 @@
+import pytest
+
+from kasa import SmartDimmer
+
+from .conftest import dimmer, handle_turn_on, turn_on
+
+
+@dimmer
+@turn_on
+async def test_set_brightness(dev, turn_on):
+    await handle_turn_on(dev, turn_on)
+
+    await dev.set_brightness(99)
+    assert dev.brightness == 99
+    assert dev.is_on == turn_on
+
+    await dev.set_brightness(0)
+    assert dev.brightness == 1
+    assert dev.is_on == turn_on
+
+
+@dimmer
+@turn_on
+async def test_set_brightness_transition(dev, turn_on, mocker):
+    await handle_turn_on(dev, turn_on)
+    query_helper = mocker.spy(SmartDimmer, "_query_helper")
+
+    await dev.set_brightness(99, transition=1000)
+
+    assert dev.brightness == 99
+    assert dev.is_on
+    query_helper.assert_called_with(
+        mocker.ANY,
+        "smartlife.iot.dimmer",
+        "set_dimmer_transition",
+        {"brightness": 99, "duration": 1000},
+    )
+
+    await dev.set_brightness(0, transition=1000)
+    assert dev.brightness == 1
+
+
+@dimmer
+async def test_set_brightness_invalid(dev):
+    for invalid_brightness in [-1, 101, 0.5]:
+        with pytest.raises(ValueError):
+            await dev.set_brightness(invalid_brightness)
+
+    for invalid_transition in [-1, 0, 0.5]:
+        with pytest.raises(ValueError):
+            await dev.set_brightness(1, transition=invalid_transition)
+
+
+@dimmer
+async def test_turn_on_transition(dev, mocker):
+    query_helper = mocker.spy(SmartDimmer, "_query_helper")
+    original_brightness = dev.brightness
+
+    await dev.turn_on(transition=1000)
+
+    assert dev.is_on
+    assert dev.brightness == original_brightness
+    query_helper.assert_called_with(
+        mocker.ANY,
+        "smartlife.iot.dimmer",
+        "set_dimmer_transition",
+        {"brightness": original_brightness, "duration": 1000},
+    )
+
+
+@dimmer
+async def test_turn_off_transition(dev, mocker):
+    await handle_turn_on(dev, True)
+    query_helper = mocker.spy(SmartDimmer, "_query_helper")
+    original_brightness = dev.brightness
+
+    await dev.turn_off(transition=1000)
+
+    assert dev.is_off
+    assert dev.brightness == original_brightness
+    query_helper.assert_called_with(
+        mocker.ANY,
+        "smartlife.iot.dimmer",
+        "set_dimmer_transition",
+        {"brightness": 0, "duration": 1000},
+    )
+
+
+@dimmer
+@turn_on
+async def test_set_dimmer_transition(dev, turn_on, mocker):
+    await handle_turn_on(dev, turn_on)
+    query_helper = mocker.spy(SmartDimmer, "_query_helper")
+
+    await dev.set_dimmer_transition(99, 1000)
+
+    assert dev.is_on
+    assert dev.brightness == 99
+    query_helper.assert_called_with(
+        mocker.ANY,
+        "smartlife.iot.dimmer",
+        "set_dimmer_transition",
+        {"brightness": 99, "duration": 1000},
+    )
+
+
+@dimmer
+@turn_on
+async def test_set_dimmer_transition_to_off(dev, turn_on, mocker):
+    await handle_turn_on(dev, turn_on)
+    original_brightness = dev.brightness
+    query_helper = mocker.spy(SmartDimmer, "_query_helper")
+
+    await dev.set_dimmer_transition(0, 1000)
+
+    assert dev.is_off
+    assert dev.brightness == original_brightness
+    query_helper.assert_called_with(
+        mocker.ANY,
+        "smartlife.iot.dimmer",
+        "set_dimmer_transition",
+        {"brightness": 0, "duration": 1000},
+    )
+
+
+@dimmer
+async def test_set_dimmer_transition_invalid(dev):
+    for invalid_brightness in [-1, 101, 0.5]:
+        with pytest.raises(ValueError):
+            await dev.set_dimmer_transition(invalid_brightness, 1000)
+
+    for invalid_transition in [-1, 0, 0.5]:
+        with pytest.raises(ValueError):
+            await dev.set_dimmer_transition(1, invalid_transition)


### PR DESCRIPTION
* Adds a transition param to set_brightness() that specifies the duration in milliseconds that the dimmer switch will take to transition to the new brightness

This is a stab at the first part of #44.

Closes #44 