### PR TITLE
Bulbs: allow specifying transition for state changes

### DIFF
--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -493,7 +493,7 @@ class SmartDevice:
         """
         await self._query_helper("system", "reboot", {"delay": delay})
 
-    async def turn_off(self) -> None:
+    async def turn_off(self) -> Dict:
         """Turn off the device."""
         raise NotImplementedError("Device subclass needs to implement this.")
 
@@ -503,7 +503,7 @@ class SmartDevice:
         """Return True if device is off."""
         return not self.is_on
 
-    async def turn_on(self) -> None:
+    async def turn_on(self) -> Dict:
         """Turn device on."""
         raise NotImplementedError("Device subclass needs to implement this.")
 

--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -70,6 +70,17 @@ async def test_hsv(dev, turn_on):
 
 
 @color_bulb
+async def test_set_hsv_transition(dev, mocker):
+    set_light_state = mocker.patch("kasa.SmartBulb.set_light_state")
+    await dev.set_hsv(10, 10, 100, transition=1000)
+
+    set_light_state.assert_called_with(
+        {"hue": 10, "saturation": 10, "brightness": 100, "color_temp": 0},
+        transition=1000,
+    )
+
+
+@color_bulb
 @turn_on
 async def test_invalid_hsv(dev, turn_on):
     await handle_turn_on(dev, turn_on)
@@ -124,6 +135,14 @@ async def test_try_set_colortemp(dev, turn_on):
 
 
 @variable_temp
+async def test_set_color_temp_transition(dev, mocker):
+    set_light_state = mocker.patch("kasa.SmartBulb.set_light_state")
+    await dev.set_color_temp(2700, transition=100)
+
+    set_light_state.assert_called_with({"color_temp": 2700}, transition=100)
+
+
+@variable_temp
 async def test_unknown_temp_range(dev, monkeypatch):
     with pytest.raises(SmartDeviceException):
         monkeypatch.setitem(dev._sys_info, "model", "unknown bulb")
@@ -164,6 +183,26 @@ async def test_dimmable_brightness(dev, turn_on):
 
     with pytest.raises(ValueError):
         await dev.set_brightness("foo")
+
+
+@bulb
+async def test_turn_on_transition(dev, mocker):
+    set_light_state = mocker.patch("kasa.SmartBulb.set_light_state")
+    await dev.turn_on(transition=1000)
+
+    set_light_state.assert_called_with({"on_off": 1}, transition=1000)
+
+    await dev.turn_off(transition=100)
+
+    set_light_state.assert_called_with({"on_off": 0}, transition=100)
+
+
+@bulb
+async def test_dimmable_brightness_transition(dev, mocker):
+    set_light_state = mocker.patch("kasa.SmartBulb.set_light_state")
+    await dev.set_brightness(10, transition=1000)
+
+    set_light_state.assert_called_with({"brightness": 10}, transition=1000)
 
 
 @dimmable


### PR DESCRIPTION
This adds `transition` kwarg for all state changing methods.

The values are in milliseconds, and limits of what values are accepted differ likely between devices, so there is no checks for that for now. This has only been tested using the brightness & turn on/off transitions on a KL60.

This is a WIP, as mypy does not like that the signature of `turn_on` and `turn_off` differ, so this does not currently pass the tests and that needs to be investigated.

This PR also changes the setters to return the response from the device, which can potentially be useful for downstream developers:
```
>>> asyncio.run(b.set_brightness(1))
{'on_off': 1, 'mode': 'normal', 'hue': 0, 'saturation': 0, 'color_temp': 2000, 'brightness': 1}
```


I wanted to push this up to give an example how to test the transitions, this is related to #69