### PR TITLE
Added .gitattributes file to retain LF only EOL markers when checking out on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh        text eol=lf


### PR DESCRIPTION
Added .gitattributes file to retain LF only EOL markers when checking out on Windows to prevent excessive warnings from doc8 when doing pre-commit

Windows defaults to CRLF most of the time and when you check out LF only files typically get converted and then restored when committed. As doc8 does checks during pre-commit on rst files its handy to have them default to not being converted when pulled.