### PR TITLE
Adding cli command to delete a schedule rule

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -549,10 +549,7 @@ def _schedule_list(dev, type):
 async def delete_rule(dev, id):
     """Delete rule from device."""
     schedule = dev.modules["schedule"]
-    rule_to_delete = ""
-    for rule in schedule.rules:
-        if rule.id == id:
-            rule_to_delete = rule
+    rule_to_delete = next(filter(lambda rule: (rule.id == id), schedule.rules), None)
     if rule_to_delete:
         click.echo(f"Deleting rule id {id}")
         await schedule.delete_rule(rule_to_delete)

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -549,7 +549,7 @@ def _schedule_list(dev, type):
 async def delete_rule(dev, id):
     """Delete rule from device."""
     schedule = dev.modules["schedule"]
-    rule_to_delete = ''
+    rule_to_delete = ""
     for rule in schedule.rules:
         if rule.id == id:
             rule_to_delete = rule

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -543,6 +543,23 @@ def _schedule_list(dev, type):
         click.echo(f"No rules of type {type}")
 
 
+@schedule.command(name="delete_rule")
+@pass_dev
+@click.option("--id", type=str, required=True)
+async def delete_rule(dev, id):
+    """Delete rule from device."""
+    schedule = dev.modules["schedule"]
+    rule_to_delete = ''
+    for rule in schedule.rules:
+        if rule.id == id:
+            rule_to_delete = rule
+    if rule_to_delete:
+        click.echo(f"Deleting rule id {id}")
+        await schedule.delete_rule(rule_to_delete)
+    else:
+        click.echo(f"No rule with id {id} was found")
+
+
 @cli.group(invoke_without_command=True)
 @click.pass_context
 async def presets(ctx):

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -543,7 +543,7 @@ def _schedule_list(dev, type):
         click.echo(f"No rules of type {type}")
 
 
-@schedule.command(name="delete_rule")
+@schedule.command(name="delete")
 @pass_dev
 @click.option("--id", type=str, required=True)
 async def delete_rule(dev, id):


### PR DESCRIPTION
I was looking for a quick way to delete schedules via cli now that the official Kasa app is requiring an account. Discovered this was already implemented in this library but not yet in the cli.