### PR TITLE
Fix test_deprecated_type stalling

### DIFF
--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -111,13 +111,14 @@ def _generate_type_class_pairs():
 
 
 @pytest.mark.parametrize("type_class", _generate_type_class_pairs())
-async def test_deprecated_type(dev, type_class):
+async def test_deprecated_type(dev, type_class, mocker):
     """Make sure that using deprecated types yields a warning."""
     type, cls = type_class
     if type == "dimmer":
         return
     runner = CliRunner()
-    res = await runner.invoke(cli, ["--host", "127.0.0.2", f"--{type}"])
+    with mocker.patch("kasa.SmartDevice.update"):
+        res = await runner.invoke(cli, ["--host", "127.0.0.2", f"--{type}"])
     assert "Using --bulb, --plug, --strip, and --lightstrip is deprecated" in res.output
 
 


### PR DESCRIPTION
The tests were taking a long time to run because this wasn't patched out