### PR TITLE
Return usage.get_{monthstat,daystat} in expected format 

### DIFF
--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -19,7 +19,7 @@ class Emeter(Usage):
         """Return today's energy consumption in kWh."""
         raw_data = self.daily_data
         today = datetime.now().day
-        data = self._emeter_convert_emeter_data(raw_data)
+        data = self._convert_stat_data(raw_data, entry_key="day")
 
         return data.get(today)
 
@@ -28,7 +28,7 @@ class Emeter(Usage):
         """Return this month's energy consumption in kWh."""
         raw_data = self.monthly_data
         current_month = datetime.now().month
-        data = self._emeter_convert_emeter_data(raw_data)
+        data = self._convert_stat_data(raw_data, entry_key="month")
 
         return data.get(current_month)
 
@@ -74,7 +74,7 @@ class Emeter(Usage):
         if not data:
             return {}
 
-        scale = 1
+        scale: float = 1
 
         if "energy_wh" in data[0]:
             value_key = "energy_wh"
@@ -88,4 +88,3 @@ class Emeter(Usage):
         data = {entry[entry_key]: entry[value_key] * scale for entry in data}
 
         return data
-

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -58,7 +58,8 @@ class Emeter(Usage):
     def _convert_stat_data(self, data, entry_key, kwh=True) -> Dict:
         """Return emeter information keyed with the day/month.
 
-        The incoming data is a list of dictionaries:
+        The incoming data is a list of dictionaries::
+
             [{'year':      int,
               'month':     int,
               'day':       int,     <-- for get_daystat not get_monthstat
@@ -66,10 +67,7 @@ class Emeter(Usage):
               'energy':    float    <-- for emeter in other versions (kwh)
             }, ...]
 
-        We determine what we're doing by checking for the presence of the energy_wh/energy keys
-
-        We return a dictionary keyed by day or month with time or energy as the value.
-        When energy is returned it is returned in the units requested (kwh or wh)
+        :return: a dictionary keyed by day or month with energy as the value.
         """
         if not data:
             return {}

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -56,20 +56,20 @@ class Emeter(Usage):
         return data
 
     def _convert_stat_data(self, data, entry_key, kwh=True) -> Dict:
-        """Return emeter information keyed with the day/month."""
-        """
-            The incoming data is a list of dictionaries:
-                [{'year':      int,
-                  'month':     int,
-                  'day':       int,     <-- for get_daystat not get_monthstat
-                  'energy_wh': int,     <-- for emeter in some versions (wh)
-                  'energy':    float    <-- for emeter in other versions (kwh)
-                }, ...]
+        """Return emeter information keyed with the day/month.
 
-            We determine what we're doing by checking for the presence of the energy_wh/energy keys
+        The incoming data is a list of dictionaries:
+            [{'year':      int,
+              'month':     int,
+              'day':       int,     <-- for get_daystat not get_monthstat
+              'energy_wh': int,     <-- for emeter in some versions (wh)
+              'energy':    float    <-- for emeter in other versions (kwh)
+            }, ...]
 
-            We return a dictionary keyed by day or month with time or energy as the value.
-            When energy is returned it is returned in the units requested (kwh or wh)
+        We determine what we're doing by checking for the presence of the energy_wh/energy keys
+
+        We return a dictionary keyed by day or month with time or energy as the value.
+        When energy is returned it is returned in the units requested (kwh or wh)
         """
         if not data:
             return {}

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -86,14 +86,15 @@ class Usage(Module):
     def _convert_stat_data(self, data, entry_key) -> Dict:
         """Return usage information keyed with the day/month.
 
-        The incoming data is a list of dictionaries:
+        The incoming data is a list of dictionaries::
+
                [{'year':      int,
                  'month':     int,
                  'day':       int,     <-- for get_daystat not get_monthstat
                  'time':      int,     <-- for usage (mins)
                }, ...]
 
-           We return a dictionary keyed by day or month with time as the value.
+        :return: return a dictionary keyed by day or month with time as the value.
         """
         if not data:
             return {}

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -84,15 +84,16 @@ class Usage(Module):
         return await self.call("erase_runtime_stat")
 
     def _convert_stat_data(self, data, entry_key) -> Dict:
-        """Return usage information keyed with the day/month."""
-        """ The incoming data is a list of dictionaries:
-                [{'year':      int,
-                  'month':     int,
-                  'day':       int,     <-- for get_daystat not get_monthstat
-                  'time':      int,     <-- for usage (mins)
-                }, ...]
+        """Return usage information keyed with the day/month.
 
-            We return a dictionary keyed by day or month with time as the value.
+        The incoming data is a list of dictionaries:
+               [{'year':      int,
+                 'month':     int,
+                 'day':       int,     <-- for get_daystat not get_monthstat
+                 'time':      int,     <-- for usage (mins)
+               }, ...]
+
+           We return a dictionary keyed by day or month with time as the value.
         """
         if not data:
             return {}

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -1,6 +1,7 @@
 """Implementation of the usage interface."""
 from datetime import datetime
 from typing import Dict
