### PR TITLE
Add inactivity setting for the motion module

### DIFF
--- a/kasa/modules/motion.py
+++ b/kasa/modules/motion.py
@@ -68,7 +68,7 @@ class Motion(Module):
     async def set_inactivity_timeout(self, timeout: int):
         """Set inactivity timeout in milliseconds.
 
-        Note, that you need to delete the default rule to avoid reverting this
-        back to 60 seconds after a period of time.
+        Note, that you need to delete the default "Smart Control" rule in the app
+        to avoid reverting this back to 60 seconds after a period of time.
         """
         return await self.call("set_cold_time", {"cold_time": timeout})

--- a/kasa/modules/motion.py
+++ b/kasa/modules/motion.py
@@ -59,3 +59,16 @@ class Motion(Module):
             )
 
         return await self.call("set_trigger_sens", payload)
+
+    @property
+    def inactivity_timeout(self) -> int:
+        """Return inactivity timeout in milliseconds."""
+        return self.data["cold_time"]
+
+    async def set_inactivity_timeout(self, timeout: int):
+        """Set inactivity timeout in milliseconds.
+
+        Note, that you need to delete the default rule to avoid reverting this
+        back to 60 seconds after a period of time.
+        """
+        return await self.call("set_cold_time", timeout)

--- a/kasa/modules/motion.py
+++ b/kasa/modules/motion.py
@@ -71,4 +71,4 @@ class Motion(Module):
         Note, that you need to delete the default rule to avoid reverting this
         back to 60 seconds after a period of time.
         """
-        return await self.call("set_cold_time", timeout)
+        return await self.call("set_cold_time", {"cold_time": timeout})


### PR DESCRIPTION
This allows obtaining and changing the inactivity timeout for motion detectors.

Per comment in #452, there is a default rule that reverts this back to 60s which needs to be deleted if you want to use this.

Closes #452