### PR TITLE
Return None instead of raising an exception on missing, valid emeter keys

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.4.0
+  rev: v3.4.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -10,30 +10,30 @@ repos:
   - id: check-ast
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.25.2
+  rev: v2.10.1
   hooks:
   - id: pyupgrade
     args: ['--py36-plus']
 
 - repo: https://github.com/python/black
-  rev: stable
+  rev: 20.8b1
   hooks:
   - id: black
 
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.9.0
   hooks:
   - id: flake8
     additional_dependencies: [flake8-docstrings]
 
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v4.3.21
+  rev: v5.7.0
   hooks:
   - id: isort
     additional_dependencies: [toml]
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.740
+  rev: v0.812
   hooks:
   - id: mypy
 #    args: [--no-strict-optional, --ignore-missing-imports]

--- a/devtools/parse_pcap.py
+++ b/devtools/parse_pcap.py
@@ -8,6 +8,7 @@ from pprint import pprint as pp
 import click
 import dpkt
 from dpkt.ethernet import ETH_TYPE_IP, Ethernet
+
 from kasa.protocol import TPLinkSmartHomeProtocol
 
 

--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -12,6 +12,7 @@ Module-specific errors are raised as `SmartDeviceException` and are expected
 to be handled by the user of the library.
 """
 from importlib_metadata import version  # type: ignore
+
 from kasa.discover import Discover
 from kasa.exceptions import SmartDeviceException
 from kasa.protocol import TPLinkSmartHomeProtocol

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -87,7 +87,8 @@ class EmeterStatus(dict):
                     if i.startswith(item):
                         return self.__getitem__(i) / 1000
 
-                raise SmartDeviceException("Unable to find a value for '%s'" % item)
+                _LOGGER.debug(f"Unable to find value for '{item}'")
+                return None
 
 
 def requires_update(f):

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -115,3 +115,19 @@ async def test_current_consumption(dev):
         assert x >= 0.0
     else:
         assert await dev.current_consumption() is None
+
+
+async def test_emeterstatus_missing_current():
+    """KL125 does not report 'current' for emeter."""
+    from kasa import EmeterStatus
+
+    regular = EmeterStatus(
+        {"err_code": 0, "power_mw": 0, "total_wh": 13, "current_ma": 123}
+    )
+    assert regular["current"] == 0.123
+
+    with pytest.raises(KeyError):
+        regular["invalid_key"]
+
+    missing_current = EmeterStatus({"err_code": 0, "power_mw": 0, "total_wh": 13})
+    assert missing_current["current"] is None

--- a/kasa/tests/test_readme_examples.py
+++ b/kasa/tests/test_readme_examples.py
@@ -1,8 +1,8 @@
 import sys
 
 import pytest
-
 import xdoctest
+
 from kasa.tests.conftest import get_device_for_file
 
 


### PR DESCRIPTION
Fixes #142

Also, update the pre-commit hooks to their newest versions