### PR TITLE
Guard emeter accesses to avoid keyerrors

### DIFF
--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -219,6 +219,8 @@ class SmartDevice:
         """Raise an exception if there is no emeter."""
         if not self.has_emeter:
             raise SmartDeviceException("Device has no emeter")
+        if self.emeter_type not in self._last_update:
+            raise SmartDeviceException("update() required prior accessing emeter")
 
     async def _query_helper(
         self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None


### PR DESCRIPTION
Raise an exception to inform the caller that update() is needed

The emeter information is not available if the device has been initialized from the discovery information, and no update() has been called.

Related to #302