### PR TITLE
Make cli interface more consistent

### DIFF
--- a/.gitchangelog.rc
+++ b/.gitchangelog.rc
@@ -1,1 +1,0 @@
-include_merge = False

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,5 +1,0 @@
-python:
-  enabled: true
-  config_file: tox.ini
-flake8:
-  enabled: true


### PR DESCRIPTION
* Device is updated in the click.Group so that individual commands do not need to do that separately
* Device response to actions are just returned and not printed anymore 
  * Printout could be re-added by making click callback to print them out, also in other formats (see #209)
* Deprecated `dump_discover` command is removed
* Also, removes unnused `.gitchangelog.rc` and `hound.yaml`.