### PR TITLE
fix more outdated CLI examples, remove EP40 from bulb list

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,6 @@ If your device is unlisted but working, please open a pull request to update the
 
 ### Bulbs
 
-* EP40
 * LB100
 * LB110
 * LB120

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -5,7 +5,7 @@ The package is shipped with a console tool named kasa, please refer to ``kasa --
 The device to which the commands are sent is chosen by ``KASA_HOST`` environment variable or passing ``--host <address>`` as an option.
 To see what is being sent to and received from the device, specify option ``--debug``.
 
-To avoid discovering the devices when executing commands its type can be passed as an option (e.g., ``--plug`` for plugs, ``--bulb`` for bulbs, ..).
+To avoid discovering the devices when executing commands its type can be passed as an option (e.g., ``--type plug`` for plugs, ``--type bulb`` for bulbs, ..).
 If no type is manually given, its type will be discovered automatically which causes a short delay.
 
 If no command is given, the ``state`` command will be executed to query the device state.
@@ -13,7 +13,7 @@ If no command is given, the ``state`` command will be executed to query the devi
 .. note::
 
     Some commands (such as reading energy meter values, changing bulb settings, or accessing individual sockets on smart strips) additional parameters are required,
-    which you can find by adding ``--help`` after the command, e.g. ``kasa emeter --help`` or ``kasa hsv --help``.
+    which you can find by adding ``--help`` after the command, e.g. ``kasa --type emeter --help`` or ``kasa --type hsv --help``.
     Refer to the device type specific documentation for more details.
 
 

--- a/docs/source/smartbulb.rst
+++ b/docs/source/smartbulb.rst
@@ -42,13 +42,13 @@ All command-line commands can be used with transition period for smooth changes.
 
 .. code::
 
-    $ kasa --bulb --host <host> off --transition 15000
+    $ kasa --type bulb --host <host> off --transition 15000
 
 **Example:** Change the bulb to red with 20% brightness over 15 seconds:
 
 .. code::
 
-    $ kasa --bulb --host <host> hsv 0 100 20 --transition 15000
+    $ kasa --type bulb --host <host> hsv 0 100 20 --transition 15000
 
 
 API documentation


### PR DESCRIPTION
All documentation tweaks.

All command examples were tested with current release:

```text
hbarta@pilog3b:~/Downloads/byte-unixbench/UnixBench$ kasa --version
kasa, version 0.5.0
hbarta@pilog3b:~/Downloads/byte-unixbench/UnixBench$ 
```

One command failed (and with multiple stacks to unwind :o ) 

```text
kasa --type bulb --host <host> hsv 0 100 20 --transition 15000
```

I believe the syntax is correct and there may be a problem with the code, but that is a subject for another issue.