### PR TITLE
Fix for usage module get_day/month_stat so they return expected format

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -57,7 +57,7 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     "--type",
     envvar="KASA_TYPE",
     default=None,
-    type=click.Choice(list(TYPE_TO_CLASS.keys()), case_sensitive=False),
+    type=click.Choice(list(TYPE_TO_CLASS), case_sensitive=False),
 )
 @click.version_option(package_name="python-kasa")
 @click.pass_context

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -57,7 +57,7 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     "--type",
     envvar="KASA_TYPE",
     default=None,
-    type=click.Choice(TYPE_TO_CLASS, case_sensitive=False),
+    type=click.Choice(list(TYPE_TO_CLASS.keys()), case_sensitive=False),
 )
 @click.version_option(package_name="python-kasa")
 @click.pass_context

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -44,20 +44,19 @@ class Emeter(Usage):
         return await self.call("get_realtime")
 
     async def get_daystat(self, *, year=None, month=None, kwh=True) -> Dict:
-        """Return daily stats for the given year & month as a dictionary of {day: energy, ...}"""
+        """Return daily stats for the given year & month as a dictionary of {day: energy, ...}."""
         data = await self.get_raw_daystat(year=year, month=month)
         data = self._convert_stat_data(data["day_list"], entry_key="day", kwh=kwh)
         return data
 
     async def get_monthstat(self, *, year=None, kwh=True) -> Dict:
-        """Return monthly stats for the given year as a dictionary of {month: energy, ...}"""
+        """Return monthly stats for the given year as a dictionary of {month: energy, ...}."""
         data = await self.get_raw_monthstat(year=year)
         data = self._convert_stat_data(data["month_list"], entry_key="month", kwh=kwh)
         return data
 
     def _convert_stat_data(self, data, entry_key, kwh=True) -> Dict:
-        """Return emeter information keyed with the day/month.."""
-
+        """Return emeter information keyed with the day/month."""
         """
             The incoming data is a list of dictionaries:
                 [{'year':      int,
@@ -66,7 +65,7 @@ class Emeter(Usage):
                   'energy_wh': int,     <-- for emeter in some versions (wh)
                   'energy':    float    <-- for emeter in other versions (kwh)
                 }, ...]
-            
+
             We determine what we're doing by checking for the presence of the energy_wh/energy keys
 
             We return a dictionary keyed by day or month with time or energy as the value.

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -80,12 +80,12 @@ class Emeter(Usage):
         if "energy_wh" in data[0]:
             value_key = "energy_wh"
             if kwh:
-                scale = 1/1000
+                scale = 1 / 1000
         else:
             value_key = "energy"
             if not kwh:
-                scale = 1000 
-    
+                scale = 1000
+
         data = {entry[entry_key]: entry[value_key] * scale for entry in data}
 
         return data

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -43,31 +43,49 @@ class Emeter(Usage):
         """Return real-time statistics."""
         return await self.call("get_realtime")
 
-    async def get_daystat(self, *, year, month, kwh=True):
-        """Return daily stats for the given year & month."""
-        raw_data = await super().get_daystat(year=year, month=month)
-        return self._emeter_convert_emeter_data(raw_data["day_list"], kwh)
+    async def get_daystat(self, *, year=None, month=None, kwh=True) -> Dict:
+        """Return daily stats for the given year & month as a dictionary of {day: energy, ...}"""
+        data = await self.get_raw_daystat(year=year, month=month)
+        data = self._convert_stat_data(data["day_list"], entry_key="day", kwh=kwh)
+        return data
 
-    async def get_monthstat(self, *, year, kwh=True):
-        """Return monthly stats for the given year."""
-        raw_data = await super().get_monthstat(year=year)
-        return self._emeter_convert_emeter_data(raw_data["month_list"], kwh)
+    async def get_monthstat(self, *, year=None, kwh=True) -> Dict:
+        """Return monthly stats for the given year as a dictionary of {month: energy, ...}"""
+        data = await self.get_raw_monthstat(year=year)
+        data = self._convert_stat_data(data["month_list"], entry_key="month", kwh=kwh)
+        return data
 
-    def _emeter_convert_emeter_data(self, data, kwh=True) -> Dict:
+    def _convert_stat_data(self, data, entry_key, kwh=True) -> Dict:
         """Return emeter information keyed with the day/month.."""
-        response = [EmeterStatus(**x) for x in data]
 
-        if not response:
+        """
+            The incoming data is a list of dictionaries:
+                [{'year':      int,
+                  'month':     int,
+                  'day':       int,     <-- for get_daystat not get_monthstat
+                  'energy_wh': int,     <-- for emeter in some versions (wh)
+                  'energy':    float    <-- for emeter in other versions (kwh)
+                }, ...]
+            
+            We determine what we're doing by checking for the presence of the energy_wh/energy keys
+
+            We return a dictionary keyed by day or month with time or energy as the value.
+            When energy is returned it is returned in the units requested (kwh or wh)
+        """
+        if not data:
             return {}
 
-        energy_key = "energy_wh"
-        if kwh:
-            energy_key = "energy"
+        scale = 1
 
-        entry_key = "month"
-        if "day" in response[0]:
-            entry_key = "day"
-
-        data = {entry[entry_key]: entry[energy_key] for entry in response}
+        if "energy_wh" in data[0]:
+            value_key = "energy_wh"
+            if kwh:
+                scale = 1/1000
+        else:
+            value_key = "energy"
+            if not kwh:
+                scale = 1000 
+    
+        data = {entry[entry_key]: entry[value_key] * scale for entry in data}
 
         return data

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -96,7 +96,7 @@ class Usage(Module):
         """
         if not data:
             return {}
