### PR TITLE
bump version for the second pre-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-kasa"
-version = "0.4.0.dev0"
+version = "0.4.0.dev1"
 description = "Python API for TP-Link Kasa Smarthome devices"
 license = "GPL-3.0-or-later"
 authors = ["Your Name <you@example.com>"]


### PR DESCRIPTION
Since the dev0 got released some two weeks ago (https://pypi.org/project/python-kasa/), the bulbs and dimmers have gained the transition functionality. In the hopes of making it simpler to get downstream testers to test these, it is time for a new pre-release.

TBD:
* Depends on #76
* Tag the previous release that I forgot previously (done: 0.4.0.pre0)
* Tag the release & publish to pypi