### PR TITLE
Add coverage[toml] dependency to fix coverage on CI

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -142,6 +142,9 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+
 [package.extras]
 toml = ["tomli"]
 
@@ -639,6 +642,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "tomli"
+version = "1.2.2"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "tox"
 version = "3.24.4"
 description = "tox is a generic virtualenv management and test command line tool"
@@ -754,7 +765,7 @@ docs = ["sphinx", "sphinx_rtd_theme", "m2r", "mistune", "sphinxcontrib-programou
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "17223bb140646ca65f1781c993d807d7434df6ebf2123cc0a7e34a6f22aea7e1"
+content-hash = "45ff80e61743682fdf21021f3c75758c703bfe453a4ab96235f7b71d7a61a237"
 
 [metadata.files]
 alabaster = [
@@ -1081,6 +1092,10 @@ termcolor = [
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]
+tomli = [
+    {file = "tomli-1.2.2-py3-none-any.whl", hash = "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"},
+    {file = "tomli-1.2.2.tar.gz", hash = "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee"},
 ]
 tox = [
     {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ tox = "*"
 pytest-mock = "^3"
 codecov = "^2"
 xdoctest = "^0"
+coverage = {version = "^6", extras = ["toml"]}
 
 [tool.poetry.extras]
 docs = ["sphinx", "sphinx_rtd_theme", "m2r", "mistune", "sphinxcontrib-programoutput"]


### PR DESCRIPTION
Looks like some version update done on the doc build PR broke coverage, this makes it build again by adding explicit dependency on coverage[toml].