### PR TITLE
Fix unsafe __del__ in TPLinkSmartHomeProtocol

### DIFF
--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -157,7 +157,7 @@ class TPLinkSmartHomeProtocol:
     def __del__(self) -> None:
         if self.writer and self.loop and self.loop.is_running():
             # Since __del__ will be called when python does
-            # garbage collection is can happen in the event loop
+            # garbage collection is can happen in the event loop thread
             # or in another thread so we need to make sure the call to
             # close is called safely with call_soon_threadsafe
             self.loop.call_soon_threadsafe(self.writer.close)

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -158,7 +158,7 @@ class TPLinkSmartHomeProtocol:
         if self.writer and self.loop and self.loop.is_running():
             # Since __del__ will be called when python does
             # garbage collection is can happen in the event loop
-            # or in a thread so we need to make sure the call to
+            # or in another thread so we need to make sure the call to
             # close is called safely with call_soon_threadsafe
             self.loop.call_soon_threadsafe(self.writer.close)
         self._reset()

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -156,6 +156,10 @@ class TPLinkSmartHomeProtocol:
 
     def __del__(self) -> None:
         if self.writer and self.loop and self.loop.is_running():
+            # Since __del__ will be called when python does
+            # garbage collection is can happen in the event loop
+            # or in a thread so we need to make sure the call to
+            # close is called safely with call_soon_threadsafe
             self.loop.call_soon_threadsafe(self.writer.close)
         self._reset()
 

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -156,7 +156,7 @@ class TPLinkSmartHomeProtocol:
 
     def __del__(self) -> None:
         if self.writer and self.loop and self.loop.is_running():
-            self.writer.close()
+            self.loop.call_soon_threadsafe(self.writer.close)
         self._reset()
 
     @staticmethod


### PR DESCRIPTION
Fixes
```
Exception ignored in: <function TPLinkSmartHomeProtocol.__del__ at 0x1096d0670>
Traceback (most recent call last):
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/kasa/protocol.py", line 159, in __del__
    self.writer.close()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/streams.py", line 353, in close
    return self._transport.close()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/selector_events.py", line 700, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 748, in call_soon
    self._check_thread()
  File "/opt/homebrew/Cellar/python@3.9/3.9.6/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/base_events.py", line 785, in _check_thread
    raise RuntimeError(
RuntimeError: Non-thread-safe operation invoked on an event loop other than the current one
```