### PR TITLE
Add module support & query their information during update cycle

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -215,9 +215,12 @@ async def state(ctx, dev: SmartDevice):
         emeter_status = dev.emeter_realtime
         click.echo(f"\t{emeter_status}")
 
-    click.echo(click.style("\n\t== Supported modules ==", bold=True))
-    for module in dev.supported_modules:
-        click.echo(f"\t- {module}")
+    click.echo(click.style("\n\t== Modules ==", bold=True))
+    for module in dev.modules.values():
+        if module.is_supported:
+            click.echo(click.style(f"\t+ {module}", fg="green"))
+        else:
+            click.echo(click.style(f"\t- {module}", fg="red"))
 
 
 @cli.command()
@@ -458,14 +461,14 @@ async def schedule(dev):
 
 @schedule.command(name="list")
 @pass_dev
-def _schedule_list(dev):
+@click.argument("type", default="schedule")
+def _schedule_list(dev, type):
     """Return the list of schedule actions for the given type."""
-    type_ = "schedule"
-    sched = dev.modules[type_]
+    sched = dev.modules[type]
     for rule in sched.rules:
         print(rule)
     else:
-        click.echo(f"No rules of type {type_}")
+        click.echo(f"No rules of type {type}")
 
 
 if __name__ == "__main__":

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -199,7 +199,7 @@ async def state(ctx, dev: SmartDevice):
         click.echo()
 
     click.echo(click.style("\t== Generic information ==", bold=True))
-    click.echo(f"\tTime:         {await dev.get_time()}")
+    click.echo(f"\tTime:         {dev.time} (tz: {dev.timezone}")
     click.echo(f"\tHardware:     {dev.hw_info['hw_ver']}")
     click.echo(f"\tSoftware:     {dev.hw_info['sw_ver']}")
     click.echo(f"\tMAC (rssi):   {dev.mac} ({dev.rssi})")
@@ -388,7 +388,7 @@ async def led(dev, state):
 @pass_dev
 async def time(dev):
     """Get the device time."""
-    res = await dev.get_time()
+    res = dev.time
     click.echo(f"Current time: {res}")
     return res
 
@@ -444,6 +444,24 @@ async def reboot(plug, delay):
     """Reboot the device."""
     click.echo("Rebooting the device..")
     return await plug.reboot(delay)
+
+
+@cli.group()
+@pass_dev
+async def schedule(dev):
+    """Scheduling commands."""
+
+
+@schedule.command(name="list")
+@pass_dev
+def _schedule_list(dev):
+    """Return the list of schedule actions for the given type."""
+    type_ = "schedule"
+    sched = dev.modules[type_]
+    for rule in sched.rules:
+        print(rule)
+    else:
+        click.echo(f"No rules of type {type_}")
 
 
 if __name__ == "__main__":

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -215,6 +215,10 @@ async def state(ctx, dev: SmartDevice):
         emeter_status = dev.emeter_realtime
         click.echo(f"\t{emeter_status}")
 
+    click.echo(click.style("\n\t== Supported modules ==", bold=True))
+    for module in dev.supported_modules:
+        click.echo(f"\t- {module}")
+
 
 @cli.command()
 @pass_dev

--- a/kasa/modules/__init__.py
+++ b/kasa/modules/__init__.py
@@ -7,3 +7,4 @@ from .module import Module
 from .rulemodule import Rule, RuleModule
 from .schedule import Schedule
 from .time import Time
+from .usage import Usage

--- a/kasa/modules/__init__.py
+++ b/kasa/modules/__init__.py
@@ -1,0 +1,9 @@
+# flake8: noqa
+from .antitheft import Antitheft
+from .cloud import Cloud
+from .countdown import Countdown
+from .emeter import Emeter
+from .module import Module
+from .rulemodule import Rule, RuleModule
+from .schedule import Schedule
+from .time import Time

