### PR TITLE
Publish to pypi on github release published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,6 @@ jobs:
         --outdir dist/
         .
     - name: Publish release on pypi
-      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,7 @@
 name: Publish packages
 on:
-  push:
-    branches:
-    - master
+  release:
+    types: [published]
 
 jobs:
   build-n-publish:
@@ -30,13 +29,6 @@ jobs:
         --wheel
         --outdir dist/
         .
-    - name: Publish on test pypi
-      uses: pypa/gh-action-pypi-publish@master
-      continue-on-error: true
-      with:
-        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
-        repository_url: https://test.pypi.org/legacy/
-
     - name: Publish release on pypi
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@master


### PR DESCRIPTION
* Instead of master commits, create a release when github release gets published
* Remove testpypi uploads