### PR TITLE
Fix pytest warnings about asyncio

### DIFF
--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -134,10 +134,6 @@ async def handle_turn_on(dev, turn_on):
         await dev.turn_off()
 
 
-# to avoid adding this for each async function separately
-pytestmark = pytest.mark.asyncio
-
-
 def device_for_file(model):
     for d in STRIPS:
         if d in model:

--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -10,7 +10,6 @@ from .conftest import (
     non_color_bulb,
     non_dimmable,
     non_variable_temp,
-    pytestmark,
     turn_on,
     variable_temp,
 )

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -15,7 +15,7 @@ from kasa.cli import (
     sysinfo,
 )
 
-from .conftest import handle_turn_on, pytestmark, turn_on
+from .conftest import handle_turn_on, turn_on
 
 
 async def test_sysinfo(dev):

--- a/kasa/tests/test_dimmer.py
+++ b/kasa/tests/test_dimmer.py
@@ -2,7 +2,7 @@ import pytest
 
 from kasa import SmartDimmer
 
-from .conftest import dimmer, handle_turn_on, pytestmark, turn_on
+from .conftest import dimmer, handle_turn_on, turn_on
 
 
 @dimmer

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -6,7 +6,7 @@ import pytest  # type: ignore # https://github.com/pytest-dev/pytest/issues/3342
 from kasa import DeviceType, Discover, SmartDevice, SmartDeviceException, protocol
 from kasa.discover import _DiscoverProtocol
 
-from .conftest import bulb, dimmer, lightstrip, plug, pytestmark, strip
+from .conftest import bulb, dimmer, lightstrip, plug, strip
 
 
 @plug

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -2,7 +2,7 @@ import pytest
 
 from kasa import EmeterStatus, SmartDeviceException
 
-from .conftest import has_emeter, no_emeter, pytestmark
+from .conftest import has_emeter, no_emeter
 from .newfakes import CURRENT_CONSUMPTION_SCHEMA
 
 

--- a/kasa/tests/test_lightstrip.py
+++ b/kasa/tests/test_lightstrip.py
@@ -3,7 +3,7 @@ import pytest
 from kasa import DeviceType, SmartLightStrip
 from kasa.exceptions import SmartDeviceException
 
-from .conftest import lightstrip, pytestmark
+from .conftest import lightstrip
 
 
 @lightstrip

--- a/kasa/tests/test_plug.py
+++ b/kasa/tests/test_plug.py
@@ -1,6 +1,6 @@
 from kasa import DeviceType
 
-from .conftest import plug, pytestmark
+from .conftest import plug
 from .newfakes import PLUG_SCHEMA
 
 

--- a/kasa/tests/test_protocol.py
+++ b/kasa/tests/test_protocol.py
@@ -8,7 +8,6 @@ import pytest
 
 from ..exceptions import SmartDeviceException
 from ..protocol import TPLinkSmartHomeProtocol
-from .conftest import pytestmark
 
 
 @pytest.mark.parametrize("retry_count", [1, 3, 5])

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -6,7 +6,7 @@ import pytest  # type: ignore # https://github.com/pytest-dev/pytest/issues/3342
 from kasa import SmartDeviceException
 from kasa.smartstrip import SmartStripPlug
 
-from .conftest import handle_turn_on, has_emeter, no_emeter, pytestmark, turn_on
+from .conftest import handle_turn_on, has_emeter, no_emeter, turn_on
 from .newfakes import PLUG_SCHEMA, TZ_SCHEMA, FakeTransportProtocol
 
 

--- a/kasa/tests/test_strip.py
+++ b/kasa/tests/test_strip.py
@@ -4,7 +4,7 @@ import pytest
 
 from kasa import SmartDeviceException, SmartStrip
 
-from .conftest import handle_turn_on, pytestmark, strip, turn_on
+from .conftest import handle_turn_on, strip, turn_on
 
 
 @strip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ verbose = 2
 markers = [
     "requires_dummy: test requires dummy data to pass, skipped on real devices",
 ]
+asyncio_mode = "auto"
 
 [tool.doc8]
 paths = ["docs"]


### PR DESCRIPTION
As mentioned in https://github.com/python-kasa/python-kasa/issues/396

Solution is to turn on auto mode in the pytest section of the toml file, and then remove the global async marking flag.


lib\site-packages\pytest_asyncio\plugin.py:191
  C:\Users\jphda\miniconda3\envs\python-kasa\lib\site-packages\pytest_asyncio\plugin.py:191: DeprecationWarning: The 'asyncio_mode' default value will change to 'strict' in future, please explicitly use 'asyncio_mode=strict' or 'asyncio_mode=auto' in pytest configuration file.
    config.issue_config_time_warning(LEGACY_MODE, stacklevel=2)

lib\site-packages\pytest_asyncio\plugin.py:230
  C:\Users\jphda\miniconda3\envs\python-kasa\lib\site-packages\pytest_asyncio\plugin.py:230: DeprecationWarning: '@pytest.fixture' is applied to <fixture dev, file=C:\Dev\python-kasa-jules43\kasa\tests\conftest.py, line=197> in 'legacy' mode, please replace it with '@pytest_asyncio.fixture' as a preparation for switching to 'strict' mode (or use 'auto' mode to seamlessly handle all these fixtures as asyncio-driven).
    warnings.warn(

kasa/tests/test_protocol.py::test_encrypt
  kasa\tests\test_protocol.py:135: PytestWarning: The test <Function test_encrypt> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    def test_encrypt():

kasa/tests/test_protocol.py::test_encrypt_unicode
  kasa\tests\test_protocol.py:143: PytestWarning: The test <Function test_encrypt_unicode> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    def test_encrypt_unicode():

kasa/tests/test_protocol.py::test_decrypt_unicode
  kasa\tests\test_protocol.py:176: PytestWarning: The test <Function test_decrypt_unicode> is marked with '@pytest.mark.asyncio' but it is not an async function. Please remove asyncio marker. If the test is not marked explicitly, check for global markers applied via 'pytestmark'.
    def test_decrypt_unicode():


Fixes #396