--- a/kasa/modules/antitheft.py
+++ b/kasa/modules/antitheft.py
@@ -1,6 +1,5 @@
-from typing import Dict, List
-
-from .rulemodule import Rule, RuleModule
+"""Implementation of the antitheft module."""
+from .rulemodule import RuleModule
 
 
 class Antitheft(RuleModule):

--- a/kasa/modules/antitheft.py
+++ b/kasa/modules/antitheft.py
@@ -1,0 +1,10 @@
+from typing import Dict, List
+
+from .rulemodule import Rule, RuleModule
+
+
+class Antitheft(RuleModule):
+    """Implementation of the antitheft module.
+
+    This shares the functionality among other rule-based modules.
+    """

--- a/kasa/modules/cloud.py
+++ b/kasa/modules/cloud.py
@@ -1,0 +1,50 @@
+"""Cloud module implementation."""
+from pydantic import BaseModel
+
+from .module import Module
+
+
+class CloudInfo(BaseModel):
+    """Container for cloud settings."""
+
+    binded: bool
+    cld_connection: int
+    fwDlPage: str
+    fwNotifyType: int
+    illegalType: int
+    server: str
+    stopConnect: int
+    tcspInfo: str
+    tcspStatus: int
+    username: str
+
+
+class Cloud(Module):
+    """Module implementing support for cloud services."""
+
+    def query(self):
+        """Request cloud connectivity info."""
+        return self.query_for_command("get_info")
+
+    @property
+    def info(self) -> CloudInfo:
+        """Return information about the cloud connectivity."""
+        return CloudInfo.parse_obj(self.data["get_info"])
+
+    def get_available_firmwares(self):
+        """Return list of available firmwares."""
+        return self.query_for_command("get_intl_fw_list")
+
+    def set_server(self, url: str):
+        """Set the update server URL."""
+        return self.query_for_command("set_server_url", {"server": url})
+
+    def connect(self, username: str, password: str):
+        """Login to the cloud using given information."""
+        return self.query_for_command(
+            "bind", {"username": username, "password": password}
+        )
+
+    def disconnect(self):
+        """Disconnect from the cloud."""
+        return self.query_for_command("unbind")

--- a/kasa/modules/countdown.py
+++ b/kasa/modules/countdown.py
@@ -1,4 +1,4 @@
-"""Implmention for the countdown timer."""
+"""Implementation for the countdown timer."""
 from .rulemodule import RuleModule
 
 

--- a/kasa/modules/countdown.py
+++ b/kasa/modules/countdown.py
@@ -1,3 +1,4 @@
+"""Implmention for the countdown timer."""
 from .rulemodule import RuleModule
 
 

--- a/kasa/modules/countdown.py
+++ b/kasa/modules/countdown.py
@@ -1,0 +1,5 @@
+from .rulemodule import RuleModule
+
+
+class Countdown(RuleModule):
+    """Implementation of countdown module."""

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -1,6 +1,6 @@
 """Implementation of the emeter module."""
 from ..emeterstatus import EmeterStatus
-from .usagemodule import Usage
+from .usage import Usage
 
 
 class Emeter(Usage):

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -1,0 +1,20 @@
+"""Implementation of the emeter module."""
+from ..emeterstatus import EmeterStatus
+from .usagemodule import Usage
+
+
+class Emeter(Usage):
+    """Emeter module."""
+
+    def query(self):
+        """Prepare query for emeter data."""
+        return self._device._create_emeter_request()
+
+    @property  # type: ignore
+    def realtime(self) -> EmeterStatus:
+        """Return current energy readings."""
+        return EmeterStatus(self.data["get_realtime"])
+
+    async def erase_stats(self):
+        """Erase all stats."""
+        return await self.call("erase_emeter_stat")

--- a/kasa/modules/module.py
+++ b/kasa/modules/module.py
@@ -1,8 +1,10 @@
 """Base class for all module implementations."""
 import collections
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
-from kasa import SmartDevice
+if TYPE_CHECKING:
+    from kasa import SmartDevice
 
 
 # TODO: This is used for query construcing