+
 from .module import Module, merge
 
 
@@ -99,4 +100,3 @@ class Usage(Module):
         data = {entry[entry_key]: entry["time"] for entry in data}
 
         return data
-        

--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -1,6 +1,6 @@
 """Implementation of the usage interface."""
 from datetime import datetime
-
+from typing import Dict
 from .module import Module, merge
 
 
@@ -50,8 +50,8 @@ class Usage(Module):
 
         return converted.pop()
 
-    async def get_daystat(self, *, year=None, month=None):
-        """Return daily stats for the given year & month."""
+    async def get_raw_daystat(self, *, year=None, month=None) -> Dict:
+        """Return raw daily stats for the given year & month."""
         if year is None:
             year = datetime.now().year
         if month is None:
@@ -59,13 +59,44 @@ class Usage(Module):
 
         return await self.call("get_daystat", {"year": year, "month": month})
 
-    async def get_monthstat(self, *, year=None):
-        """Return monthly stats for the given year."""
+    async def get_raw_monthstat(self, *, year=None) -> Dict:
+        """Return raw monthly stats for the given year."""
         if year is None:
             year = datetime.now().year
 
         return await self.call("get_monthstat", {"year": year})
 
+    async def get_daystat(self, *, year=None, month=None) -> Dict:
+        """Return daily stats for the given year & month as a dictionary of {day: time, ...}."""
+        data = await self.get_raw_daystat(year=year, month=month)
+        data = self._convert_stat_data(data["day_list"], entry_key="day")
+        return data
+
+    async def get_monthstat(self, *, year=None) -> Dict:
+        """Return monthly stats for the given year as a dictionary of {month: time, ...}."""
+        data = await self.get_raw_monthstat(year=year)
+        data = self._convert_stat_data(data["month_list"], entry_key="month")
+        return data
+
     async def erase_stats(self):
         """Erase all stats."""
         return await self.call("erase_runtime_stat")
+
+    def _convert_stat_data(self, data, entry_key) -> Dict:
+        """Return usage information keyed with the day/month."""
+        """ The incoming data is a list of dictionaries:
+                [{'year':      int,
+                  'month':     int,
+                  'day':       int,     <-- for get_daystat not get_monthstat
+                  'time':      int,     <-- for usage (mins)
+                }, ...]
+
+            We return a dictionary keyed by day or month with time as the value.
+        """
+        if not data:
+            return {}
+
+        data = {entry[entry_key]: entry["time"] for entry in data}
+
+        return data
+        

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -490,25 +490,6 @@ class SmartDevice:
         self._verify_emeter()
         return self.modules["emeter"].emeter_this_month
 
-    def _emeter_convert_emeter_data(self, data, kwh=True) -> Dict:
-        """Return emeter information keyed with the day/month.."""
-        response = [EmeterStatus(**x) for x in data]
-
-        if not response:
-            return {}
-
-        energy_key = "energy_wh"
-        if kwh:
-            energy_key = "energy"
-
-        entry_key = "month"
-        if "day" in response[0]:
-            entry_key = "day"
-
-        data = {entry[entry_key]: entry[energy_key] for entry in response}
-
-        return data
-
     async def get_emeter_daily(
         self, year: Optional[int] = None, month: Optional[int] = None, kwh: bool = True
     ) -> Dict:

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -1,0 +1,21 @@
+import pytest
+
+from kasa.modules import Usage
+
+
+def test_usage_convert_stat_data():
+    usage = Usage(None, module="usage")
+
+    test_data = []
+    assert usage._convert_stat_data(test_data, "day") == {}
+
+    test_data = [
+        {"year": 2016, "month": 5, "day": 2, "time": 20},
+        {"year": 2016, "month": 5, "day": 4, "time": 30},
+    ]
+    d = usage._convert_stat_data(test_data, "day")
+    assert len(d) == len(test_data)
+    assert isinstance(d, dict)
+    k, v = d.popitem()
+    assert isinstance(k, int)
+    assert isinstance(v, int)

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -19,3 +19,4 @@ def test_usage_convert_stat_data():
     k, v = d.popitem()
     assert isinstance(k, int)
     assert isinstance(v, int)
+    assert k == 4 and v == 30


### PR DESCRIPTION
This is an initial fix for the issue discussed here:

Fixes https://github.com/python-kasa/python-kasa/issues/373

This code largely duplicates the solution used for the Emeter module.

I have work in progress on a pydantic based version for which I will create a second PR. 