### PR TITLE
Drop python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,14 +64,14 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.7"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # exclude pypy on windows, as the poetry install seems to be very flaky:
         # PermissionError(13, 'The process cannot access the file because it is being used by another process'))
         # at C:\hostedtoolcache\windows\PyPy\3.7.10\x86\site-packages\requests\models.py:761 in generate
-        exclude:
-        - python-version: pypy-3.7
-          os: windows-latest
+        # exclude:
+        # - python-version: pypy-3.8
+        #  os: windows-latest
 
     steps:
       - uses: "actions/checkout@v2"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.11"]
 
     steps:
       - uses: "actions/checkout@v2"
@@ -64,7 +64,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.7"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # exclude pypy on windows, as the poetry install seems to be very flaky:
         # PermissionError(13, 'The process cannot access the file because it is being used by another process'))

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
   rev: v3.4.0
   hooks:
   - id: pyupgrade
-    args: ['--py37-plus']
+    args: ['--py38-plus']
 
 - repo: https://github.com/python/black
   rev: 23.3.0

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,7 +2,7 @@ build:
   image: latest
 
 python:
-  version: 3.7
+  version: 3.8
   pip_install: true
   extra_requirements:
     - docs

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -60,7 +60,6 @@ async def test_raw_command(dev):
     assert "Usage" in res.output
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="3.8 is first one with asyncmock")
 async def test_emeter(dev: SmartDevice, mocker):
     runner = CliRunner()
 
@@ -103,9 +102,6 @@ async def test_brightness(dev):
     assert "Brightness: 12" in res.output
 
 
-# Invoke fails when run on py3.7 with the following error:
-# E        +  where 1 = <Result TypeError("object list can't be used in 'await' expression")>.exit_code
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="fails on python3.7")
 async def test_json_output(dev: SmartDevice, mocker):
     """Test that the json output produces correct output."""
     mocker.patch("kasa.Discover.discover", return_value=[dev])

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -52,7 +52,6 @@ async def test_type_unknown():
         Discover._get_device_class(invalid_info)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="3.8 is first one with asyncmock")
 async def test_discover_single(discovery_data: dict, mocker):
     """Make sure that discover_single returns an initialized SmartDevice instance."""
     mocker.patch("kasa.TPLinkSmartHomeProtocol.query", return_value=discovery_data)
@@ -71,7 +70,6 @@ INVALIDS = [
 ]
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="3.8 is first one with asyncmock")
 @pytest.mark.parametrize("msg, data", INVALIDS)
 async def test_discover_invalid_info(msg, data, mocker):
     """Make sure that invalid discovery information raises an exception."""

--- a/kasa/tests/test_protocol.py
+++ b/kasa/tests/test_protocol.py
@@ -62,7 +62,6 @@ async def test_protocol_retry_recoverable_error(mocker):
     assert conn.call_count == 6
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="3.8 is first one with asyncmock")
 @pytest.mark.parametrize("retry_count", [1, 3, 5])
 async def test_protocol_reconnect(mocker, retry_count):
     remaining = retry_count
@@ -98,7 +97,6 @@ async def test_protocol_reconnect(mocker, retry_count):
     assert response == {"great": "success"}
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="3.8 is first one with asyncmock")
 @pytest.mark.parametrize("log_level", [logging.WARNING, logging.DEBUG])
 async def test_protocol_logging(mocker, caplog, log_level):
     caplog.set_level(log_level)

--- a/kasa/tests/test_readme_examples.py
+++ b/kasa/tests/test_readme_examples.py
@@ -65,8 +65,6 @@ def test_discovery_examples(mocker):
     """Test discovery examples."""
     p = asyncio.run(get_device_for_file("KP303(UK)_1.0_1.0.3.json"))
 
-    # This succeeds on python 3.8 but fails on 3.7
-    # ValueError: a coroutine was expected, got [<DeviceType.Strip model KP303(UK) ...
     mocker.patch("kasa.discover.Discover.discover", return_value=[p])
     res = xdoctest.doctest_module("kasa.discover", "all")
     assert not res["failed"]

--- a/kasa/tests/test_readme_examples.py
+++ b/kasa/tests/test_readme_examples.py
@@ -61,9 +61,6 @@ def test_lightstrip_examples(mocker):
     assert not res["failed"]
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 8), reason="3.7 handles asyncio.run differently"
-)
 def test_discovery_examples(mocker):
     """Test discovery examples."""
     p = asyncio.run(get_device_for_file("KP303(UK)_1.0_1.0.3.json"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ include = ["CHANGELOG.md"]
 kasa = "kasa.cli:cli"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 anyio = "*"  # see https://github.com/python-trio/asyncclick/issues/18
 importlib-metadata = "*"
 asyncclick = ">=8"


### PR DESCRIPTION
Python 3.7 will become EOL by the end of June '23, so I think we can drop its support whenever a new release gets done.