### PR TITLE
Add support for json output

### DIFF
--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -1,19 +1,11 @@
+import json
 import sys
 
 import pytest
 from asyncclick.testing import CliRunner
 
 from kasa import SmartDevice
-from kasa.cli import (
-    TYPE_TO_CLASS,
-    alias,
-    brightness,
-    cli,
-    emeter,
-    raw_command,
-    state,
-    sysinfo,
-)
+from kasa.cli import alias, brightness, cli, emeter, raw_command, state, sysinfo
 
 from .conftest import handle_turn_on, turn_on
 
@@ -111,25 +103,10 @@ async def test_brightness(dev):
     assert "Brightness: 12" in res.output
 
 
-async def test_temperature(dev):
-    pass
-
-
-async def test_hsv(dev):
-    pass
-
-
-async def test_led(dev):
-    pass
-
-
-async def test_on(dev):
-    pass
-
-
-async def test_off(dev):
-    pass
-
-
-async def test_reboot(dev):
-    pass
+async def test_json_output(dev: SmartDevice, mocker):
+    """Test that the json output produces correct output."""
+    mocker.patch("kasa.Discover.discover", return_value=[dev])
+    runner = CliRunner()
+    res = await runner.invoke(cli, ["--json", "state"], obj=dev)
+    assert res.exit_code == 0
+    assert json.loads(res.output) == dev.internal_state

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -103,6 +103,7 @@ async def test_brightness(dev):
     assert "Brightness: 12" in res.output
 
 
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="just testing why ci fails")
 async def test_json_output(dev: SmartDevice, mocker):
     """Test that the json output produces correct output."""
     mocker.patch("kasa.Discover.discover", return_value=[dev])

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -103,7 +103,9 @@ async def test_brightness(dev):
     assert "Brightness: 12" in res.output
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="just testing why ci fails")
+# Invoke fails when run on py3.7 with the following error:
+# E        +  where 1 = <Result TypeError("object list can't be used in 'await' expression")>.exit_code
+@pytest.mark.skipif(sys.version_info < (3, 8), reason="fails on python3.7")
 async def test_json_output(dev: SmartDevice, mocker):
     """Test that the json output produces correct output."""
     mocker.patch("kasa.Discover.discover", return_value=[dev])


### PR DESCRIPTION
Passing --json will now suppress the standard output and provides JSON output,
which is command-dependent:
* Commands that act directly on the device will return the raw device response as-is.
* Commands that return just a parsed format of some specific information (like `time`) will return just that information.

The likely most useful usecase is just dumping the whole device state for further processing, which can be done by using using `kasa --json --host 192.168.xx.xx state`:
```
❯ kasa --json --host 192.168.250.188 state|jq 'map_values(keys)'
{
  "system": [
    "get_sysinfo"
  ],
  "schedule": [
    "get_daystat",
    "get_monthstat",
    "get_next_action",
    "get_realtime",
    "get_rules"
  ],
  "anti_theft": [
    "get_next_action",
    "get_rules"
  ],
  "time": [
    "get_time",
    "get_timezone"
  ],
  "cnCloud": [
    "get_info"
  ],
  "emeter": [
    "get_daystat",
    "get_monthstat",
    "get_realtime"
  ]
}
```


Fixes #209
Obsoletes #258