### PR TITLE
Add brightness to lightstrip's set_effect

### DIFF
--- a/kasa/smartlightstrip.py
+++ b/kasa/smartlightstrip.py
@@ -88,17 +88,17 @@ class SmartLightStrip(SmartBulb):
         return info
 
     @requires_update
-    async def set_effect(
-        self,
-        effect: str,
-    ) -> None:
+    async def set_effect(self, effect: str, *, brightness: int = 100) -> None:
         """Set an effect on the device.
 
         :param str effect: The effect to set
+        :param int brightness: The wanted brightness
         """
         if effect not in EFFECT_MAPPING_V1:
             raise SmartDeviceException(f"The effect {effect} is not a built in effect.")
-        await self.set_custom_effect(EFFECT_MAPPING_V1[effect])
+        effect_dict = EFFECT_MAPPING_V1[effect]
+        effect_dict["brightness"] = brightness
+        await self.set_custom_effect(effect_dict)
 
     @requires_update
     async def set_custom_effect(

--- a/kasa/smartlightstrip.py
+++ b/kasa/smartlightstrip.py
@@ -88,7 +88,9 @@ class SmartLightStrip(SmartBulb):
         return info
 
     @requires_update
-    async def set_effect(self, effect: str, *, brightness: int = 100) -> None:
+    async def set_effect(
+        self, effect: str, *, brightness: Optional[int] = None
+    ) -> None:
         """Set an effect on the device.
 
         :param str effect: The effect to set
@@ -97,7 +99,8 @@ class SmartLightStrip(SmartBulb):
         if effect not in EFFECT_MAPPING_V1:
             raise SmartDeviceException(f"The effect {effect} is not a built in effect.")
         effect_dict = EFFECT_MAPPING_V1[effect]
-        effect_dict["brightness"] = brightness
+        if brightness is not None:
+            effect_dict["brightness"] = brightness
         await self.set_custom_effect(effect_dict)
 
     @requires_update

--- a/kasa/tests/test_lightstrip.py
+++ b/kasa/tests/test_lightstrip.py
@@ -31,6 +31,23 @@ async def test_effects_lightstrip_set_effect(dev: SmartLightStrip):
 
 
 @lightstrip
+@pytest.mark.parametrize("brightness", [100, 50])
+async def test_effects_lightstrip_set_effect_brightness(
+    dev: SmartLightStrip, brightness, mocker
+):
+    query_helper = mocker.patch("kasa.SmartLightStrip._query_helper")
+
+    if brightness == 100:  # test that default brightness works
+        await dev.set_effect("Candy Cane")
+    else:
+        await dev.set_effect("Candy Cane", brightness=brightness)
+
+    args, kwargs = query_helper.call_args_list[0]
+    payload = args[2]
+    assert payload["brightness"] == brightness
+
+
+@lightstrip
 async def test_effects_lightstrip_has_effects(dev: SmartLightStrip):
     assert dev.has_effects is True
     assert dev.effect_list


### PR DESCRIPTION
This allows for defining the wanted brightness directly when setting an effect by its name.
Untested as I don't have a test device, feel free to test if you have one.

Slightly related to fixing https://github.com/home-assistant/core/issues/84671 properly.