### PR TITLE
Add devtools script to create module fixtures

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -15,6 +15,28 @@ Options:
   --help       Show this message and exit.
 ```
 
+## create_module_fixtures
+
+* Queries the device for all supported modules and outputs module-based fixture files for each device.
+* This could be used to create fixture files for module-specific tests, but it might also be useful for other use-cases.
+
+```shell
+Usage: create_module_fixtures.py [OPTIONS] OUTPUTDIR
+
+  Create module fixtures for given host/network.
+
+Arguments:
+  OUTPUTDIR  [required]
+
+Options:
+  --host TEXT
+  --network TEXT
+  --install-completion  Install completion for the current shell.
+  --show-completion     Show completion for the current shell, to copy it or
+                        customize the installation.
+  --help                Show this message and exit.
+```
+
 ## parse_pcap
 
 * Requires dpkt (pip install dpkt)

--- a/devtools/create_module_fixtures.py
+++ b/devtools/create_module_fixtures.py
@@ -1,0 +1,60 @@
+"""Create fixture files for modules supported by a device.
+
+This script can be used to create fixture files for individual modules.
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import typer
+
+from kasa import Discover, SmartDevice
+
+app = typer.Typer()
+
+
+def create_fixtures(dev: SmartDevice, outputdir: Path):
+    """Iterate over supported modules and create version-specific fixture files."""
+    for name, module in dev.modules.items():
+        module_dir = outputdir / name
+        if not module_dir.exists():
+            module_dir.mkdir(exist_ok=True, parents=True)
+
+        sw_version = dev.hw_info["sw_ver"]
+        sw_version = sw_version.split(" ", maxsplit=1)[0]
+        filename = f"{dev.model}_{dev.hw_info['hw_ver']}_{sw_version}.json"
+        module_file = module_dir / filename
+
+        if module_file.exists():
+            continue
+
+        typer.echo(f"Creating {module_file} for {dev.model}")
+        with module_file.open("w") as f:
+            json.dump(module.data, f, indent=4)
+
+
+@app.command()
+def create_module_fixtures(
+    outputdir: Path,
+    host: str = typer.Option(default=None),
+    network: str = typer.Option(default=None),
+):
+    """Create module fixtures for given host/network."""
+    devs = []
+    if host is not None:
+        dev: SmartDevice = asyncio.run(Discover.discover_single(host))
+        devs.append(dev)
+    else:
+        if network is None:
+            network = "255.255.255.255"
+        devs = asyncio.run(Discover.discover(target=network)).values()
+        for dev in devs:
+            asyncio.run(dev.update())
+
+    for dev in devs:
+        create_fixtures(dev, outputdir)
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
I created this script earlier to test the idea of having module-specific fixture files for testing, but never had time to finish working on that. This draft is created just to not forget about it completely.
```
Usage: create_module_fixtures.py [OPTIONS] OUTPUTDIR

  Create module fixtures for given host/network.

Arguments:
  OUTPUTDIR  [required]

Options:
  --host TEXT
  --network TEXT
  --install-completion  Install completion for the current shell.
  --show-completion     Show completion for the current shell, to copy it or
                        customize the installation.
  --help                Show this message and exit.

```
for example:
```
python create_module_fixtures.py --network 192.168.4.255 /tmp/testfix
```
will create files from the given network under `/tmp/testfix/`:
```
ls -alR /tmp/testfix/

❯ ls -alR /tmp/testfix/
drwxr-xr-x - tpr 17 Nov 21:38 antitheft
drwxr-xr-x - tpr 17 Nov 21:38 cloud
drwxr-xr-x - tpr 17 Nov 21:38 countdown
drwxr-xr-x - tpr 17 Nov 21:38 emeter
drwxr-xr-x - tpr 17 Nov 21:38 schedule
drwxr-xr-x - tpr 17 Nov 21:38 time
drwxr-xr-x - tpr 17 Nov 21:38 usage

/tmp/testfix/antitheft:
.rw-r--r-- 816 tpr 17 Nov 21:38 HS110(EU)_1.0_1.2.5.json
.rw-r--r-- 214 tpr 17 Nov 21:38 HS110(EU)_4.0_1.0.4.json
.rw-r--r-- 214 tpr 17 Nov 21:38 KP115(EU)_1.0_1.0.16.json
.rw-r--r-- 214 tpr 17 Nov 21:38 KP303(UK)_1.0_1.0.3.json

/tmp/testfix/cloud:
.rw-r--r-- 320 tpr 17 Nov 21:38 HS110(EU)_1.0_1.2.5.json
.rw-r--r-- 320 tpr 17 Nov 21:38 HS110(EU)_4.0_1.0.4.json
.rw-r--r-- 320 tpr 17 Nov 21:38 KP115(EU)_1.0_1.0.16.json
```

```
cat /tmp/testfix/cloud/HS110\(EU\)_1.0_1.2.5.json 
{
    "get_info": {
        "username": "",
        "server": "devs.tplinkcloud.com",
        "binded": 0,
        "cld_connection": 0,
        "illegalType": -1,
        "stopConnect": -1,
        "tcspStatus": -1,
        "fwDlPage": "",
        "tcspInfo": "",
        "fwNotifyType": 0,
        "err_code": 0
    }
}

```