### PR TITLE
Use codecov-action@v2 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,6 @@ jobs:
         run: |
           poetry run pytest --cov kasa --cov-report xml
       - name: "Upload coverage to Codecov"
-        uses: "codecov/codecov-action@v1"
+        uses: "codecov/codecov-action@v2"
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
The v1 is deprecated and will be removed in the near future, see https://github.com/codecov/codecov-action#%EF%B8%8F--deprecration-of-v1