### PR TITLE
Show an error if both --alias and --host are defined

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -209,6 +209,9 @@ async def cli(
     if ctx.invoked_subcommand == "discover":
         return
 
+    if alias is not None and host is not None:
+        raise click.BadOptionUsage("alias", "Use either --alias or --host, not both.")
+
     if alias is not None and host is None:
         echo(f"Alias is given, using discovery to find host {alias}")
         host = await find_host_from_alias(alias=alias, target=target)
@@ -219,7 +222,7 @@ async def cli(
             return
 
     if bool(password) != bool(username):
-        echo("Using authentication requires both --username and --password")
+        raise click.BadOptionUsage("username", "Using authentication requires both --username and --password")
         return
 
     credentials = Credentials(username=username, password=password)

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -223,7 +223,6 @@ async def cli(
 
     if bool(password) != bool(username):
         raise click.BadOptionUsage("username", "Using authentication requires both --username and --password")
-        return
 
     credentials = Credentials(username=username, password=password)
 

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -222,7 +222,9 @@ async def cli(
             return
 
     if bool(password) != bool(username):
-        raise click.BadOptionUsage("username", "Using authentication requires both --username and --password")
+        raise click.BadOptionUsage(
+            "username", "Using authentication requires both --username and --password"
+        )
 
     credentials = Credentials(username=username, password=password)
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -183,9 +183,9 @@ async def test_credentials(discovery_data: dict, mocker):
 
 @pytest.mark.parametrize("auth_param", ["--username", "--password"])
 async def test_invalid_credential_params(auth_param):
+    """Test for handling only one of username or password supplied."""
     runner = CliRunner()
 
-    # Test for handling only one of username or password supplied.
     res = await runner.invoke(
         cli,
         [
@@ -202,3 +202,20 @@ async def test_invalid_credential_params(auth_param):
         "Error: Using authentication requires both --username and --password"
         in res.output
     )
+
+
+async def test_duplicate_target_device():
+    """Test that defining both --host or --alias gives an error."""
+    runner = CliRunner()
+
+    res = await runner.invoke(
+        cli,
+        [
+            "--host",
+            "127.0.0.1",
+            "--alias",
+            "foo",
+        ],
+    )
+    assert res.exit_code == 2
+    assert "Error: Use either --alias or --host, not both." in res.output

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -185,7 +185,7 @@ async def test_credentials(discovery_data: dict, mocker):
 async def test_invalid_credential_params(auth_param):
     runner = CliRunner()
 
-    # Test for handling only one of username or passowrd supplied.
+    # Test for handling only one of username or password supplied.
     res = await runner.invoke(
         cli,
         [
@@ -197,7 +197,5 @@ async def test_invalid_credential_params(auth_param):
             "foo",
         ],
     )
-    assert res.exit_code == 0
-    assert (
-        res.output == "Using authentication requires both --username and --password\n"
-    )
+    assert res.exit_code == 2
+    assert "Error: Using authentication requires both --username and --password" in res.output

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -198,4 +198,7 @@ async def test_invalid_credential_params(auth_param):
         ],
     )
     assert res.exit_code == 2
-    assert "Error: Using authentication requires both --username and --password" in res.output
+    assert (
+        "Error: Using authentication requires both --username and --password"
+        in res.output
+    )


### PR DESCRIPTION
Display an error if both --alias and --host are defined to avoid ambiguous target device:
```
❯ kasa --host 123 --alias 123 state
Usage: kasa [OPTIONS] COMMAND [ARGS]...
Try 'kasa --help' for help.

Error: Use either --alias or --host, not both.
```

Also, use `click.BadOptionUsage` consistently for other errors, like when only `--username` or `--password` is given.

Related to #511