### PR TITLE
Replace asyncio.wait_for with async-timeout

### DIFF
--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -17,7 +17,7 @@ import struct
 from pprint import pformat as pf
 from typing import Dict, Generator, Optional, Union
 
-# When support for cpython older than 3.12 is dropped
+# When support for cpython older than 3.11 is dropped
 # async_timeout can be replaced with asyncio.timeout
 from async_timeout import timeout as asyncio_timeout
 

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -14,19 +14,16 @@ import contextlib
 import errno
 import logging
 import struct
-import sys
 from pprint import pformat as pf
 from typing import Dict, Generator, Optional, Union
+
+# When support for cpython older than 3.12 is dropped
+# async_timeout can be replaced with asyncio.timeout
+from async_timeout import timeout as asyncio_timeout
 
 from .exceptions import SmartDeviceException
 from .json import dumps as json_dumps
 from .json import loads as json_loads
-
-if sys.version_info[:2] < (3, 11):
-    from async_timeout import timeout as asyncio_timeout
-else:
-    from asyncio import timeout as asyncio_timeout
-
 
 _LOGGER = logging.getLogger(__name__)
 _NO_RETRY_ERRORS = {errno.EHOSTDOWN, errno.EHOSTUNREACH, errno.ECONNREFUSED}

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -165,7 +165,7 @@ class TPLinkSmartHomeProtocol:
                 assert self.reader is not None
                 assert self.writer is not None
                 async with asyncio_timeout(timeout):
-                    await self._execute_query(request)
+                    return await self._execute_query(request)
             except Exception as ex:
                 await self.close()
                 if retry >= retry_count:

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,6 +35,18 @@ test = ["anyio[trio]", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=
 trio = ["trio (<0.22)"]
 
 [[package]]
+name = "async-timeout"
+version = "4.0.2"
+description = "Timeout context manager for asyncio programs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
+    {file = "async_timeout-4.0.2-py3-none-any.whl", hash = "sha256:8ca1e4fcf50d07413d66d1a5e416e42cfdf5851c981d679a09851a6853383b3c"},
+]
+
+[[package]]
 name = "asyncclick"
 version = "8.1.3.4"
 description = "Composable command line interface toolkit, async version"
@@ -1404,4 +1416,4 @@ speedups = ["orjson", "kasa-crypt"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "b85f55f0ca928b1f3510da37196c21f40eb07cd4d07b3a9c3dd29215ba9777fe"
+content-hash = "fcb657fbabe28548021f5f6a1fcb7b60aa82d60f3de015b4b0c7b37260a6a29f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ sphinx_rtd_theme = { version = "^0", optional = true }
 sphinxcontrib-programoutput = { version = "^0", optional = true }
 myst-parser = { version = "*", optional = true }
 docutils = { version = ">=0.17", optional = true }
+async-timeout = ">=3.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "*"


### PR DESCRIPTION
Note: CI failure is fixed by https://github.com/python-kasa/python-kasa/pull/482

`asyncio.wait_for` has some underlying problems that are only fixed in cpython 3.12. 

Use `async_timeout` instead until the minimum supported version is 3.11+ and it can be replaced with `asyncio.timeout` 

See https://github.com/python/cpython/pull/98518