-    
+
         data = {entry[entry_key]: entry["time"] for entry in data}
 
         return data

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -67,13 +67,13 @@ class Usage(Module):
         return await self.call("get_monthstat", {"year": year})
 
     async def get_daystat(self, *, year=None, month=None) -> Dict:
-        """Return daily stats for the given year & month as a dictionary of {day: time, ...}"""
+        """Return daily stats for the given year & month as a dictionary of {day: time, ...}."""
         data = await self.get_raw_daystat(year=year, month=month)
         data = self._convert_stat_data(data["day_list"], entry_key="day")
         return data
 
     async def get_monthstat(self, *, year=None) -> Dict:
-        """Return monthly stats for the given year as a dictionary of {month: time, ...}"""
+        """Return monthly stats for the given year as a dictionary of {month: time, ...}."""
         data = await self.get_raw_monthstat(year=year)
         data = self._convert_stat_data(data["month_list"], entry_key="month")
         return data
@@ -83,15 +83,14 @@ class Usage(Module):
         return await self.call("erase_runtime_stat")
 
     def _convert_stat_data(self, data, entry_key) -> Dict:
-        """Return usage information keyed with the day/month.."""
-
+        """Return usage information keyed with the day/month."""
         """ The incoming data is a list of dictionaries:
                 [{'year':      int,
                   'month':     int,
                   'day':       int,     <-- for get_daystat not get_monthstat
                   'time':      int,     <-- for usage (mins)
                 }, ...]
-            
+
             We return a dictionary keyed by day or month with time as the value.
         """
         if not data:


### PR DESCRIPTION
First pass fix for issue described in https://github.com/python-kasa/python-kasa/issues/373

I've tested it on Kasa plugs UK KP105/115 using the cli.py interface.

This is an initial version of a fix that probably isn't the cleanest way to do it. In particular it doesn't attempt to switch over to using Pydantic to replace EmeterStatus and to help with the data conversion as suggested in  the issue discussion.

Also, some of the changes to emeter.py may not be wanted, just added to make things more consistent.

I'm happy to make further changes but would need a little more guidance.