### PR TITLE
Allow later asyncclick

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ kasa = "kasa.cli:cli"
 [tool.poetry.dependencies]
 python = "^3.7"
 importlib-metadata = "*"
-asyncclick = "^7"
+asyncclick = "^8"
 
 # required only for docs
 sphinx = { version = "^3", optional = true }


### PR DESCRIPTION
`asyncclick` > 8 was released in Spring 2021. The constrain on 7 is starting to cause issue for distribution which are shipping `python-kasa` as package. 