### PR TITLE
'Interface' parameter added to discovery process

### DIFF
--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 import logging
 import socket
-from typing import Awaitable, Callable, Dict, Mapping, Type, Union, cast
+from typing import Awaitable, Callable, Dict, Mapping, Type, Union, Optional, cast
 
 from kasa.protocol import TPLinkSmartHomeProtocol
 from kasa.smartbulb import SmartBulb
@@ -34,7 +34,7 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         target: str = "255.255.255.255",
         timeout: int = 5,
         discovery_packets: int = 3,
-        interface: bytes = b""
+        interface: Optional[str] = None
     ):
         self.transport = None
         self.tries = discovery_packets
@@ -52,8 +52,8 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         sock = transport.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        if self.interface is not None and len(self.interface) > 0:
-            sock.setsockopt(socket.SOL_SOCKET, 25, self.interface)
+        if self.interface is not None:
+            sock.setsockopt(socket.SOL_SOCKET, 25, self.interface.encode())
 
         self.do_discover()
 

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -3,7 +3,7 @@ import asyncio
 import json
 import logging
 import socket
-from typing import Awaitable, Callable, Dict, Mapping, Type, Union, Optional, cast
+from typing import Awaitable, Callable, Dict, Mapping, Optional, Type, Union, cast
 
 from kasa.protocol import TPLinkSmartHomeProtocol
 from kasa.smartbulb import SmartBulb
@@ -34,7 +34,7 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         target: str = "255.255.255.255",
         timeout: int = 5,
         discovery_packets: int = 3,
-        interface: Optional[str] = None
+        interface: Optional[str] = None,
     ):
         self.transport = None
         self.tries = discovery_packets
@@ -127,7 +127,7 @@ class Discover:
         timeout=5,
         discovery_packets=3,
         return_raw=False,
-        interface=None
+        interface=None,
     ) -> Mapping[str, Union[SmartDevice, Dict]]:
         """Discover supported devices.
 
@@ -153,7 +153,7 @@ class Discover:
                 on_discovered=on_discovered,
                 timeout=timeout,
                 discovery_packets=discovery_packets,
-                interface=interface
+                interface=interface,
             ),
             local_addr=("0.0.0.0", 0),
         )

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -34,10 +34,12 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         target: str = "255.255.255.255",
         timeout: int = 5,
         discovery_packets: int = 3,
+        interface: bytes = b""
     ):
         self.transport = None
         self.tries = discovery_packets
         self.timeout = timeout
+        self.interface = interface
         self.on_discovered = on_discovered
         self.protocol = TPLinkSmartHomeProtocol()
         self.target = (target, Discover.DISCOVERY_PORT)
@@ -50,6 +52,8 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         sock = transport.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        if self.interface is not None and len(self.interface) > 0:
+            sock.setsockopt(socket.SOL_SOCKET, 25, self.interface)
 
         self.do_discover()
 
@@ -123,6 +127,7 @@ class Discover:
         timeout=5,
         discovery_packets=3,
         return_raw=False,
+        interface=None
     ) -> Mapping[str, Union[SmartDevice, Dict]]:
         """Discover supported devices.
 
@@ -148,6 +153,7 @@ class Discover:
                 on_discovered=on_discovered,
                 timeout=timeout,
                 discovery_packets=discovery_packets,
+                interface=interface
             ),
             local_addr=("0.0.0.0", 0),
         )

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -53,7 +53,7 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if self.interface is not None:
-            sock.setsockopt(socket.SOL_SOCKET, 25, self.interface.encode())
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_BINDTODEVICE, self.interface.encode())
 
         self.do_discover()
 


### PR DESCRIPTION
Some systems (for example dd-wrt routers) requires specifying the network interface name, otherwise the broadcast search does not work. Optional parameter 'interface' added.

Usage example:
```python
devices = asyncio.run(Discover.discover(interface=b'br0'))
for addr, dev in devices.items():
    ...
```