### PR TITLE
cli: add human-friendly printout when calling temperature on non-supported devices

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -346,7 +346,7 @@ async def temperature(dev: SmartBulb, temperature: int, transition: int):
     """Get or set color temperature."""
     await dev.update()
     if not dev.is_variable_color_temp:
-        click.echo(f"Device does not support color temperature")
+        click.echo("Device does not support color temperature")
         return
     if temperature is None:
         click.echo(f"Color temperature: {dev.color_temp}")

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -345,19 +345,22 @@ async def brightness(dev: SmartBulb, brightness: int, transition: int):
 async def temperature(dev: SmartBulb, temperature: int, transition: int):
     """Get or set color temperature."""
     await dev.update()
-    if temperature is None:
-        click.echo(f"Color temperature: {dev.color_temp}")
-        valid_temperature_range = dev.valid_temperature_range
-        if valid_temperature_range != (0, 0):
-            click.echo("(min: {}, max: {})".format(*valid_temperature_range))
+    if not dev.is_plug:
+        if temperature is None:
+            click.echo(f"Color temperature: {dev.color_temp}")
+            valid_temperature_range = dev.valid_temperature_range
+            if valid_temperature_range != (0, 0):
+                click.echo("(min: {}, max: {})".format(*valid_temperature_range))
+            else:
+                click.echo(
+                    "Temperature range unknown, please open a github issue"
+                    f" or a pull request for model '{dev.model}'"
+                )
         else:
-            click.echo(
-                "Temperature range unknown, please open a github issue"
-                f" or a pull request for model '{dev.model}'"
-            )
+            click.echo(f"Setting color temperature to {temperature}")
+            await dev.set_color_temp(temperature, transition=transition)
     else:
-        click.echo(f"Setting color temperature to {temperature}")
-        await dev.set_color_temp(temperature, transition=transition)
+        print("This device does not support temperature.")
 
 
 @cli.command()

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -345,22 +345,22 @@ async def brightness(dev: SmartBulb, brightness: int, transition: int):
 async def temperature(dev: SmartBulb, temperature: int, transition: int):
     """Get or set color temperature."""
     await dev.update()
-    if not dev.is_plug:
-        if temperature is None:
-            click.echo(f"Color temperature: {dev.color_temp}")
-            valid_temperature_range = dev.valid_temperature_range
-            if valid_temperature_range != (0, 0):
-                click.echo("(min: {}, max: {})".format(*valid_temperature_range))
-            else:
-                click.echo(
-                    "Temperature range unknown, please open a github issue"
-                    f" or a pull request for model '{dev.model}'"
-                )
+    if not dev.is_variable_color_temp:
+        click.echo(f"Device does not support color temperature")
+        return
+    if temperature is None:
+        click.echo(f"Color temperature: {dev.color_temp}")
+        valid_temperature_range = dev.valid_temperature_range
+        if valid_temperature_range != (0, 0):
+            click.echo("(min: {}, max: {})".format(*valid_temperature_range))
         else:
-            click.echo(f"Setting color temperature to {temperature}")
-            await dev.set_color_temp(temperature, transition=transition)
+            click.echo(
+                "Temperature range unknown, please open a github issue"
+                f" or a pull request for model '{dev.model}'"
+            )
     else:
-        print("This device does not support temperature.")
+        click.echo(f"Setting color temperature to {temperature}")
+        await dev.set_color_temp(temperature, transition=transition)
 
 
 @cli.command()


### PR DESCRIPTION
**Temperature is not supported on plugs**

One of the best things about this python library is that even when we throw unsupported commands at it, it doesn't return errors because there is a clause to tell the user it isn't supported. To maintain this clean style, a simple `if not dev.is_plug:` can prevent the user from receiving errors if they attempt to change the colour temperature of a plug. This is already set with changing the brightness of a plug so why not here?

Consider this pull request. 
- Thanks