### PR TITLE
Only query emeter on update if feature is supported

### DIFF
--- a/kasa/tests/test_readme_examples.py
+++ b/kasa/tests/test_readme_examples.py
@@ -18,13 +18,8 @@ def test_bulb_examples(mocker):
 def test_smartdevice_examples(mocker):
     """Use HS110 for emeter examples."""
     p = get_device_for_file("HS110(EU)_1.0_real.json")
-    has_emeter = p.has_emeter
     mocker.patch("kasa.smartdevice.SmartDevice", return_value=p)
     mocker.patch("kasa.smartdevice.SmartDevice.update")
-    mocker.patch(
-        "kasa.smartdevice.SmartDevice._check_emeter_feature_presence",
-        return_value=has_emeter,
-    )
     res = xdoctest.doctest_module("kasa.smartdevice", "all")
     assert not res["failed"]
 

--- a/kasa/tests/test_readme_examples.py
+++ b/kasa/tests/test_readme_examples.py
@@ -18,8 +18,13 @@ def test_bulb_examples(mocker):
 def test_smartdevice_examples(mocker):
     """Use HS110 for emeter examples."""
     p = get_device_for_file("HS110(EU)_1.0_real.json")
+    has_emeter = p.has_emeter
     mocker.patch("kasa.smartdevice.SmartDevice", return_value=p)
     mocker.patch("kasa.smartdevice.SmartDevice.update")
+    mocker.patch(
+        "kasa.smartdevice.SmartDevice._check_emeter_feature_presence",
+        return_value=has_emeter,
+    )
     res = xdoctest.doctest_module("kasa.smartdevice", "all")
     assert not res["failed"]
 


### PR DESCRIPTION
Starts to address #105 by splitting the `get_sysinfo` and `emeter` queries into two distinct API calls. As noted today by @dcmorton on #119, the underlying cause of the current request hanging is the combination of multiple queries in the same request. Making a second, standalone `emeter` request should always work, but since we can determine whether an emeter is present by checking the response from `get_sysinfo`, I figured let's just avoid the second call if it's not needed.

This PR is only designed to address points 2 and 3 of [this comment](https://github.com/python-kasa/python-kasa/issues/105#issuecomment-723336506) from @rytilahti but I'd be interested in tackling the first point as time allows unless someone else gets there first.

Fixes #161