### PR TITLE
Fix type hinting issue with call to click.Choice 

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -57,7 +57,7 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     "--type",
     envvar="KASA_TYPE",
     default=None,
-    type=click.Choice(list(TYPE_TO_CLASS.keys()), case_sensitive=False),
+    type=click.Choice(list(TYPE_TO_CLASS), case_sensitive=False),
 )
 @click.version_option(package_name="python-kasa")
 @click.pass_context

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -57,7 +57,7 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     "--type",
     envvar="KASA_TYPE",
     default=None,
-    type=click.Choice(TYPE_TO_CLASS, case_sensitive=False),
+    type=click.Choice(list(TYPE_TO_CLASS.keys()), case_sensitive=False),
 )
 @click.version_option(package_name="python-kasa")
 @click.pass_context


### PR DESCRIPTION
click.Choice argument is type hinted as a Sequence convert TYPE_TO_CLASS to a list of its keys to pass it in.
Fixes pylance warning (fixes #384)