### PR TITLE
Allow publish on test pypi workflow to fail

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,7 @@ jobs:
         .
     - name: Publish on test pypi
       uses: pypa/gh-action-pypi-publish@master
+      continue-on-error: true
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
The CD pipeline pieces are not currently working properly, this is a stopgap solution to avoid all merges on master to fail due to testpypi upload failure happening always after the first merged PR for the given version.

If testpypi uploads are wanted, https://github.com/pypa/setuptools_scm could be considered to handle the versioning.