### PR TITLE
Do not request unsupported modules after the initial update

### DIFF
--- a/kasa/modules/module.py
+++ b/kasa/modules/module.py
@@ -1,10 +1,14 @@
 """Base class for all module implementations."""
 import collections
+import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from kasa import SmartDevice
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # TODO: This is used for query construcing
@@ -45,6 +49,10 @@ class Module(ABC):
     @property
     def is_supported(self) -> bool:
         """Return whether the module is supported by the device."""
+        if self._module not in self._device._last_update:
+            _LOGGER.debug("Initial update, so consider supported: %s", self._module)
+            return True
+
         return "err_code" not in self.data
 
     def call(self, method, params=None):

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -321,6 +321,9 @@ class SmartDevice:
             self.add_module("emeter", Emeter(self, self.emeter_type))
 
         for module in self.modules.values():
+            if not module.is_supported:
+                _LOGGER.info("Module %s not supported, skipping" % module)
+                continue
             q = module.query()
             _LOGGER.debug("Adding query for %s: %s", module, q)
             req = merge(req, module.query())

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -322,7 +322,7 @@ class SmartDevice:
 
         for module in self.modules.values():
             if not module.is_supported:
-                _LOGGER.info("Module %s not supported, skipping" % module)
+                _LOGGER.debug("Module %s not supported, skipping" % module)
                 continue
             q = module.query()
             _LOGGER.debug("Adding query for %s: %s", module, q)


### PR DESCRIPTION
We know after the initial update whether a module is supported or not, so no need to request unsupported ones in future update cycles.