### PR TITLE
Fix outdated smartstrip cli examples

### DIFF
--- a/docs/source/smartstrip.rst
+++ b/docs/source/smartstrip.rst
@@ -15,13 +15,13 @@ If not specified, the commands will act on the parent device: turning the strip 
 
 .. code::
 
-   $ kasa --strip --host <host> on --index 0
+   $ kasa --type strip --host <host> on --index 0
 
 **Example:** Turn off the socket by name:
 
 .. code::
 
-   $ kasa --strip --host <host> off --name "Maybe Kitchen"
+   $ kasa --type strip --host <host> off --name "Maybe Kitchen"
 
 
 API documentation


### PR DESCRIPTION
```text
hbarta@pilog3b:~$ kasa --type strip --host 192.168.20.215 on
Turning on TP-LINK_Smart Plug_83A6
hbarta@pilog3b:~$ kasa --strip --host 192.168.20.215 on
Usage: kasa [OPTIONS] COMMAND [ARGS]...
Try 'kasa --help' for help.

Error: No such option: --strip (Possible options: --host, --type)
hbarta@pilog3b:~$
```