### PR TITLE
Add fixture for newer KP400 firmware

### DIFF
--- a/kasa/tests/fixtures/KP400(US)_2.0_1.0.6.json
+++ b/kasa/tests/fixtures/KP400(US)_2.0_1.0.6.json
@@ -1,0 +1,45 @@
+{
+    "system": {
+        "get_sysinfo": {
+            "alias": "TP-LINK_Smart Plug_DC2A",
+            "child_num": 2,
+            "children": [
+                {
+                    "alias": "Anc ",
+                    "id": "8006B8E953CC4149E2B13AA27E0D18EF1DCFBF3400",
+                    "next_action": {
+                        "type": -1
+                    },
+                    "on_time": 313,
+                    "state": 1
+                },
+                {
+                    "alias": "Plug 2",
+                    "id": "8006B8E953CC4149E2B13AA27E0D18EF1DCFBF3401",
+                    "next_action": {
+                        "type": -1
+                    },
+                    "on_time": 313,
+                    "state": 1
+                }
+            ],
+            "deviceId": "0000000000000000000000000000000000000000",
+            "err_code": 0,
+            "feature": "TIM",
+            "hwId": "00000000000000000000000000000000",
+            "hw_ver": "2.0",
+            "latitude_i": 0,
+            "led_off": 0,
+            "longitude_i": 0,
+            "mac": "00:00:00:00:00:00",
+            "mic_type": "IOT.SMARTPLUGSWITCH",
+            "model": "KP400(US)",
+            "ntc_state": 0,
+            "oemId": "00000000000000000000000000000000",
+            "rssi": -46,
+            "status": "new",
+            "sw_ver": "1.0.6 Build 200821 Rel.090909",
+            "updating": 0
+        }
+    }
+}


### PR DESCRIPTION
I think #149 isn't an issue anymore, but I could be wrong.

@dlee1j1 do you still see an issue on the master branch?

```

== TP-LINK_Smart Plug_DC2A - KP400(US) ==
	Host: 192.168.107.71
	Device state: ON

	== Plugs ==
	* Socket 'Anc ' state: ON on_since: 2021-10-03 13:54:17.893155
	* Socket 'Plug 2' state: ON on_since: 2021-10-03 13:54:17.893235

	== Generic information ==
	Time:         2021-10-03 14:01:30
	Hardware:     2.0
	Software:     1.0.6 Build 200821 Rel.090909
	MAC (rssi):   40:3F:8C:A8:DC:2A (-46)
	Location:     {'latitude': 29.7852, 'longitude': -95.4073}

	== Device specific information ==
	LED state: True
	Childs count: 2
	On since: 2021-10-03 13:54:17.904614
```