### PR TITLE
Add --transition to bulb-specific cli commands, fix turn_{on,off} signatures

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -337,8 +337,9 @@ async def emeter(dev: SmartDevice, year, month, erase):
 
 @cli.command()
 @click.argument("brightness", type=click.IntRange(0, 100), default=None, required=False)
+@click.option("--transition", type=int, required=False)
 @pass_dev
-async def brightness(dev, brightness):
+async def brightness(dev: SmartBulb, brightness: int, transition: int):
     """Get or set brightness."""
     await dev.update()
     if not dev.is_dimmable:
@@ -348,15 +349,16 @@ async def brightness(dev, brightness):
         click.echo(f"Brightness: {dev.brightness}")
     else:
         click.echo(f"Setting brightness to {brightness}")
-        click.echo(await dev.set_brightness(brightness))
+        click.echo(await dev.set_brightness(brightness, transition=transition))
 
 
 @cli.command()
 @click.argument(
     "temperature", type=click.IntRange(2500, 9000), default=None, required=False
 )
+@click.option("--transition", type=int, required=False)
 @pass_dev
-async def temperature(dev: SmartBulb, temperature):
+async def temperature(dev: SmartBulb, temperature: int, transition: int):
     """Get or set color temperature."""
     await dev.update()
     if temperature is None:
@@ -371,16 +373,17 @@ async def temperature(dev: SmartBulb, temperature):
             )
     else:
         click.echo(f"Setting color temperature to {temperature}")
-        asyncio.run(dev.set_color_temp(temperature))
+        asyncio.run(dev.set_color_temp(temperature, transition=transition))
 
 
 @cli.command()
 @click.argument("h", type=click.IntRange(0, 360), default=None, required=False)
 @click.argument("s", type=click.IntRange(0, 100), default=None, required=False)
 @click.argument("v", type=click.IntRange(0, 100), default=None, required=False)
+@click.option("--transition", type=int, required=False)
 @click.pass_context
 @pass_dev
-async def hsv(dev, ctx, h, s, v):
+async def hsv(dev, ctx, h, s, v, transition):
     """Get or set color in HSV. (Bulb only)."""
     await dev.update()
     if h is None or s is None or v is None:
@@ -389,7 +392,7 @@ async def hsv(dev, ctx, h, s, v):
         raise click.BadArgumentUsage("Setting a color requires 3 values.", ctx)
     else:
         click.echo(f"Setting HSV: {h} {s} {v}")
-        click.echo(await dev.set_hsv(h, s, v))
+        click.echo(await dev.set_hsv(h, s, v, transition=transition))
 
 
 @cli.command()
@@ -415,8 +418,9 @@ async def time(dev):
 @cli.command()
 @click.option("--index", type=int, required=False)
 @click.option("--name", type=str, required=False)
+@click.option("--transition", type=int, required=False)
 @pass_dev
-async def on(dev: SmartDevice, index, name):
+async def on(dev: SmartDevice, index: int, name: str, transition: int):
     """Turn the device on."""
     await dev.update()
     if index is not None or name is not None:
@@ -430,14 +434,15 @@ async def on(dev: SmartDevice, index, name):
             dev = dev.get_plug_by_name(name)
 
     click.echo(f"Turning on {dev.alias}")
-    await dev.turn_on()
+    await dev.turn_on(transition=transition)
 
 
 @cli.command()
 @click.option("--index", type=int, required=False)
 @click.option("--name", type=str, required=False)
+@click.option("--transition", type=int, required=False)
 @pass_dev
-async def off(dev, index, name):
+async def off(dev: SmartDevice, index: int, name: str, transition: int):
     """Turn the device off."""
     await dev.update()
     if index is not None or name is not None:
@@ -451,7 +456,7 @@ async def off(dev, index, name):
             dev = dev.get_plug_by_name(name)
 
     click.echo(f"Turning off {dev.alias}")
-    await dev.turn_off()
+    await dev.turn_off(transition=transition)
 
 
 @cli.command()

--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -306,14 +306,14 @@ class SmartBulb(SmartDevice):
         light_state = self.light_state
         return bool(light_state["on_off"])
 
-    async def turn_off(self, *, transition: int = None) -> Dict:
+    async def turn_off(self, *, transition: int = None, **kwargs) -> Dict:
         """Turn the bulb off.
 
         :param int transition: transition in milliseconds.
         """
         return await self.set_light_state({"on_off": 0}, transition=transition)
 
-    async def turn_on(self, *, transition: int = None) -> Dict:
+    async def turn_on(self, *, transition: int = None, **kwargs) -> Dict:
         """Turn the bulb on.
 
         :param int transition: transition in milliseconds.

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -590,7 +590,7 @@ class SmartDevice:
         """
         await self._query_helper("system", "reboot", {"delay": delay})
 
-    async def turn_off(self) -> Dict:
+    async def turn_off(self, **kwargs) -> Dict:
         """Turn off the device."""
         raise NotImplementedError("Device subclass needs to implement this.")
 
@@ -600,7 +600,7 @@ class SmartDevice:
         """Return True if device is off."""
         return not self.is_on
 
-    async def turn_on(self) -> Dict:
+    async def turn_on(self, **kwargs) -> Dict:
         """Turn device on."""
         raise NotImplementedError("Device subclass needs to implement this.")
 

--- a/kasa/smartdimmer.py
+++ b/kasa/smartdimmer.py
@@ -84,7 +84,7 @@ class SmartDimmer(SmartPlug):
             self.DIMMER_SERVICE, "set_brightness", {"brightness": brightness}
         )
 
-    async def turn_off(self, *, transition: int = None):
+    async def turn_off(self, *, transition: int = None, **kwargs):
         """Turn the bulb off.
 
         :param int transition: transition duration in milliseconds.
@@ -95,7 +95,7 @@ class SmartDimmer(SmartPlug):
         return await super().turn_off()
 
     @requires_update
-    async def turn_on(self, *, transition: int = None):
+    async def turn_on(self, *, transition: int = None, **kwargs):
         """Turn the bulb on.
 
         :param int transition: transition duration in milliseconds.

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -48,11 +48,11 @@ class SmartPlug(SmartDevice):
         sys_info = self.sys_info
         return bool(sys_info["relay_state"])
 
-    async def turn_on(self):
+    async def turn_on(self, **kwargs):
         """Turn the switch on."""
         return await self._query_helper("system", "set_relay_state", {"state": 1})
 
-    async def turn_off(self):
+    async def turn_off(self, **kwargs):
         """Turn the switch off."""
         return await self._query_helper("system", "set_relay_state", {"state": 0})
 

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -97,12 +97,12 @@ class SmartStrip(SmartDevice):
                     SmartStripPlug(self.host, parent=self, child_id=child["id"])
                 )
 
-    async def turn_on(self):
+    async def turn_on(self, **kwargs):
         """Turn the strip on."""
         await self._query_helper("system", "set_relay_state", {"state": 1})
         await self.update()
 
-    async def turn_off(self):
+    async def turn_off(self, **kwargs):
         """Turn the strip off."""
         await self._query_helper("system", "set_relay_state", {"state": 0})
         await self.update()


### PR DESCRIPTION
* `on`, `off`, `hsv`, `temperature` and `brightness` now allow defining `--transition`
* `turn_on` and `turn_on` are now defined now to take `**kwargs` to match with the signatures for dimmers and bulbs.