### PR TITLE
Add the --output-format option.

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -1,7 +1,7 @@
 """python-kasa cli tool."""
 import logging
-from pprint import pformat as pf
-from typing import cast
+from datetime import datetime
+from typing import List, cast
 
 import asyncclick as click
 
@@ -13,11 +13,22 @@ from kasa import (
     SmartPlug,
     SmartStrip,
 )
+from kasa.exceptions import SmartDeviceException
+from kasa.printmanager import (
+    DataWrapper,
+    HumanMessenger,
+    JsonMessenger,
+    Messenger,
+    StyleFlag,
+)
 
 click.anyio_backend = "asyncio"
 
 
-pass_dev = click.make_pass_decorator(SmartDevice)
+class CliData:
+    """Holds context data."""
+
+    pass
 
 
 @click.group(invoke_without_command=True)
@@ -34,6 +45,13 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     help="The device name, or alias, of the device to connect to.",
 )
 @click.option(
+    "--output-format",
+    "-f",
+    default="human",
+    required=False,
+    help="The format for the output. Can be 'json', 'json-ws'. 'Human' is default.",
+)
+@click.option(
     "--target",
     default="255.255.255.255",
     required=False,
@@ -46,8 +64,20 @@ pass_dev = click.make_pass_decorator(SmartDevice)
 @click.option("--strip", default=False, is_flag=True)
 @click.version_option()
 @click.pass_context
-async def cli(ctx, host, alias, target, debug, bulb, plug, lightstrip, strip):
+async def cli(
+    ctx, host, alias, output_format, target, debug, bulb, plug, lightstrip, strip
+):
     """A tool for controlling TP-Link smart home devices."""  # noqa
+    ctx.obj = CliData()
+    output_format = output_format.lower()
+    if output_format == "json":
+        msgr = JsonMessenger(whitespace=False)
+    elif output_format == "json-ws":
+        msgr = JsonMessenger(whitespace=True)
+    else:
+        msgr = HumanMessenger()
+    ctx.obj.msgr = msgr
+
     if debug:
         logging.basicConfig(level=logging.DEBUG)
     else:
@@ -55,59 +85,67 @@ async def cli(ctx, host, alias, target, debug, bulb, plug, lightstrip, strip):
 
     if ctx.invoked_subcommand == "discover":
         return
+    elif not ctx.invoked_subcommand:
+        raise click.UsageError(
+            "Nothing to do. Type 'kasa --help' for a list of available commands."
+        )
 
-    if alias is not None and host is None:
-        click.echo(f"Alias is given, using discovery to find host {alias}")
-        host = await find_host_from_alias(alias=alias, target=target)
-        if host:
-            click.echo(f"Found hostname is {host}")
-        else:
-            click.echo(f"No device with name {alias} found")
-            return
+    try:
+        if alias is not None and host is None:
+            msgr.prog(f"Alias is given, using discovery to find host {alias}")
+            dev = await find_device_from_alias(alias=alias, target=target)
+            if dev:
+                ctx.obj.dev = dev
+                msgr.prog(f"Found hostname is {dev.host}")
+                await dev.update()
+            else:
+                msgr.err(f"No device with name {alias} found", fatal=True)
+                exit()
+        elif host is not None:
+            if bulb:
+                dev = SmartBulb(host)
+            elif plug:
+                dev = SmartPlug(host)
+            elif strip:
+                dev = SmartStrip(host)
+            elif lightstrip:
+                dev = SmartLightStrip(host)
+            else:
+                msgr.prog("No --strip nor --bulb nor --plug given, discovering..")
+                dev = await Discover.discover_single(host)
 
-    if host is None:
-        click.echo("No host name given, trying discovery..")
-        await ctx.invoke(discover)
-        return
-    else:
-        if not bulb and not plug and not strip and not lightstrip:
-            click.echo("No --strip nor --bulb nor --plug given, discovering..")
-            dev = await Discover.discover_single(host)
-        elif bulb:
-            dev = SmartBulb(host)
-        elif plug:
-            dev = SmartPlug(host)
-        elif strip:
-            dev = SmartStrip(host)
-        elif lightstrip:
-            dev = SmartLightStrip(host)
-        else:
-            click.echo("Unable to detect type, use --strip or --bulb or --plug!")
-            return
+            ctx.obj.dev = dev
+            await dev.update()
+    except SmartDeviceException as e:
+        msgr.err(str(e), fatal=True)
+        exit()
 
-        await dev.update()
-        ctx.obj = dev
 
-    if ctx.invoked_subcommand is None:
-        await ctx.invoke(state)
+# Produces error: '@cli.result_callback() TypeError: 'NoneType' object is not callable' (Python 3.7)
+# @cli.result_callback()
+# def callback(ctx, host, alias, output_format, target, debug, bulb, plug, lightstrip, strip, res):
+#     ctx.obj.msgr.print_data()
 
 
 @cli.group()
-@pass_dev
-def wifi(dev):
+@click.pass_context
+def wifi(ctx):
     """Commands to control wifi settings."""
 
 
 @wifi.command()
-@pass_dev
-async def scan(dev):
+@click.pass_context
+async def scan(ctx):
     """Scan for available wifi networks."""
-    click.echo("Scanning for wifi networks, wait a second..")
-    devs = await dev.wifi_scan()
-    click.echo(f"Found {len(devs)} wifi networks!")
-    for dev in devs:
-        click.echo(f"\t {dev}")
+    msgr: Messenger = ctx.obj.msgr
+    msgr.prog("Scanning for wifi networks, wait a second..")
+    devs = await ctx.obj.dev.wifi_scan()
+    msgr.prog(f"Found {len(devs)} wifi networks!")
+    dw = msgr.data_wrapper
+    for idx, nw in enumerate(devs):
+        dw.add_point(f"network_{idx}", str(nw))
 
+    msgr.print_data()
     return devs
 
 
@@ -115,15 +153,18 @@ async def scan(dev):
 @click.argument("ssid")
 @click.option("--password", prompt=True, hide_input=True)
 @click.option("--keytype", default=3)
-@pass_dev
-async def join(dev: SmartDevice, ssid, password, keytype):
+@click.pass_context
+async def join(ctx, ssid, password, keytype):
     """Join the given wifi network."""
-    click.echo(f"Asking the device to connect to {ssid}..")
-    res = await dev.wifi_join(ssid, password, keytype=keytype)
-    click.echo(
-        f"Response: {res} - if the device is not able to join the network, it will revert back to its previous state."
+    msgr: Messenger = ctx.obj.msgr
+    msgr.prog(f"Asking the device to connect to {ssid}..")
+    res = await ctx.obj.dev.wifi_join(ssid, password, keytype=keytype)
+    msgr.prog(
+        "If the device is not able to join the network, \
+        it will revert back to its previous state."
     )
-
+    msgr.data_wrapper.add_point("res", res, "Result", StyleFlag.BOLD)
+    msgr.print_data()
     return res
 
 
@@ -134,193 +175,165 @@ async def join(dev: SmartDevice, ssid, password, keytype):
 @click.pass_context
 async def discover(ctx, timeout, discover_only, dump_raw):
     """Discover devices in the network."""
+    msgr = ctx.obj.msgr
+    dw = msgr.data_wrapper
     target = ctx.parent.params["target"]
-    click.echo(f"Discovering devices on {target} for {timeout} seconds")
+    msgr.prog(f"Discovering devices on {target} for {timeout} seconds")
     found_devs = await Discover.discover(target=target, timeout=timeout)
     if not discover_only:
-        for ip, dev in found_devs.items():
+        for dev in found_devs.values():
             if dump_raw:
-                click.echo(dev.sys_info)
-                continue
-            ctx.obj = dev
-            await ctx.invoke(state)
-            click.echo()
+                dw = dw.add_categorie(dev.host, name=dev.alias, style=StyleFlag.BOLD)
+                wrap_dev_sysinfo(dw, dev)
+            else:
+                await wrap_dev_state(dw, dev)
 
+    msgr.print_data()
     return found_devs
 
 
-async def find_host_from_alias(alias, target="255.255.255.255", timeout=1, attempts=3):
+async def find_device_from_alias(
+    alias, target="255.255.255.255", timeout=1, attempts=3
+):
     """Discover a device identified by its alias."""
     for attempt in range(1, attempts):
         found_devs = await Discover.discover(target=target, timeout=timeout)
         for ip, dev in found_devs.items():
             if dev.alias.lower() == alias.lower():
-                host = dev.host
-                return host
+                return dev
 
     return None
 
 
 @cli.command()
-@pass_dev
-async def sysinfo(dev):
-    """Print out full system information."""
-    click.echo(click.style("== System info ==", bold=True))
-    click.echo(pf(dev.sys_info))
-    return dev.sys_info
-
-
-@cli.command()
-@pass_dev
 @click.pass_context
-async def state(ctx, dev: SmartDevice):
-    """Print out device state and versions."""
-    click.echo(click.style(f"== {dev.alias} - {dev.model} ==", bold=True))
-    click.echo(f"\tHost: {dev.host}")
-    click.echo(
-        click.style(
-            "\tDevice state: {}\n".format("ON" if dev.is_on else "OFF"),
-            fg="green" if dev.is_on else "red",
-        )
-    )
-    if dev.is_strip:
-        click.echo(click.style("\t== Plugs ==", bold=True))
-        for plug in dev.children:  # type: ignore
-            is_on = plug.is_on
-            alias = plug.alias
-            click.echo(
-                click.style(
-                    "\t* Socket '{}' state: {} on_since: {}".format(
-                        alias, ("ON" if is_on else "OFF"), plug.on_since
-                    ),
-                    fg="green" if is_on else "red",
-                )
-            )
-        click.echo()
-
-    click.echo(click.style("\t== Generic information ==", bold=True))
-    click.echo(f"\tTime:         {await dev.get_time()}")
-    click.echo(f"\tHardware:     {dev.hw_info['hw_ver']}")
-    click.echo(f"\tSoftware:     {dev.hw_info['sw_ver']}")
-    click.echo(f"\tMAC (rssi):   {dev.mac} ({dev.rssi})")
-    click.echo(f"\tLocation:     {dev.location}")
-
-    click.echo(click.style("\n\t== Device specific information ==", bold=True))
-    for k, v in dev.state_information.items():
-        click.echo(f"\t{k}: {v}")
-    click.echo()
-
-    if dev.has_emeter:
-        click.echo(click.style("\n\t== Current State ==", bold=True))
-        emeter_status = dev.emeter_realtime
-        click.echo(f"\t{emeter_status}")
+async def sysinfo(ctx):
+    """Print out full system information."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    wrap_dev_sysinfo(msgr.data_wrapper, dev)
+    msgr.print_data()
 
 
 @cli.command()
-@pass_dev
+@click.pass_context
+async def state(ctx):
+    """Print out device state and versions."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    await wrap_dev_state(msgr.data_wrapper, dev)
+    msgr.print_data()
+
+
+@cli.command()
+@click.pass_context
 @click.argument("new_alias", required=False, default=None)
 @click.option("--index", type=int)
-async def alias(dev, new_alias, index):
+async def alias(ctx, new_alias, index):
     """Get or set the device (or plug) alias."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    dw = msgr.data_wrapper
     if index is not None:
         if not dev.is_strip:
-            click.echo("Index can only used for power strips!")
+            msgr.err("Index can only used for power strips!", fatal=True)
             return
         dev = cast(SmartStrip, dev)
         dev = dev.get_plug_by_index(index)
 
     if new_alias is not None:
-        click.echo(f"Setting alias to {new_alias}")
-        res = await dev.set_alias(new_alias)
-        return res
+        msgr.prog("Setting new alias..")
+        try:
+            res = await dev.set_alias(new_alias)
+            dw.add_point("res", res, "Result")
+        except Exception as e:
+            msgr.err(str(e), fatal=True)
+            return
 
-    click.echo(f"Alias: {dev.alias}")
+    dw.add_point("alias", dev.alias)
     if dev.is_strip:
-        for plug in dev.children:
-            click.echo(f"  * {plug.alias}")
+        dw.add_point("plugs", list(map(lambda p: p.alias, dev.children)))
+    msgr.print_data()
 
 
 @cli.command()
-@pass_dev
+@click.pass_context
 @click.argument("module")
 @click.argument("command")
 @click.argument("parameters", default=None, required=False)
-async def raw_command(dev: SmartDevice, module, command, parameters):
+async def raw_command(ctx, module, command, parameters):
     """Run a raw command on the device."""
     import ast
 
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
     if parameters is not None:
         parameters = ast.literal_eval(parameters)
 
-    res = await dev._query_helper(module, command, parameters)
-
-    click.echo(res)
-    return res
+    try:
+        res = await dev._query_helper(module, command, parameters)
+        msgr.data_wrapper.add_point("res", res, "Result")
+        msgr.print_data()
+    except Exception as e:
+        msgr.err(str(e), fatal=True)
 
 
 @cli.command()
-@pass_dev
-@click.option("--year", type=click.DateTime(["%Y"]), default=None, required=False)
-@click.option("--month", type=click.DateTime(["%Y-%m"]), default=None, required=False)
+@click.option(
+    "--year", type=click.DateTime(["%Y"]), default=None, required=False, multiple=True
+)
+@click.option(
+    "--month",
+    type=click.DateTime(["%Y-%m"]),
+    default=None,
+    required=False,
+    multiple=True,
+)
+@click.option("--realtime", "-r", is_flag=True)
 @click.option("--erase", is_flag=True)
-async def emeter(dev: SmartDevice, year, month, erase):
+@click.pass_context
+async def emeter(ctx, year, month, realtime, erase):
     """Query emeter for historical consumption.
 
     Daily and monthly data provided in CSV format.
+    The year and month flags can be specified multiple times.
     """
-    click.echo(click.style("== Emeter ==", bold=True))
-    if not dev.has_emeter:
-        click.echo("Device has no emeter")
-        return
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    dw = msgr.data_wrapper
 
     if erase:
-        click.echo("Erasing emeter statistics..")
-        click.echo(await dev.erase_emeter_stats())
+        msgr.prog("Erasing emeter statistics..")
+        try:
+            await dev.erase_emeter_stats()
+            msgr.print_data()
+        except Exception as e:
+            msgr.err(str(e), fatal=True)
         return
 
-    if year:
-        click.echo(f"== For year {year.year} ==")
-        click.echo("Month, usage (kWh)")
-        usage_data = await dev.get_emeter_monthly(year.year)
-    elif month:
-        click.echo(f"== For month {month.month} of {month.year} ==")
-        click.echo("Day, usage (kWh)")
-        usage_data = await dev.get_emeter_daily(year=month.year, month=month.month)
-    else:
-        # Call with no argument outputs summary data and returns
-        usage_data = {}
-        emeter_status = dev.emeter_realtime
-
-        click.echo("Current: %s A" % emeter_status["current"])
-        click.echo("Voltage: %s V" % emeter_status["voltage"])
-        click.echo("Power: %s W" % emeter_status["power"])
-        click.echo("Total consumption: %s kWh" % emeter_status["total"])
-
-        click.echo("Today: %s kWh" % dev.emeter_today)
-        click.echo("This month: %s kWh" % dev.emeter_this_month)
-
-        return
-
-    # output any detailed usage data
-    for index, usage in usage_data.items():
-        click.echo(f"{index}, {usage}")
+    if not year and not month:
+        realtime = True
+    await wrap_dev_emeter(dw, dev, year, month, realtime)
+    msgr.print_data()
 
 
 @cli.command()
 @click.argument("brightness", type=click.IntRange(0, 100), default=None, required=False)
 @click.option("--transition", type=int, required=False)
-@pass_dev
-async def brightness(dev: SmartBulb, brightness: int, transition: int):
+@click.pass_context
+async def brightness(ctx, brightness: int, transition: int):
     """Get or set brightness."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
     if not dev.is_dimmable:
-        click.echo("This device does not support brightness.")
+        msgr.err("This device does not support brightness.", fatal=True)
         return
 
     if brightness is None:
-        click.echo(f"Brightness: {dev.brightness}")
+        msgr.data_wrapper.add_point("brightness", dev.brightness, style=StyleFlag.BOLD)
     else:
-        click.echo(f"Setting brightness to {brightness}")
-        return await dev.set_brightness(brightness, transition=transition)
+        msgr.prog(f"Setting brightness to {brightness}")
+        try:
+            await dev.set_brightness(brightness, transition=transition)
+        except Exception as e:
+            msgr.err(str(e), fatal=True)
+            return
+
+    msgr.print_data()
 
 
 @cli.command()
@@ -328,26 +341,35 @@ async def brightness(dev: SmartBulb, brightness: int, transition: int):
     "temperature", type=click.IntRange(2500, 9000), default=None, required=False
 )
 @click.option("--transition", type=int, required=False)
-@pass_dev
-async def temperature(dev: SmartBulb, temperature: int, transition: int):
+@click.pass_context
+async def temperature(ctx, temperature: int, transition: int):
     """Get or set color temperature."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
     if not dev.is_variable_color_temp:
-        click.echo("Device does not support color temperature")
+        msgr.err("Device does not support color temperature", fatal=True)
         return
 
+    dw = msgr.data_wrapper
     if temperature is None:
-        click.echo(f"Color temperature: {dev.color_temp}")
+        dw.add_point("color_temperature", dev.color_temp, StyleFlag.BOLD)
         valid_temperature_range = dev.valid_temperature_range
         if valid_temperature_range != (0, 0):
-            click.echo("(min: {}, max: {})".format(*valid_temperature_range))
+            dw.add_point("min", valid_temperature_range[0])
+            dw.add_point("max", valid_temperature_range[1])
         else:
-            click.echo(
+            msgr.prog(
                 "Temperature range unknown, please open a github issue"
                 f" or a pull request for model '{dev.model}'"
             )
     else:
-        click.echo(f"Setting color temperature to {temperature}")
-        return await dev.set_color_temp(temperature, transition=transition)
+        msgr.prog(f"Setting color temperature to {temperature}")
+        try:
+            await dev.set_color_temp(temperature, transition=transition)
+        except Exception as e:
+            msgr.err(str(e), fatal=True)
+            return
+
+    msgr.print_data()
 
 
 @cli.command()
@@ -356,94 +378,205 @@ async def temperature(dev: SmartBulb, temperature: int, transition: int):
 @click.argument("v", type=click.IntRange(0, 100), default=None, required=False)
 @click.option("--transition", type=int, required=False)
 @click.pass_context
-@pass_dev
-async def hsv(dev, ctx, h, s, v, transition):
+async def hsv(ctx, h, s, v, transition):
     """Get or set color in HSV."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
     if not dev.is_color:
-        click.echo("Device does not support colors")
+        msgr.err("Device does not support colors", fatal=True)
         return
 
     if h is None or s is None or v is None:
-        click.echo(f"Current HSV: {dev.hsv}")
+        msgr.data_wrapper.add_point("current_hsv", dev.hsv, "Current HSV")
     elif s is None or v is None:
-        raise click.BadArgumentUsage("Setting a color requires 3 values.", ctx)
+        msgr.err("Setting a color requires 3 values.", fatal=True)
     else:
-        click.echo(f"Setting HSV: {h} {s} {v}")
-        return await dev.set_hsv(h, s, v, transition=transition)
+        msgr.prog(f"Setting HSV: {h} {s} {v}")
+        try:
+            await dev.set_hsv(h, s, v, transition=transition)
+        except Exception as e:
+            msgr.err(str(e), fatal=True)
+            return
+    msgr.print_data()
 
 
 @cli.command()
 @click.argument("state", type=bool, required=False)
-@pass_dev
-async def led(dev, state):
+@click.pass_context
+async def led(ctx, state):
     """Get or set (Plug's) led state."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
     if state is not None:
-        click.echo(f"Turning led to {state}")
-        return await dev.set_led(state)
+        msgr.prog(f"Turning led to {state}")
+        try:
+            await dev.set_led(state)
+        except Exception as e:
+            msgr.err(str(e), fatal=True)
+            return
     else:
-        click.echo(f"LED state: {dev.led}")
+        msgr.data_wrapper.add_point("led_state", dev.led, "LED state")
+    msgr.print_data()
 
 
 @cli.command()
-@pass_dev
-async def time(dev):
+@click.pass_context
+async def time(ctx):
     """Get the device time."""
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
     res = await dev.get_time()
-    click.echo(f"Current time: {res}")
-    return res
+    msgr.data_wrapper.add_point("current_time", res)
+    msgr.print_data()
 
 
 @cli.command()
 @click.option("--index", type=int, required=False)
 @click.option("--name", type=str, required=False)
 @click.option("--transition", type=int, required=False)
-@pass_dev
-async def on(dev: SmartDevice, index: int, name: str, transition: int):
+@click.pass_context
+async def on(ctx, index: int, name: str, transition: int):
     """Turn the device on."""
-    if index is not None or name is not None:
-        if not dev.is_strip:
-            click.echo("Index and name are only for power strips!")
-            return
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    try:
+        if dev.is_strip and (index is not None or name is not None):
+            dev = cast(SmartStrip, dev)
+            if index is not None:
+                dev = dev.get_plug_by_index(index)
+            elif name:
+                dev = dev.get_plug_by_name(name)
 
-        dev = cast(SmartStrip, dev)
-        if index is not None:
-            dev = dev.get_plug_by_index(index)
-        elif name:
-            dev = dev.get_plug_by_name(name)
-
-    click.echo(f"Turning on {dev.alias}")
-    return await dev.turn_on(transition=transition)
+        msgr.prog(f"Turning on {dev.alias}")
+        await dev.turn_on(transition=transition)
+    except Exception as e:
+        msgr.err(str(e), fatal=True)
+        return
+    msgr.print_data()
 
 
 @cli.command()
 @click.option("--index", type=int, required=False)
 @click.option("--name", type=str, required=False)
 @click.option("--transition", type=int, required=False)
-@pass_dev
-async def off(dev: SmartDevice, index: int, name: str, transition: int):
+@click.pass_context
+async def off(ctx, index: int, name: str, transition: int):
     """Turn the device off."""
-    if index is not None or name is not None:
-        if not dev.is_strip:
-            click.echo("Index and name are only for power strips!")
-            return
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    try:
+        if dev.is_strip and (index is not None or name is not None):
+            dev = cast(SmartStrip, dev)
+            if index is not None:
+                dev = dev.get_plug_by_index(index)
+            elif name:
+                dev = dev.get_plug_by_name(name)
 
-        dev = cast(SmartStrip, dev)
-        if index is not None:
-            dev = dev.get_plug_by_index(index)
-        elif name:
-            dev = dev.get_plug_by_name(name)
-
-    click.echo(f"Turning off {dev.alias}")
-    return await dev.turn_off(transition=transition)
+        msgr.prog(f"Turning off {dev.alias}")
+        await dev.turn_off(transition=transition)
+    except Exception as e:
+        msgr.err(str(e), fatal=True)
+        return
+    msgr.print_data()
 
 
 @cli.command()
 @click.option("--delay", default=1)
-@pass_dev
-async def reboot(plug, delay):
+@click.pass_context
+async def reboot(ctx, delay):
     """Reboot the device."""
-    click.echo("Rebooting the device..")
-    return await plug.reboot(delay)
+    dev, msgr = ctx.obj.dev, ctx.obj.msgr
+    msgr.prog("Rebooting the device..")
+    try:
+        await dev.reboot(delay)
+    except Exception as e:
+        msgr.err(str(e), fatal=True)
+        return
+    msgr.print_data()
+
+
+def wrap_dev_sysinfo(dw: DataWrapper, dev: SmartDevice):
+    """Add device system informaton to the data wrapper."""
+    dw.add_categorie("sys_info", dev.sys_info, "System Information", StyleFlag.BOLD)
+
+
+async def wrap_dev_state(dw: DataWrapper, dev: SmartDevice):
+    """Add various state info to the specified data wrapper."""
+    dw = dw.add_categorie(
+        dev.host, name=f"{dev.alias} - {dev.model}", style=StyleFlag.BOLD
+    )
+    dw.add_point("host", dev.host)
+    if dev.is_on:
+        dw.add_point("device_state", "on", style=StyleFlag.GREEN | StyleFlag.BOLD)
+    else:
+        dw.add_point("device_state", "off", style=StyleFlag.RED | StyleFlag.BOLD)
+
+    if dev.is_strip:
+        plug_data = dw.add_categorie("plugs", style=StyleFlag.BOLD)
+        for plug in dev.children:  # type: ignore
+            if plug.is_on:
+                plug_data.add_point("device_state", "on", style=StyleFlag.GREEN)
+            else:
+                plug_data.add_point("device_state", "off", style=StyleFlag.RED)
+            plug_data.add_point("alias", plug.alias)
+            plug_data.add_point("on_since", plug.on_since)
+
+    generic = dw.add_categorie(
+        "generic_info", name="Generic Information", style=StyleFlag.BOLD
+    )
+    generic.add_point("time", await dev.get_time())
+    generic.add_point("hardware", dev.hw_info["hw_ver"])
+    generic.add_point("software", dev.hw_info["sw_ver"])
+    generic.add_point("mac", dev.mac, "MAC")
+    generic.add_point("rssi", dev.rssi, "RSSI")
+    generic.add_categorie("location", dev.location)
+
+    dw.add_categorie(
+        "specific_info",
+        dev.state_information,
+        "Device specific information",
+        StyleFlag.BOLD,
+    )
+
+    if dev.has_emeter:
+        dw.add_categorie(
+            "emeter", await dev.get_emeter_realtime(), style=StyleFlag.BOLD
+        )
+
+
+async def wrap_dev_emeter(
+    dw: DataWrapper,
+    dev: SmartDevice,
+    years: List[datetime],
+    months: List[datetime],
+    realtime: bool,
+):
+    """Add device emter data to the data wrapper."""
+    dw = dw.add_categorie(dev.host, name=(dev.alias or dev.host), style=StyleFlag.BOLD)
+
+    if not dev.has_emeter:
+        dw.add_point("error", "Device has no emeter", style=StyleFlag.RED)
+        return
+
+    if len(years) > 0:
+        all_years = dw.add_categorie(
+            "year", name="Monthly Usage (kWh)", style=StyleFlag.BOLD
+        )
+        for y in years:
+            all_years.add_categorie(str(y.year), await dev.get_emeter_monthly(y.year))
+    if len(months) > 0:
+        all_months = dw.add_categorie(
+            "month", name="Daily Usage (kWh)", style=StyleFlag.BOLD
+        )
+        for m in months:
+            all_months.add_categorie(
+                str(m.year) + "-" + str(m.month),
+                await dev.get_emeter_daily(year=m.year, month=m.month),
+            )
+    if realtime:
+        emeter_status = dev.emeter_realtime
+        current = dw.add_categorie("realtime", style=StyleFlag.BOLD)
+        current.add_point("current", emeter_status["current"], "Current (A)")
+        current.add_point("voltage", emeter_status["voltage"], "Voltage (V)")
+        current.add_point("power", emeter_status["power"], "Power (A)")
+        current.add_point("total", emeter_status["total"], "Total consumption (kWh)")
+        current.add_point("today", dev.emeter_today, "Today (kWh)")
+        current.add_point("this_month", dev.emeter_this_month, "This month (kWh)")
 
 
 if __name__ == "__main__":

--- a/kasa/printmanager.py
+++ b/kasa/printmanager.py
@@ -1,0 +1,243 @@
+"""Print manager for the kasa cli tool. Handles the logic for different formats like json or human-readable."""
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from enum import Flag, auto
+from typing import Any, Dict
+
+import asyncclick as click
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class StyleFlag(Flag):
+    """StyleFlags for beautifying output."""
+
+    RED = auto()
+    GREEN = auto()
+    BOLD = auto()
+    NONE = 0
+
+
+class DataWrapper(ABC):
+    """Holds structured data to be printed later."""
+
+    @property
+    @abstractmethod
+    def data(self) -> dict[Any, Any]:
+        """Get the structured data."""
+        pass
+
+    @abstractmethod
+    def add_point(self, key, value, name: str = None, style: StyleFlag = None) -> None:
+        """Add a single data point."""
+        pass
+
+    @abstractmethod
+    def add_categorie(
+        self,
+        key,
+        data: dict[Any, Any] = None,
+        name: str = None,
+        style: StyleFlag = None,
+    ) -> DataWrapper:
+        """Add a categorie of data points."""
+        pass
+
+
+class HumanDataWrapper(DataWrapper):
+    """Contains structured data, that can be retrieved later."""
+
+    def __init__(self, dic: dict[Any, Any], style: StyleFlag = None) -> None:
+        self._data: dict[Any, tuple[Any, str | None, StyleFlag | None]] = {}
+        for k, v in dic.items():
+            if isinstance(v, Dict):
+                self._data[k] = (HumanDataWrapper(v, style), None, style)
+            else:
+                self._data[k] = (v, None, style)
+
+    @property
+    def data(self) -> dict[Any, Any]:
+        """Get the structured data."""
+        return self._data
+
+    def add_point(self, key, value, name: str = None, style: StyleFlag = None) -> None:
+        """Add a single data point."""
+        self._data[key] = (str(value), name, style)
+
+    def add_categorie(
+        self,
+        key,
+        data: dict[Any, Any] = None,
+        name: str = None,
+        style: StyleFlag = None,
+        cnt_style: StyleFlag = None,
+    ) -> DataWrapper:
+        """Add a categorie to the data set."""
+        data = data or {}
+        wrapper = HumanDataWrapper(data, cnt_style)
+        self._data[key] = (wrapper, name, style)
+        return wrapper
+
+
+class JsonDataWrapper(DataWrapper):
+    """Contains structured data, that can be retrieved later."""
+
+    def __init__(self, dic: dict[Any, Any], style: StyleFlag = None) -> None:
+        self._data: dict[Any, Any] = dic
+
+    @property
+    def data(self) -> dict[Any, Any]:
+        """Get the structured data."""
+        return self._data
+
+    def add_point(self, key, value, name: str = None, style: StyleFlag = None) -> None:
+        """Add a single data point."""
+        self._data[key] = str(value)
+
+    def add_categorie(
+        self,
+        key,
+        data: dict[Any, Any] = None,
+        name: str = None,
+        style: StyleFlag = None,
+    ) -> DataWrapper:
+        """Add a categorie to the data set."""
+        data = data or dict()
+        self._data[key] = data
+        return JsonDataWrapper(data)
+
+
+class Messenger(ABC):
+    """
+    Abstract class of a messenger.
+
+    Implemented by
+    * :class:`HumanMessenger`
+    * :class:`JsonMessenger`
+    """
+
+    @property
+    @abstractmethod
+    def data_wrapper(self) -> DataWrapper:
+        """Get the data wrapper."""
+        pass
+
+    @abstractmethod
+    def prog(self, message: str):
+        """Print a progress message."""
+        pass
+
+    @abstractmethod
+    def err(self, err_message: str, fatal: bool):
+        """Print an error message."""
+        pass
+
+    @abstractmethod
+    def print_data(self):
+        """Print all data inside the data wrapper."""
+        pass
+
+
+class HumanMessenger(Messenger):
+    """Prints data in human readable format."""
+
+    def __init__(self) -> None:
+        self._data_wraper = HumanDataWrapper(dict())
+
+    @staticmethod
+    def __nameify(key: Any):
+        return str(key).capitalize().replace("_", " ")
+
+    @classmethod
+    def __print_data(cls, data_wrapper: HumanDataWrapper, padding=0):
+        lines = []
+        max_len = 0
+        for key, (val, name, style) in data_wrapper.data.items():
+            line = (name or cls.__nameify(key), val, style or StyleFlag.NONE)
+            if max_len < len(line[0]):
+                max_len = len(line[0])
+            lines.append(line)
+
+        max_len += 3
+        for name, value, style in lines:
+            color = (
+                "green"
+                if style & StyleFlag.GREEN
+                else "red"
+                if style & StyleFlag.RED
+                else None
+            )
+            bold = style & StyleFlag.BOLD
+            if isinstance(value, HumanDataWrapper):
+                if bold:
+                    click.echo(
+                        "\n"
+                        + "\t" * (padding)
+                        + click.style("== " + name + " ==", fg=color, bold=True)
+                    )
+                    cls.__print_data(value, padding)
+                else:
+                    click.echo("\t" * padding + click.style(name + ":", fg=color))
+                    cls.__print_data(value, padding + 1)
+                continue
+            name += ":"
+            click.echo(
+                "\t" * padding
+                + click.style(
+                    name.ljust(max_len, " ") + str(value), fg=color, bold=bold
+                )
+            )
+
+    @property
+    def data_wrapper(self) -> DataWrapper:
+        """Get the data wrapper."""
+        return self._data_wraper
+
+    def prog(self, message):
+        """Print a progress message."""
+        click.echo(message)
+
+    def err(self, err_message: str, fatal: bool):
+        """Print an error message. If error is fatal a goodbye message is printed."""
+        click.echo(click.style(err_message, fg="red"))
+        if fatal:
+            click.echo(click.style("Exiting...", fg="red"))
+
+    def print_data(self):
+        """Print the data in the data wrapper in a human readable form."""
+        HumanMessenger.__print_data(self._data_wraper)
+        click.echo()
+
+
+class JsonMessenger(Messenger):
+    """Prints data in JSON format."""
+
+    def __init__(self, whitespace) -> None:
+        self._data_wraper = JsonDataWrapper(dict())
+        self._whitespace = whitespace
+
+    @property
+    def data_wrapper(self) -> DataWrapper:
+        """Get the data wrapper."""
+        return self._data_wraper
+
+    def prog(self, message):
+        """Log a progress message."""
+        _LOGGER.debug(message)
+
+    def err(self, err_message: str, fatal: bool):
+        """Log an error. If fatal, the error is additionally added to the standard output."""
+        _LOGGER.debug(err_message)
+        if fatal:
+            self.data_wrapper.add_point("error", err_message)
+            self.print_data()
+
+    def print_data(self):
+        """Print all data inside the data wrapper in JSON format."""
+        if self._whitespace:
+            click.echo(json.dumps(self._data_wraper.data, indent=4))
+        else:
+            click.echo(json.dumps(self._data_wraper.data, separators=(",", ":")))

--- a/kasa/smartbulb.py
+++ b/kasa/smartbulb.py
@@ -339,14 +339,14 @@ class SmartBulb(SmartDevice):
     def state_information(self) -> Dict[str, Any]:
         """Return bulb-specific state information."""
         info: Dict[str, Any] = {
-            "Brightness": self.brightness,
-            "Is dimmable": self.is_dimmable,
+            "brightness": self.brightness,
+            "is_dimmable": self.is_dimmable,
         }
         if self.is_variable_color_temp:
-            info["Color temperature"] = self.color_temp
-            info["Valid temperature range"] = self.valid_temperature_range
+            info["color_temperature"] = self.color_temp
+            info["valid_temperature_range"] = self.valid_temperature_range
         if self.is_color:
-            info["HSV"] = self.hsv
+            info["hsv"] = self.hsv
 
         return info
 

--- a/kasa/smartdimmer.py
+++ b/kasa/smartdimmer.py
@@ -145,6 +145,6 @@ class SmartDimmer(SmartPlug):
     def state_information(self) -> Dict[str, Any]:
         """Return switch-specific state information."""
         info = super().state_information
-        info["Brightness"] = self.brightness
+        info["brightness"] = self.brightness
 
         return info

--- a/kasa/smartlightstrip.py
+++ b/kasa/smartlightstrip.py
@@ -70,6 +70,6 @@ class SmartLightStrip(SmartBulb):
         """Return strip specific state information."""
         info = super().state_information
 
-        info["Length"] = self.length
+        info["length"] = self.length
 
         return info

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -73,5 +73,5 @@ class SmartPlug(SmartDevice):
     @requires_update
     def state_information(self) -> Dict[str, Any]:
         """Return switch-specific state information."""
-        info = {"LED state": self.led, "On since": self.on_since}
+        info = {"led_state": self.led, "on_since": str(self.on_since)}
         return info

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -143,9 +143,9 @@ class SmartStrip(SmartDevice):
         :return: Strip information dict, keys in user-presentable form.
         """
         return {
-            "LED state": self.led,
-            "Childs count": len(self.children),
-            "On since": self.on_since,
+            "led_state": self.led,
+            "childs_count": len(self.children),
+            "on_since": str(self.on_since),
         }
 
     async def current_consumption(self) -> float:
@@ -205,13 +205,13 @@ class SmartStrip(SmartDevice):
     @requires_update
     def emeter_this_month(self) -> Optional[float]:
         """Return this month's energy consumption in kWh."""
-        return sum([plug.emeter_this_month for plug in self.children])
+        return sum(plug.emeter_this_month for plug in self.children)
 
     @property  # type: ignore
     @requires_update
     def emeter_today(self) -> Optional[float]:
         """Return this month's energy consumption in kWh."""
-        return sum([plug.emeter_today for plug in self.children])
+        return sum(plug.emeter_today for plug in self.children)
 
     @property  # type: ignore
     @requires_update


### PR DESCRIPTION
The goal of this PR is the addition of an interface that can be easily called from other programs e.g. cron or a REST API. This was done by creating the kasa-mr entry point. Currently, there are only 4 commands but they can be extended fairly easily. The output is formatted as JSON for the same reason. Automated logging is now feasible without difficult parsing or error handling.

I would appreciate it if someone would tell me how to correctly generate the changelog. Currently, there are some things missing.