### PR TITLE
Add ToCs for doc pages

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,7 +1,7 @@
 Command-line usage
 ==================
 
-The package is shipped with a console tool named kasa, please refer to ``kasa --help`` for detailed usage.
+The package is shipped with a console tool named ``kasa``, refer to ``kasa --help`` for detailed usage.
 The device to which the commands are sent is chosen by ``KASA_HOST`` environment variable or passing ``--host <address>`` as an option.
 To see what is being sent to and received from the device, specify option ``--debug``.
 

--- a/docs/source/design.rst
+++ b/docs/source/design.rst
@@ -9,6 +9,9 @@ This page aims to provide some details on the design and internals of this libra
 You might be interested in this if you want to improve this library,
 or if you are just looking to access some information that is not currently exposed.
 
+.. contents:: Contents
+   :local:
+
 .. _update_cycle:
 
 Update Cycle

--- a/docs/source/discover.rst
+++ b/docs/source/discover.rst
@@ -1,16 +1,11 @@
 Discovering devices
 ===================
 
-.. code-block::
+.. contents:: Contents
+   :local:
 
-    import asyncio
-    from kasa import Discover
-
-    devices = asyncio.run(Discover.discover())
-    for addr, dev in devices.items():
-        asyncio.run(dev.update())
-        print(f"{addr} >> {dev}")
-
+API documentation
+*****************
 
 .. autoclass:: kasa.Discover
     :members:

--- a/docs/source/smartbulb.rst
+++ b/docs/source/smartbulb.rst
@@ -1,6 +1,9 @@
 Bulbs
 ===========
 
+.. contents:: Contents
+   :local:
+
 Supported features
 ******************
 

--- a/docs/source/smartdevice.rst
+++ b/docs/source/smartdevice.rst
@@ -3,6 +3,12 @@
 Common API
 ==========
 
+.. contents:: Contents
+   :local:
+
+SmartDevice class
+*****************
+
 The basic functionalities of all supported devices are accessible using the common :class:`SmartDevice` base class.
 
 The property accesses use the data obtained before by awaiting :func:`SmartDevice.update()`.

--- a/docs/source/smartdimmer.rst
+++ b/docs/source/smartdimmer.rst
@@ -1,6 +1,10 @@
 Dimmers
 =======
 
+.. contents:: Contents
+   :local:
+
+
 .. note::
 
     Feel free to open a pull request to improve the documentation!

--- a/docs/source/smartlightstrip.rst
+++ b/docs/source/smartlightstrip.rst
@@ -1,6 +1,9 @@
 Light strips
 ============
 
+.. contents:: Contents
+   :local:
+
 .. note::
 
     Feel free to open a pull request to improve the documentation!

--- a/docs/source/smartplug.rst
+++ b/docs/source/smartplug.rst
@@ -1,6 +1,9 @@
 Plugs
 =====
 
+.. contents:: Contents
+   :local:
+
 .. note::
 
     Feel free to open a pull request to improve the documentation!

--- a/docs/source/smartstrip.rst
+++ b/docs/source/smartstrip.rst
@@ -1,6 +1,9 @@
 Smart strips
 ============
 
+.. contents:: Contents
+   :local:
+
 .. note::
 
     Feel free to open a pull request to improve the documentation!


### PR DESCRIPTION
This makes it easier to get an overview of the documentation and link to specific sections directly from the top of the page.