### PR TITLE
WIP: Add preliminary support for tapo plugs

### DIFF
--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -28,6 +28,7 @@ from kasa.smartdimmer import SmartDimmer
 from kasa.smartlightstrip import SmartLightStrip
 from kasa.smartplug import SmartPlug
 from kasa.smartstrip import SmartStrip
+from kasa.tapoplug import TapoPlug
 
 __version__ = version("python-kasa")
 

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -41,8 +41,10 @@ except ImportError:
 # echo is set to _do_echo so that it can be reset to _do_echo later after
 # --json has set it to _nop_echo
 echo = _do_echo
+    TapoPlug,
 
 TYPE_TO_CLASS = {
+    "tapoplug": TapoPlug,
     "plug": SmartPlug,
     "bulb": SmartBulb,
     "dimmer": SmartDimmer,

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -19,6 +19,7 @@ from kasa import (
     SmartLightStrip,
     SmartPlug,
     SmartStrip,
+    TapoPlug,
 )
 
 try:
@@ -41,7 +42,6 @@ except ImportError:
 # echo is set to _do_echo so that it can be reset to _do_echo later after
 # --json has set it to _nop_echo
 echo = _do_echo
-    TapoPlug,
 
 TYPE_TO_CLASS = {
     "tapoplug": TapoPlug,

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -108,7 +108,9 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         elif port == Discover.DISCOVERY_PORT_2:
             info = json_loads(data[16:])
         else:
-            raise SmartDeviceException("Received response from unexpected port %s" % port)
+            raise SmartDeviceException(
+                "Received response from unexpected port %s" % port
+            )
 
         _LOGGER.debug("[DISCOVERY] %s << %s", ip, info)
         try:
@@ -388,7 +390,9 @@ class Discover:
             supported_device_types = {
                 "SMART.TAPOPLUG": TapoPlug,
             }
-            if (device_type := info["result"].get("device_type")) in supported_device_types:
+            if (
+                device_type := info["result"].get("device_type")
+            ) in supported_device_types:
                 return supported_device_types[device_type]
             else:
                 raise UnsupportDeviceException("Found unsupported device: %s" % info)

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -22,14 +22,14 @@ _LOGGER = logging.getLogger(__name__)
 
 # TODO: there should be a baseclass for plugs that does not initialize modules etc. that are related only to some implementations
 class TapoPlug(SmartPlug):
-    def __init__(self, host: str, *, port: Optional[int] = None) -> None:
+    def __init__(self, host: str, *, port: Optional[int] = None, credentials) -> None:
         # TODO: we are calling smartdevice here to avoid smartplug internal handling
-        SmartDevice.__init__(self, host, port=port)
+        SmartDevice.__init__(self, host, port=port, credentials=credentials)
         # TODO: this is needed as we don't call smartplug ctor
         self._device_type = DeviceType.Plug
         env = os.environ
         self._tapo_client = TapoClient(
-            AuthCredential(username=env["KASA_TAPO_EMAIL"], password=env["KASA_TAPO_PASSWORD"]), self.host
+            AuthCredential(username=credentials.username, password=credentials.password), self.host
         )
         self._tapo_device = PlugDevice(self._tapo_client)
         self._state = None

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -41,6 +41,7 @@ class TapoPlug(SmartPlug):
             self._tapo_client = TapoClient(
                 AuthCredential(username=user, password=pw), self.host
             )
+            await self._tapo_client.initialize()
         self._tapo_device = PlugDevice(self._tapo_client)
 
         self._state = (await self._tapo_device.get_state()).value

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -13,7 +13,7 @@ from plugp100.responses.time_info import TimeInfo
 from plugp100.common.credentials import AuthCredential
 
 
-from . import EmeterStatus
+from .emeterstatus import EmeterStatus
 from .smartdevice import DeviceType, SmartDevice
 from .smartplug import SmartPlug
 
@@ -173,3 +173,9 @@ class TapoPlug(SmartPlug):
     def features(self) -> Set[str]:
         # TODO:
         return set()
+
+    def update_from_discover_info(self, info):
+        """This can be used to update the state from discovery responses.
+
+        As this works only on the unauthenticated discovery responses, we do nothing here.
+        """

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -46,7 +46,6 @@ class TapoPlug(SmartPlug):
         self._energy: EnergyInfo = (await self._tapo_device.get_energy_usage()).value
         self._emeter: PowerInfo = (await self._tapo_device.get_current_power()).value
         self._time: TimeInfo = (await self._tapo_device.get_device_time()).value
-
         self._last_update = self._data = {
             "state": self._state,
             "usage": self._usage,
@@ -156,7 +155,7 @@ class TapoPlug(SmartPlug):
 
     @property
     def on_since(self) -> Optional[datetime]:
-        on_time = self._info.on_time
+        on_time = self._state.on_time
         return datetime.now().replace(microsecond=0) - timedelta(seconds=on_time)
 
     @property
@@ -165,8 +164,8 @@ class TapoPlug(SmartPlug):
             "is_hw_v2": self._info.is_hardware_v2,
             "overheated": self._info.overheated,
             "signal_level": self._info.signal_level,
-            "auto_off": self._info.auto_off,
-            "auto_off_remaining": self._info.auto_off_time_remaining,
+            "auto_off": self._state.auto_off,
+            "auto_off_remaining": self._state.auto_off_time_remaining,
             "On since": self.on_since,
             "SSID": self._info.ssid,
         }

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -77,10 +77,28 @@ class TapoPlug(SmartPlug):
 
     @property
     def time(self) -> datetime:
+        """Disabled as 'region' is '' on my test device
+        File "/x/python-kasa/kasa/tapoplug.py", line 80, in time
+            return self._time.local_time()
+                   ^^^^^^^^^^^^^^^^^^^^^^^
+        File "x/plugp100/responses/time_info.py", line 19, in local_time
+            return datetime.fromtimestamp(self.timestamp, tz=ZoneInfo(self.region))
+                                                          ^^^^^^^^^^^^^^^^^^^^^
+        """
+        return None
         return self._time.local_time()
 
     @property
     def timezone(self) -> Dict:
+        """Disabled as 'region' is '' on my test device
+        File "/x/python-kasa/kasa/tapoplug.py", line 80, in time
+            return self._time.local_time()
+                   ^^^^^^^^^^^^^^^^^^^^^^^
+        File "x/plugp100/responses/time_info.py", line 19, in local_time
+            return datetime.fromtimestamp(self.timestamp, tz=ZoneInfo(self.region))
+                                                          ^^^^^^^^^^^^^^^^^^^^^
+        """
+        return None
         return {"timezone": self._info.timezone, "timediff": self._info.time_difference}
 
     def has_emeter(self) -> bool:

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -9,6 +9,7 @@ from plugp100.responses.device_state import DeviceInfo, PlugDeviceState
 from plugp100.responses.device_usage_info import DeviceUsageInfo
 from plugp100.responses.energy_info import EnergyInfo
 from plugp100.responses.power_info import PowerInfo
+from plugp100.responses.time_info import TimeInfo
 
 from . import EmeterStatus
 from .smartdevice import DeviceType, SmartDevice
@@ -44,12 +45,14 @@ class TapoPlug(SmartPlug):
         ).value
         self._energy: EnergyInfo = (await self._tapo_device.get_energy_usage()).value
         self._emeter: PowerInfo = (await self._tapo_device.get_current_power()).value
+        self._time: TimeInfo = (await self._tapo_device.get_device_time()).value
 
         self._last_update = self._data = {
             "state": self._state,
             "usage": self._usage,
             "emeter": self._emeter,
             "energy": self._energy,
+            "time": self._time,
         }
 
         _LOGGER.debug("Got an update: %s", self._data)
@@ -68,7 +71,7 @@ class TapoPlug(SmartPlug):
 
     @property
     def time(self) -> datetime:
-        return None  # TODO: make return value optional
+        return self._time.local_time()
 
     @property
     def timezone(self) -> Dict:

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -1,0 +1,174 @@
+import logging
+import os
+from datetime import datetime, timedelta
+from typing import Any, Dict, Optional, Set
+
+from plugp100.api.plug_device import PlugDevice
+from plugp100.api.tapo_client import TapoClient
+from plugp100.responses.device_state import DeviceInfo, PlugDeviceState
+from plugp100.responses.device_usage_info import DeviceUsageInfo
+from plugp100.responses.energy_info import EnergyInfo
+from plugp100.responses.power_info import PowerInfo
+
+from . import EmeterStatus
+from .smartdevice import DeviceType, SmartDevice
+from .smartplug import SmartPlug
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# TODO: there should be a baseclass for plugs that does not initialize modules etc. that are related only to some implementations
+class TapoPlug(SmartPlug):
+    def __init__(self, host: str, *, port: Optional[int] = None) -> None:
+        # TODO: we are calling smartdevice here to avoid smartplug internal handling
+        SmartDevice.__init__(self, host, port=port)
+        # TODO: this is needed as we don't call smartplug ctor
+        self._device_type = DeviceType.Plug
+        env = os.environ
+        self._tapo_client = TapoClient(
+            env["KASA_TAPO_EMAIL"], env["KASA_TAPO_PASSWORD"]
+        )
+        self._tapo_device = PlugDevice(self._tapo_client, self.host)
+        self._state = None
+
+    async def update(self, update_children: bool = True):
+        if self._state is None:
+            await self._tapo_device.login()
+
+        # TODO: check for success as
+        self._state = (await self._tapo_device.get_state()).value
+        self._info: DeviceInfo = self._state.info
+
+        self._usage: DeviceUsageInfo = (
+            await self._tapo_device.get_device_usage()
+        ).value
+        self._energy: EnergyInfo = (await self._tapo_device.get_energy_usage()).value
+        self._emeter: PowerInfo = (await self._tapo_device.get_current_power()).value
+
+        self._last_update = self._data = {
+            "state": self._state,
+            "usage": self._usage,
+            "emeter": self._emeter,
+            "energy": self._energy,
+        }
+
+        _LOGGER.debug("Got an update: %s", self._data)
+
+    @property
+    def sys_info(self) -> Dict[str, Any]:
+        return self._state
+
+    @property
+    def model(self) -> str:
+        return self._info.model
+
+    @property
+    def alias(self) -> str:
+        return self._info.nickname
+
+    @property
+    def time(self) -> datetime:
+        return None  # TODO: make return value optional
+
+    @property
+    def timezone(self) -> Dict:
+        return {"timezone": self._info.timezone, "timediff": self._info.time_difference}
+
+    def has_emeter(self) -> bool:
+        return True
+
+    @property
+    def emeter_realtime(self) -> EmeterStatus:
+        return EmeterStatus({"power_mw": self._energy.current_power})
+
+    @property
+    def emeter_today(self) -> Optional[float]:
+        return None
+
+    @property
+    def emeter_this_month(self) -> Optional[float]:
+        return None
+
+    @property
+    def hw_info(self) -> Dict:
+        # TODO: check that the keys match to kasa-infos
+        return {
+            "sw_ver": self._info.firmware_version,
+            "hw_ver": self._info.hardware_version,
+            "mac": self._info.mac,
+            "type": self._info.type,
+            "hwId": self._info.device_id,
+            "dev_name": self._info.nickname,
+            "oemId": self._info.oem_id,
+        }
+
+    @property
+    def location(self) -> Dict:
+        loc = {
+            "latitude": self._info.latitude / 10_000,
+            "longitude": self._info.longitude / 10_000,
+        }
+        return loc
+
+    @property
+    def rssi(self) -> Optional[int]:
+        return self._info.rssi
+
+    @property
+    def mac(self) -> str:
+        return self._info.mac.replace("-", ":")
+
+    @property
+    def device_id(self) -> str:
+        return self._info.device_id
+
+    @property
+    def internal_state(self) -> Any:
+        return self._data
+
+    @property
+    def is_on(self) -> bool:
+        return self._state.device_on
+
+    async def turn_on(self, **kwargs):
+        return await self._tapo_device.on()
+
+    async def turn_off(self, **kwargs):
+        return await self._tapo_device.off()
+
+    async def _query_helper(
+        self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None
+    ) -> Any:
+        res = await self._tapo_device.raw_command(cmd, arg)
+        if res.is_left():
+            raise res.error
+        return res.value
+
+    @property
+    def led(self) -> bool:
+        return None
+
+    async def set_led(self, state: bool):
+        return await super().set_led(state)
+
+    @property
+    def on_since(self) -> Optional[datetime]:
+        on_time = self._info.on_time
+        return datetime.now().replace(microsecond=0) - timedelta(seconds=on_time)
+
+    @property
+    def state_information(self) -> Dict[str, Any]:
+        return {
+            "is_hw_v2": self._info.is_hardware_v2,
+            "overheated": self._info.overheated,
+            "signal_level": self._info.signal_level,
+            "auto_off": self._info.auto_off,
+            "auto_off_remaining": self._info.auto_off_time_remaining,
+            "On since": self.on_since,
+            "SSID": self._info.ssid,
+        }
+
+    @property
+    def features(self) -> Set[str]:
+        # TODO:
+        return set()

--- a/kasa/tapoplug.py
+++ b/kasa/tapoplug.py
@@ -10,6 +10,8 @@ from plugp100.responses.device_usage_info import DeviceUsageInfo
 from plugp100.responses.energy_info import EnergyInfo
 from plugp100.responses.power_info import PowerInfo
 from plugp100.responses.time_info import TimeInfo
+from plugp100.common.credentials import AuthCredential
+
 
 from . import EmeterStatus
 from .smartdevice import DeviceType, SmartDevice
@@ -27,15 +29,12 @@ class TapoPlug(SmartPlug):
         self._device_type = DeviceType.Plug
         env = os.environ
         self._tapo_client = TapoClient(
-            env["KASA_TAPO_EMAIL"], env["KASA_TAPO_PASSWORD"]
+            AuthCredential(username=env["KASA_TAPO_EMAIL"], password=env["KASA_TAPO_PASSWORD"]), self.host
         )
-        self._tapo_device = PlugDevice(self._tapo_client, self.host)
+        self._tapo_device = PlugDevice(self._tapo_client)
         self._state = None
 
     async def update(self, update_children: bool = True):
-        if self._state is None:
-            await self._tapo_device.login()
-
         # TODO: check for success as
         self._state = (await self._tapo_device.get_state()).value
         self._info: DeviceInfo = self._state.info


### PR DESCRIPTION
This is a draft to show how support for tapo plugs could be integrated into this library.
The implementation is a shim that implements the `SmartPlug` interface and uses https://github.com/petretiandrea/plugp100 for all device communications.

At the moment, this is not aimed for general consumption but is just a PoC. The username, the password and list of IP addresses that should be detected as tapo plugs are read from environment variables:
* `KASA_TAPO_EMAIL`
* `KASA_TAPO_PASSWORD`

Example how it looks like:

![image](https://github.com/python-kasa/python-kasa/assets/3705853/44136001-bf7c-430e-9911-12a51679c4c5)

![image](https://github.com/python-kasa/python-kasa/assets/3705853/f743e0c5-f127-41a1-b191-dcd9d998299a)
