### PR TITLE
Add transition parameter to lightstrip's set_effect

### DIFF
--- a/kasa/smartlightstrip.py
+++ b/kasa/smartlightstrip.py
@@ -89,18 +89,30 @@ class SmartLightStrip(SmartBulb):
 
     @requires_update
     async def set_effect(
-        self, effect: str, *, brightness: Optional[int] = None
+        self,
+        effect: str,
+        *,
+        brightness: Optional[int] = None,
+        transition: Optional[int] = None,
     ) -> None:
         """Set an effect on the device.
 
+        If brightness or transition is defined, its value will be used instead of the effect-specific default.
+
+        See :meth:`effect_list` for available effects, or use :meth:`set_custom_effect` for custom effects.
+
         :param str effect: The effect to set
         :param int brightness: The wanted brightness
+        :param int transition: The wanted transition time
         """
         if effect not in EFFECT_MAPPING_V1:
             raise SmartDeviceException(f"The effect {effect} is not a built in effect.")
         effect_dict = EFFECT_MAPPING_V1[effect]
         if brightness is not None:
             effect_dict["brightness"] = brightness
+        if transition is not None:
+            effect_dict["transition"] = transition
+
         await self.set_custom_effect(effect_dict)
 
     @requires_update

--- a/kasa/tests/test_lightstrip.py
+++ b/kasa/tests/test_lightstrip.py
@@ -37,7 +37,8 @@ async def test_effects_lightstrip_set_effect_brightness(
 ):
     query_helper = mocker.patch("kasa.SmartLightStrip._query_helper")
 
-    if brightness == 100:  # test that default brightness works
+    # test that default brightness works (100 for candy cane)
+    if brightness == 100:
         await dev.set_effect("Candy Cane")
     else:
         await dev.set_effect("Candy Cane", brightness=brightness)
@@ -45,6 +46,24 @@ async def test_effects_lightstrip_set_effect_brightness(
     args, kwargs = query_helper.call_args_list[0]
     payload = args[2]
     assert payload["brightness"] == brightness
+
+
+@lightstrip
+@pytest.mark.parametrize("transition", [500, 1000])
+async def test_effects_lightstrip_set_effect_transition(
+    dev: SmartLightStrip, transition, mocker
+):
+    query_helper = mocker.patch("kasa.SmartLightStrip._query_helper")
+
+    # test that default (500 for candy cane) transition works
+    if transition == 500:
+        await dev.set_effect("Candy Cane")
+    else:
+        await dev.set_effect("Candy Cane", transition=transition)
+
+    args, kwargs = query_helper.call_args_list[0]
+    payload = args[2]
+    assert payload["transition"] == transition
 
 
 @lightstrip


### PR DESCRIPTION
This adds a transition parameter to `set_effect`, which has not been tested on a real device and might change in the future.

~Marking this as draft as I'm not sure if the transition parameter behaves similarly as for bulbs (considering some effects have a also separate `transition_range`).~