### PR TITLE
Update internal state on successful request

### DIFF
--- a/kasa/smartlightstrip.py
+++ b/kasa/smartlightstrip.py
@@ -100,6 +100,17 @@ class SmartLightStrip(SmartBulb):
             raise SmartDeviceException(f"The effect {effect} is not a built in effect.")
         await self.set_custom_effect(EFFECT_MAPPING_V1[effect])
 
+    async def _query_helper(
+        self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None
+    ) -> Any:
+        """Override query helper to process the response."""
+        response = await super()._query_helper(target, cmd, arg)
+        if cmd == "set_lighting_effect":
+            assert arg is not None
+            self._merge_sys_info("lighting_effect_state", arg, response)
+            self._update_sys_info_from_last_update()
+        return response
+
     @requires_update
     async def set_custom_effect(
         self,

--- a/kasa/smartplug.py
+++ b/kasa/smartplug.py
@@ -1,6 +1,6 @@
 """Module for smart plugs (HS100, HS110, ..)."""
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from kasa.modules import Antitheft, Cloud, Schedule, Time, Usage
 from kasa.smartdevice import DeviceType, SmartDevice, requires_update
@@ -52,6 +52,19 @@ class SmartPlug(SmartDevice):
         """Return whether device is on."""
         sys_info = self.sys_info
         return bool(sys_info["relay_state"])
+
+    async def _query_helper(
+        self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None
+    ) -> Any:
+        """Override query helper to process the response."""
+        response = await super()._query_helper(target, cmd, arg)
+        if cmd == "set_relay_state":
+            assert arg is not None
+            self._set_last_update_sysinfo_key("relay_state", arg["state"])
+        elif cmd == "set_led_off":
+            assert arg is not None
+            self._set_last_update_sysinfo_key("led_off", arg["off"])
+        return response
 
     async def turn_on(self, **kwargs):
         """Turn the switch on."""

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -295,9 +295,20 @@ class SmartStripPlug(SmartPlug):
         self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None
     ) -> Any:
         """Override query helper to include the child_ids."""
-        return await self.parent._query_helper(
+        response = await self.parent._query_helper(
             target, cmd, arg, child_ids=[self.child_id]
         )
+        if cmd == "set_relay_state":
+            assert arg is not None
+            self.parent._set_last_update_sysinfo_key(
+                "relay_state", arg["state"], child_ids=[self.child_id]
+            )
+        elif cmd == "set_led_off":
+            assert arg is not None
+            self.parent._set_last_update_sysinfo_key(
+                "led_off", arg["off"], child_ids=[self.child_id]
+            )
+        return response
 
     @property  # type: ignore
     @requires_update


### PR DESCRIPTION
Fixes https://github.com/home-assistant/core/issues/57380

Also needs this change

```diff
--- a/homeassistant/components/tplink/entity.py
+++ b/homeassistant/components/tplink/entity.py
@@ -25,6 +25,7 @@ def async_refresh_after(
 
     async def _async_wrap(self: _T, *args: _P.args, **kwargs: _P.kwargs) -> None:
         await func(self, *args, **kwargs)
+        self.async_write_ha_state()
         await self.coordinator.async_request_refresh_without_children()
 
     return _async_wrap
```