### PR TITLE
Avoid retrying open_connection on unrecoverable errors

### DIFF
--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -117,6 +117,15 @@ class TPLinkSmartHomeProtocol:
 
     async def _query(self, request: str, retry_count: int, timeout: int) -> Dict:
         """Try to query a device."""
+        #
+        # Most of the time we will already be connected if the device is online
+        # and the connect call will do nothing and return right away
+        #
+        # However, if we get an unrecoverable error (_NO_RETRY_ERRORS and ConnectionRefusedError)
+        # we do not want to keep trying since many connection open/close operations
+        # in the same time frame can block the event loop. This is especially
+        # import when there are multiple tplink devices being polled.
+        #
         for retry in range(retry_count + 1):
             try:
                 await self._connect(timeout)


### PR DESCRIPTION
- This one should probably get a new release

- We can retry so hard that we block the event loop

Fixes
`2022-04-16 22:18:51 WARNING (MainThread) [asyncio] Executing <Task finished name=Task-3576 coro=<open_connection() done, defined at /opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/streams.py:25> exception=ConnectionRefusedError(61, "Connect call failed (192.168.107.200, 9999)") created at /opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/tasks.py:460> took 1.001 seconds`
```
2022-04-18 16:02:03 WARNING (MainThread) [asyncio] Executing <Task finished name='Task-48613' coro=<open_connection() done, defined at /opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/streams.py:25> exception=ConnectionRefusedError(61, "Connect call failed ('192.168.107.6', 9999)") created at /opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/tasks.py:460> took 1.002 seconds
2022-04-18 16:02:04 WARNING (MainThread) [asyncio] Executing <Task finished name='Task-48615' coro=<open_connection() done, defined at /opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/streams.py:25> exception=ConnectionRefusedError(61, "Connect call failed ('192.168.107.6', 9999)") created at /opt/homebrew/Cellar/python@3.9/3.9.12/Frameworks/Python.framework/Versions/3.9/lib/python3.9/asyncio/tasks.py:460> took 1.002 seconds
```