### PR TITLE
Manually pass the codecov token in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,4 @@ jobs:
         uses: "codecov/codecov-action@v2"
         with:
           fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The codecov upload has been flaky, causing CI fails. One suggested remedy is to send the token even for public repositories which is what this PR does.

Related to https://github.com/codecov/codecov-action/issues/557