### PR TITLE
bulb: allow set_hsv without v, add fallback ct range

### DIFF
--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -148,10 +148,11 @@ async def test_set_color_temp_transition(dev, mocker):
 
 
 @variable_temp
-async def test_unknown_temp_range(dev, monkeypatch):
-    with pytest.raises(SmartDeviceException):
-        monkeypatch.setitem(dev._sys_info, "model", "unknown bulb")
-        dev.valid_temperature_range()
+async def test_unknown_temp_range(dev, monkeypatch, caplog):
+    monkeypatch.setitem(dev._sys_info, "model", "unknown bulb")
+
+    assert dev.valid_temperature_range == (2700, 5000)
+    assert "Unknown color temperature range, fallback to 2700-5000" in caplog.text
 
 
 @variable_temp


### PR DESCRIPTION
* add ColorTempRange and HSV named tuples
* add a fallback color temp range if unknown, log a warning
* set_hsv: the value is now optional