### PR TITLE
Fix year emeter for cli by using kwarg for year parameter

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -297,7 +297,7 @@ async def emeter(dev: SmartDevice, year, month, erase):
     if year:
         click.echo(f"== For year {year.year} ==")
         click.echo("Month, usage (kWh)")
-        usage_data = await dev.get_emeter_monthly(year.year)
+        usage_data = await dev.get_emeter_monthly(year=year.year)
     elif month:
         click.echo(f"== For month {month.month} of {month.year} ==")
         click.echo("Day, usage (kWh)")

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from asyncclick.testing import CliRunner
 
@@ -66,6 +68,7 @@ async def test_raw_command(dev):
     assert "Usage" in res.output
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="3.8 is first one with asyncmock")
 async def test_emeter(dev: SmartDevice, mocker):
     runner = CliRunner()
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -77,16 +77,18 @@ async def test_emeter(dev: SmartDevice, mocker):
     assert "== Emeter ==" in res.output
 
     monthly = mocker.patch.object(dev, "get_emeter_monthly")
-    monthly.return_value = []
+    monthly.return_value = {1: 1234}
     res = await runner.invoke(emeter, ["--year", "1900"], obj=dev)
     assert "For year" in res.output
-    monthly.assert_called()
+    assert "1, 1234" in res.output
+    monthly.assert_called_with(year=1900)
 
     daily = mocker.patch.object(dev, "get_emeter_daily")
-    daily.return_value = []
+    daily.return_value = {1: 1234}
     res = await runner.invoke(emeter, ["--month", "1900-12"], obj=dev)
     assert "For month" in res.output
-    daily.assert_called()
+    assert "1, 1234" in res.output
+    daily.assert_called_with(year=1900, month=12)
 
 
 async def test_brightness(dev):


### PR DESCRIPTION
Fixes regression reported in #371 where the `get_emeter_monthly` was not called by passing the year value as keyword-only argument.