--- a/kasa/modules/module.py
+++ b/kasa/modules/module.py
@@ -42,6 +42,11 @@ class Module(ABC):
         """Return the module specific raw data from the last update."""
         return self._device._last_update[self._module]
 
+    @property
+    def is_supported(self) -> bool:
+        """Return whether the module is supported by the device."""
+        return "err_code" not in self.data
+
     def call(self, method, params=None):
         """Call the given method with the given parameters."""
         return self._device._query_helper(self._module, method, params)

--- a/kasa/modules/module.py
+++ b/kasa/modules/module.py
@@ -1,0 +1,52 @@
+"""Base class for all module implementations."""
+import collections
+from abc import ABC, abstractmethod
+
+from kasa import SmartDevice
+
+
+# TODO: This is used for query construcing
+def merge(d, u):
+    """Update dict recursively."""
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = merge(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
+
+class Module(ABC):
+    """Base class implemention for all modules.
+
+    The base classes should implement `query` to return the query they want to be
+    executed during the regular update cycle.
+    """
+
+    def __init__(self, device: "SmartDevice", module: str):
+        self._device: "SmartDevice" = device
+        self._module = module
+
+    @abstractmethod
+    def query(self):
+        """Query to execute during the update cycle.
+
+        The inheriting modules implement this to include their wanted
+        queries to the query that gets executed when Device.update() gets called.
+        """
+
+    @property
+    def data(self):
+        """Return the module specific raw data from the last update."""
+        return self._device._last_update[self._module]
+
+    def call(self, method, params=None):
+        """Call the given method with the given parameters."""
+        return self._device._query_helper(self._module, method, params)
+
+    def query_for_command(self, query, params=None):
+        """Create a request object for the given parameters."""
+        return self._device._create_request(self._module, query, params)
+
+    def __repr__(self) -> str:
+        return f"<Module {self.__class__.__name__} ({self._module}) for {self._device.alias}>"

--- a/kasa/modules/module.py
+++ b/kasa/modules/module.py
@@ -51,4 +51,4 @@ class Module(ABC):
         return self._device._create_request(self._module, query, params)
 
     def __repr__(self) -> str:
-        return f"<Module {self.__class__.__name__} ({self._module}) for {self._device.alias}>"
+        return f"<Module {self.__class__.__name__} ({self._module}) for {self._device.host}>"

--- a/kasa/modules/rulemodule.py
+++ b/kasa/modules/rulemodule.py
@@ -1,0 +1,83 @@
+"""Base implementation for all rule-based modules."""
+import logging
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+from .module import Module, merge
+
+
+class Action(Enum):
+    """Action to perform."""
+
+    Disabled = -1
+    TurnOff = 0
+    TurnOn = 1
+    Unknown = 2
+
+
+class TimeOption(Enum):
+    """Time when the action is executed."""
+
+    Disabled = -1
+    Enabled = 0
+    AtSunrise = 1
+    AtSunset = 2
+
+
+class Rule(BaseModel):
+    """Representation of a rule."""
+
+    id: str
+    name: str
+    enable: bool
+    wday: List[int]
+    repeat: bool
+
+    # start action
+    sact: Optional[Action]
+    stime_opt: TimeOption
+    smin: int
+
+    eact: Optional[Action]
+    etime_opt: TimeOption
+    emin: int
+
+    # Only on bulbs
+    s_light: Optional[Dict]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RuleModule(Module):
+    """Base class for rule-based modules, such as countdown and antitheft."""
+
+    def query(self):
+        """Prepare the query for rules."""
+        q = self.query_for_command("get_rules")
+        return merge(q, self.query_for_command("get_next_action"))
+
+    @property
+    def rules(self) -> List[Rule]:
+        """Return the list of rules for the service."""
+        try:
+            return [
+                Rule.parse_obj(rule) for rule in self.data["get_rules"]["rule_list"]
+            ]
+        except Exception as ex:
+            _LOGGER.error("Unable to read rule list: %s (data: %s)", ex, self.data)
+            return []
+
+    async def set_enabled(self, state: bool):
+        """Enable or disable the service."""
+        return await self.call("set_overall_enable", state)
+
+    async def delete_rule(self, rule: Rule):
+        """Delete the given rule."""
+        return await self.call("delete_rule", {"id": rule.id})
+
+    async def delete_all_rules(self):
+        """Delete all rules."""
+        return await self.call("delete_all_rules")

--- a/kasa/modules/schedule.py
+++ b/kasa/modules/schedule.py
@@ -1,0 +1,11 @@
+"""Schedule module implementation."""
+from .rulemodule import RuleModule
+from .usage import Usage
+
+
+class Schedule(Usage, RuleModule):
+    """Implements the scheduling interface & usage statistics.
+
+    Some devices do not support emeter, but may still keep track about their on/off state.
+    This module implements the interface to access that usage data.
+    """

--- a/kasa/modules/schedule.py
+++ b/kasa/modules/schedule.py
@@ -1,11 +1,6 @@
 """Schedule module implementation."""
 from .rulemodule import RuleModule
-from .usage import Usage
 
 
-class Schedule(Usage, RuleModule):
-    """Implements the scheduling interface & usage statistics.
-
-    Some devices do not support emeter, but may still keep track about their on/off state.
-    This module implements the interface to access that usage data.
-    """
+class Schedule(RuleModule):
+    """Implements the scheduling interface."""

--- a/kasa/modules/time.py
+++ b/kasa/modules/time.py
@@ -1,0 +1,34 @@
+"""Provides the current time and timezone information."""
+from datetime import datetime
+
+from .module import Module, merge
+
+
+class Time(Module):
+    """Implements the timezone settings."""
+
+    def query(self):
+        """Request time and timezone."""
+        q = self.query_for_command("get_time")
+
+        merge(q, self.query_for_command("get_timezone"))
+        return q
+
+    @property
+    def time(self) -> datetime:
+        """Return current device time."""
+        res = self.data["get_time"]
+        return datetime(
+            res["year"],
+            res["month"],
+            res["mday"],
+            res["hour"],
+            res["min"],
+            res["sec"],
+        )
+
+    @property
+    def timezone(self):
+        """Return current timezone."""
+        res = self.data["get_timezone"]
+        return res

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -12,7 +12,7 @@ class Usage(Module):
         year = datetime.now().year
         month = datetime.now().month
 
-        req = self.query_for_command(self._module, "get_realtime")
+        req = self.query_for_command("get_realtime")
         req = merge(
             req, self.query_for_command("get_daystat", {"year": year, "month": month})
         )

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -1,0 +1,40 @@
+"""Implementation of the usage interface."""
+from datetime import datetime
+
+from .module import Module, merge
+
+
+class Usage(Module):
+    """Baseclass for emeter/usage interfaces."""
+
+    def query(self):
+        """Return the base query."""
+        year = datetime.now().year
+        month = datetime.now().month
+
+        req = self.query_for_command(self._module, "get_realtime")
+        req = merge(
+            req, self.query_for_command("get_daystat", {"year": year, "month": month})
+        )
+        req = merge(req, self.query_for_command("get_monthstat", {"year": year}))
+        req = merge(req, self.query_for_command("get_next_action"))
+
+        return req
+
+    async def get_daystat(self, year, month):
+        """Return stats for the current day."""
+        if year is None:
+            year = datetime.now().year
+        if month is None:
+            month = datetime.now().month
+        return await self.call("get_daystat", {"year": year, "month": month})
+
+    async def get_monthstat(self, year):
+        """Return stats for the current month."""
+        if year is None:
+            year = datetime.now().year
+        return await self.call("get_monthstat", {"year": year})
+
+    async def erase_stats(self):
+        """Erase all stats."""
+        return await self.call("erase_runtime_stat")

--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -3,7 +3,7 @@ import logging
 import re
 from typing import Any, Dict, NamedTuple, cast
 
-from .modules import Antitheft, Cloud, Countdown, Emeter, Schedule, Time
+from .modules import Antitheft, Cloud, Countdown, Emeter, Schedule, Time, Usage
 from .smartdevice import DeviceType, SmartDevice, SmartDeviceException, requires_update
 
 
@@ -113,6 +113,7 @@ class SmartBulb(SmartDevice):
         super().__init__(host=host)
         self._device_type = DeviceType.Bulb
         self.add_module("schedule", Schedule(self, "smartlife.iot.common.schedule"))
+        self.add_module("usage", Usage(self, "smartlife.iot.common.schedule"))
         self.add_module("antitheft", Antitheft(self, "smartlife.iot.common.anti_theft"))
         self.add_module("time", Time(self, "smartlife.iot.common.timesetting"))
         self.add_module("emeter", Emeter(self, self.emeter_type))

--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -3,6 +3,7 @@ import logging
 import re
 from typing import Any, Dict, NamedTuple, cast
 
+from .modules import Antitheft, Cloud, Countdown, Emeter, Schedule, Time
 from .smartdevice import DeviceType, SmartDevice, SmartDeviceException, requires_update
 
 
@@ -105,13 +106,18 @@ class SmartBulb(SmartDevice):
     """
 
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
-    TIME_SERVICE = "smartlife.iot.common.timesetting"
     SET_LIGHT_METHOD = "transition_light_state"
+    emeter_type = "smartlife.iot.common.emeter"
 
     def __init__(self, host: str) -> None:
         super().__init__(host=host)
-        self.emeter_type = "smartlife.iot.common.emeter"
         self._device_type = DeviceType.Bulb
+        self.add_module("schedule", Schedule(self, "smartlife.iot.common.schedule"))
+        self.add_module("antitheft", Antitheft(self, "smartlife.iot.common.anti_theft"))
+        self.add_module("time", Time(self, "smartlife.iot.common.timesetting"))
+        self.add_module("emeter", Emeter(self, self.emeter_type))
+        self.add_module("countdown", Countdown(self, "countdown"))
+        self.add_module("cloud", Cloud(self, "smartlife.iot.common.cloud"))
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -321,8 +321,9 @@ class SmartDevice:
             self.add_module("emeter", Emeter(self, self.emeter_type))
 
         for module in self.modules.values():
-            _LOGGER.debug("Adding query from %s", module)
-            req.update(module.query())
+            q = module.query()
+            _LOGGER.debug("Adding query for %s: %s", module, q)
+            req = merge(req, module.query(q))
 
         self._last_update = await self.protocol.query(req)
         self._sys_info = self._last_update["system"]["get_sysinfo"]

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -277,6 +277,14 @@ class SmartDevice:
 
     @property  # type: ignore
     @requires_update
+    def supported_modules(self) -> List[str]:
+        """Return a set of modules supported by the device."""
+        # TODO: this should rather be called `features`, but we don't want to break
+        #       the API now. Maybe just deprecate it and point the users to use this?
+        return list(self.modules.keys())
+
+    @property  # type: ignore
+    @requires_update
     def has_emeter(self) -> bool:
         """Return True if device has an energy meter."""
         return "ENE" in self.features

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -323,7 +323,7 @@ class SmartDevice:
         for module in self.modules.values():
             q = module.query()
             _LOGGER.debug("Adding query for %s: %s", module, q)
-            req = merge(req, module.query(q))
+            req = merge(req, module.query())
 
         self._last_update = await self.protocol.query(req)
         self._sys_info = self._last_update["system"]["get_sysinfo"]

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Set
 
 from .emeterstatus import EmeterStatus
 from .exceptions import SmartDeviceException
+from .modules import Emeter, Module
 from .protocol import TPLinkSmartHomeProtocol
 
 _LOGGER = logging.getLogger(__name__)
@@ -186,6 +187,7 @@ class SmartDevice:
     """
 
     TIME_SERVICE = "time"
+    emeter_type = "emeter"
 
     def __init__(self, host: str) -> None:
         """Create a new SmartDevice instance.
@@ -195,7 +197,6 @@ class SmartDevice:
         self.host = host
 
         self.protocol = TPLinkSmartHomeProtocol(host)
-        self.emeter_type = "emeter"
         _LOGGER.debug("Initializing %s of type %s", self.host, type(self))
         self._device_type = DeviceType.Unknown
         # TODO: typing Any is just as using Optional[Dict] would require separate checks in
@@ -203,8 +204,20 @@ class SmartDevice:
         #       are not accessed incorrectly.
         self._last_update: Any = None
         self._sys_info: Any = None  # TODO: this is here to avoid changing tests
+        self.modules: Dict[str, Any] = {}
 
         self.children: List["SmartDevice"] = []
+
+    def add_module(self, name: str, module: Module):
+        """Register a module."""
+        if name in self.modules:
+            _LOGGER.debug("Module %s already registered, ignoring..." % name)
+            return
+
+        assert name not in self.modules
+
+        _LOGGER.debug("Adding module %s", module)
+        self.modules[name] = module
 
     def _create_request(
         self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None
@@ -297,7 +310,11 @@ class SmartDevice:
             _LOGGER.debug(
                 "The device has emeter, querying its information along sysinfo"
             )
-            req.update(self._create_emeter_request())
+            self.add_module("emeter", Emeter(self, self.emeter_type))
+
+        for module in self.modules.values():
+            _LOGGER.debug("Adding query from %s", module)
+            req.update(module.query())
 
         self._last_update = await self.protocol.query(req)
         self._sys_info = self._last_update["system"]["get_sysinfo"]
@@ -330,6 +347,18 @@ class SmartDevice:
     async def set_alias(self, alias: str) -> None:
         """Set the device name (alias)."""
         return await self._query_helper("system", "set_dev_alias", {"alias": alias})
+
+    @property  # type: ignore
+    @requires_update
+    def time(self) -> datetime:
+        """Return current time from the device."""
+        return self.modules["time"].time
+
+    @property  # type: ignore
+    @requires_update
+    def timezone(self) -> Dict:
+        """Return the current timezone."""
+        return self.modules["time"].timezone
 
     async def get_time(self) -> Optional[datetime]:
         """Return current time from the device, if available."""
@@ -429,7 +458,7 @@ class SmartDevice:
     def emeter_realtime(self) -> EmeterStatus:
         """Return current energy readings."""
         self._verify_emeter()
-        return EmeterStatus(self._last_update[self.emeter_type]["get_realtime"])
+        return EmeterStatus(self.modules["emeter"].realtime)
 
     async def get_emeter_realtime(self) -> EmeterStatus:
         """Retrieve current energy readings."""
@@ -549,7 +578,7 @@ class SmartDevice:
     async def erase_emeter_stats(self) -> Dict:
         """Erase energy meter statistics."""
         self._verify_emeter()
-        return await self._query_helper(self.emeter_type, "erase_emeter_stat", None)
+        return await self.modules["emeter"].erase_stats()
 
     @requires_update
     async def current_consumption(self) -> float:

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any, Dict
 
+from kasa.modules import Antitheft, Cloud, Schedule, Time
 from kasa.smartdevice import DeviceType, SmartDevice, requires_update
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +41,10 @@ class SmartPlug(SmartDevice):
         super().__init__(host)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug
+        self.add_module("schedule", Schedule(self, "schedule"))
+        self.add_module("antitheft", Antitheft(self, "anti_theft"))
+        self.add_module("time", Time(self, "time"))
+        self.add_module("cloud", Cloud(self, "cnCloud"))
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Any, Dict
 
-from kasa.modules import Antitheft, Cloud, Schedule, Time
+from kasa.modules import Antitheft, Cloud, Schedule, Time, Usage
 from kasa.smartdevice import DeviceType, SmartDevice, requires_update
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ class SmartPlug(SmartDevice):
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Plug
         self.add_module("schedule", Schedule(self, "schedule"))
+        self.add_module("usage", Usage(self, "schedule"))
         self.add_module("antitheft", Antitheft(self, "anti_theft"))
         self.add_module("time", Time(self, "time"))
         self.add_module("cloud", Cloud(self, "cnCloud"))

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -13,6 +13,8 @@ from kasa.smartdevice import (
 )
 from kasa.smartplug import SmartPlug
 
+from .modules import Antitheft, Countdown, Schedule, Time
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -80,6 +82,10 @@ class SmartStrip(SmartDevice):
         super().__init__(host=host)
         self.emeter_type = "emeter"
         self._device_type = DeviceType.Strip
+        self.add_module("antitheft", Antitheft(self, "anti_theft"))
+        self.add_module("schedule", Schedule(self, "schedule"))
+        self.add_module("time", Time(self, "time"))
+        self.add_module("countdown", Countdown(self, "countdown"))
 
     @property  # type: ignore
     @requires_update
@@ -205,13 +211,13 @@ class SmartStrip(SmartDevice):
     @requires_update
     def emeter_this_month(self) -> Optional[float]:
         """Return this month's energy consumption in kWh."""
-        return sum([plug.emeter_this_month for plug in self.children])
+        return sum(plug.emeter_this_month for plug in self.children)
 
     @property  # type: ignore
     @requires_update
     def emeter_today(self) -> Optional[float]:
         """Return this month's energy consumption in kWh."""
-        return sum([plug.emeter_today for plug in self.children])
+        return sum(plug.emeter_today for plug in self.children)
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -13,7 +13,7 @@ from kasa.smartdevice import (
 )
 from kasa.smartplug import SmartPlug
 
-from .modules import Antitheft, Countdown, Schedule, Time
+from .modules import Antitheft, Countdown, Schedule, Time, Usage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,6 +84,7 @@ class SmartStrip(SmartDevice):
         self._device_type = DeviceType.Strip
         self.add_module("antitheft", Antitheft(self, "anti_theft"))
         self.add_module("schedule", Schedule(self, "schedule"))
+        self.add_module("usage", Usage(self, "schedule"))
         self.add_module("time", Time(self, "time"))
         self.add_module("countdown", Countdown(self, "countdown"))
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -334,6 +334,21 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pydantic"
+version = "1.8.2"
+description = "Data validation and settings management using python 3.6 type hinting"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+typing-extensions = ">=3.7.4.3"
+
+[package.extras]
+dotenv = ["python-dotenv (>=0.10.4)"]
+email = ["email-validator (>=1.0.3)"]
+
+[[package]]
 name = "pygments"
 version = "2.10.0"
 description = "Pygments is a syntax highlighting package written in Python."
@@ -747,7 +762,7 @@ docs = ["sphinx", "sphinx_rtd_theme", "m2r", "sphinxcontrib-programoutput"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "e388fa366e9423e60697bfa77c37151094ca0367eb3ed441d61bb8cc7f055675"
+content-hash = "9b67c28fae544c487b54137b9953d86b359113c2de58020f4c4981361afbcf5a"
 
 [metadata.files]
 alabaster = [
@@ -954,6 +969,30 @@ pre-commit = [
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pydantic = [
+    {file = "pydantic-1.8.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:05ddfd37c1720c392f4e0d43c484217b7521558302e7069ce8d318438d297739"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a7c6002203fe2c5a1b5cbb141bb85060cbff88c2d78eccbc72d97eb7022c43e4"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:589eb6cd6361e8ac341db97602eb7f354551482368a37f4fd086c0733548308e"},
+    {file = "pydantic-1.8.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:10e5622224245941efc193ad1d159887872776df7a8fd592ed746aa25d071840"},
+    {file = "pydantic-1.8.2-cp36-cp36m-win_amd64.whl", hash = "sha256:99a9fc39470010c45c161a1dc584997f1feb13f689ecf645f59bb4ba623e586b"},
+    {file = "pydantic-1.8.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a83db7205f60c6a86f2c44a61791d993dff4b73135df1973ecd9eed5ea0bda20"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:41b542c0b3c42dc17da70554bc6f38cbc30d7066d2c2815a94499b5684582ecb"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:ea5cb40a3b23b3265f6325727ddfc45141b08ed665458be8c6285e7b85bd73a1"},
+    {file = "pydantic-1.8.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:18b5ea242dd3e62dbf89b2b0ec9ba6c7b5abaf6af85b95a97b00279f65845a23"},
+    {file = "pydantic-1.8.2-cp37-cp37m-win_amd64.whl", hash = "sha256:234a6c19f1c14e25e362cb05c68afb7f183eb931dd3cd4605eafff055ebbf287"},
+    {file = "pydantic-1.8.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:021ea0e4133e8c824775a0cfe098677acf6fa5a3cbf9206a376eed3fc09302cd"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e710876437bc07bd414ff453ac8ec63d219e7690128d925c6e82889d674bb505"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:ac8eed4ca3bd3aadc58a13c2aa93cd8a884bcf21cb019f8cfecaae3b6ce3746e"},
+    {file = "pydantic-1.8.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:4a03cbbe743e9c7247ceae6f0d8898f7a64bb65800a45cbdc52d65e370570820"},
+    {file = "pydantic-1.8.2-cp38-cp38-win_amd64.whl", hash = "sha256:8621559dcf5afacf0069ed194278f35c255dc1a1385c28b32dd6c110fd6531b3"},
+    {file = "pydantic-1.8.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8b223557f9510cf0bfd8b01316bf6dd281cf41826607eada99662f5e4963f316"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:244ad78eeb388a43b0c927e74d3af78008e944074b7d0f4f696ddd5b2af43c62"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:05ef5246a7ffd2ce12a619cbb29f3307b7c4509307b1b49f456657b43529dc6f"},
+    {file = "pydantic-1.8.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:54cd5121383f4a461ff7644c7ca20c0419d58052db70d8791eacbbe31528916b"},
+    {file = "pydantic-1.8.2-cp39-cp39-win_amd64.whl", hash = "sha256:4be75bebf676a5f0f87937c6ddb061fa39cbea067240d98e298508c1bda6f3f3"},
+    {file = "pydantic-1.8.2-py3-none-any.whl", hash = "sha256:fec866a0b59f372b7e776f2d7308511784dace622e0992a0b59ea3ccee0ae833"},
+    {file = "pydantic-1.8.2.tar.gz", hash = "sha256:26464e57ccaafe72b7ad156fdaa4e9b9ef051f69e175dbbb463283000c05ab7b"},
 ]
 pygments = [
     {file = "Pygments-2.10.0-py3-none-any.whl", hash = "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ sphinx = { version = "^3", optional = true }
 m2r = { version = "^0", optional = true }
 sphinx_rtd_theme = { version = "^0", optional = true }
 sphinxcontrib-programoutput = { version = "^0", optional = true }
+pydantic = "^1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5"


### PR DESCRIPTION
This PR creates a modularized foundation to expose more features on the supported devices, with the goal of making it more straightforward to implement new features in the future. This PR should not break the API.

At the moment, the most visible change is that each update cycle queries the information from all modules in a single query:
* Basic system info
* Cloud (new)
* Countdown (new)
* Antitheft (new)
* Schedule (new)
* Usage (new)
* Time (existing, implements the time/timezone handling)
* Emeter (existing, partially separated from smartdevice)

As some devices are known to be picky on multimodule queries, I'm marking this a draft in hopes of getting feedback if this works on the majority of devices as it is or not.

Further updates and improvements are to be done on `modularize` branch which is the target branch of this PR.