### PR TITLE
Update cli.py to addresss crash on year/month calls and improve output formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ __pycache__/
 # IntelliJ
 .idea
 
+# vscode
+.vscode
+
 # VirtualEnvs
 venv
 .venv

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -311,7 +311,8 @@ async def raw_command(dev: SmartDevice, module, command, parameters):
 async def emeter(dev: SmartDevice, year, month, erase):
     """Query emeter for historical consumption.
 
-    Daily and monthly data provided in CSV format."""
+    Daily and monthly data provided in CSV format.
+    """
     click.echo(click.style("== Emeter ==", bold=True))
     await dev.update()
     if not dev.has_emeter:

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -323,12 +323,14 @@ async def emeter(dev: SmartDevice, year, month, erase):
 
     if year:
         click.echo(f"== For year {year.year} ==")
-        emeter_status = await dev.get_emeter_monthly(year.year)
+        click.echo(await dev.get_emeter_monthly(year.year))
+        return
     elif month:
         click.echo(f"== For month {month.month} of {month.year} ==")
-        emeter_status = await dev.get_emeter_daily(year=month.year, month=month.month)
-    else:
-        emeter_status = dev.emeter_realtime
+        click.echo(await dev.get_emeter_daily(year=month.year, month=month.month))
+        return
+               
+    emeter_status = dev.emeter_realtime
 
     if isinstance(emeter_status, list):
         for plug in emeter_status:

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -329,7 +329,7 @@ async def emeter(dev: SmartDevice, year, month, erase):
         click.echo(f"== For month {month.month} of {month.year} ==")
         click.echo(await dev.get_emeter_daily(year=month.year, month=month.month))
         return
-               
+
     emeter_status = dev.emeter_realtime
 
     if isinstance(emeter_status, list):

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -309,7 +309,9 @@ async def raw_command(dev: SmartDevice, module, command, parameters):
 @click.option("--month", type=click.DateTime(["%Y-%m"]), default=None, required=False)
 @click.option("--erase", is_flag=True)
 async def emeter(dev: SmartDevice, year, month, erase):
-    """Query emeter for historical consumption."""
+    """Query emeter for historical consumption.
+
+    Daily and monthly data provided in CSV format."""
     click.echo(click.style("== Emeter ==", bold=True))
     await dev.update()
     if not dev.has_emeter:
@@ -323,20 +325,17 @@ async def emeter(dev: SmartDevice, year, month, erase):
 
     if year:
         click.echo(f"== For year {year.year} ==")
-        click.echo(await dev.get_emeter_monthly(year.year))
-        return
+        click.echo("Month, usage (kWh)")
+        usage_data = await dev.get_emeter_monthly(year.year)
     elif month:
         click.echo(f"== For month {month.month} of {month.year} ==")
-        click.echo(await dev.get_emeter_daily(year=month.year, month=month.month))
-        return
-
-    emeter_status = dev.emeter_realtime
-
-    if isinstance(emeter_status, list):
-        for plug in emeter_status:
-            index = emeter_status.index(plug) + 1
-            click.echo(f"Plug {index}: {plug}")
+        click.echo("Day, usage (kWh)")
+        usage_data = await dev.get_emeter_daily(year=month.year, month=month.month)
     else:
+        # Call with no argument outputs summary data and returns
+        usage_data = {}
+        emeter_status = dev.emeter_realtime
+
         click.echo("Current: %s A" % emeter_status["current"])
         click.echo("Voltage: %s V" % emeter_status["voltage"])
         click.echo("Power: %s W" % emeter_status["power"])
@@ -344,6 +343,12 @@ async def emeter(dev: SmartDevice, year, month, erase):
 
         click.echo("Today: %s kWh" % dev.emeter_today)
         click.echo("This month: %s kWh" % dev.emeter_this_month)
+
+        return
+
+    # output any detailed usage data
+    for index, usage in usage_data.items():
+        click.echo(f"{index}, {usage}")
 
 
 @cli.command()


### PR DESCRIPTION
Fix crash when kasa cli is called with --month or --year arguments.

Per discussions in #102.