### PR TITLE
Fix antitheft is_supported check

### DIFF
--- a/kasa/modules/antitheft.py
+++ b/kasa/modules/antitheft.py
@@ -7,3 +7,15 @@ class Antitheft(RuleModule):
 
     This shares the functionality among other rule-based modules.
     """
+
+    @property
+    def is_supported(self) -> bool:
+        """Return whether the module is supported by the device."""
+        if (
+            (is_supported := super().is_supported)
+            and (module_data := self._device._last_update.get(self._module))
+            and (get_next_action := module_data.get("get_next_action"))
+            and "err_code" in get_next_action
+        ):
+            return False
+        return is_supported

--- a/kasa/modules/antitheft.py
+++ b/kasa/modules/antitheft.py
@@ -11,11 +11,10 @@ class Antitheft(RuleModule):
     @property
     def is_supported(self) -> bool:
         """Return whether the module is supported by the device."""
-        if (
-            (is_supported := super().is_supported)
-            and (module_data := self._device._last_update.get(self._module))
-            and (get_next_action := module_data.get("get_next_action"))
-            and "err_code" in get_next_action
-        ):
+        if not super().is_supported:
             return False
-        return is_supported
+        return (
+            not (module_data := self._device._last_update.get(self._module))
+            or not (get_next_action := module_data.get("get_next_action"))
+            or "err_code" not in get_next_action
+        )

--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -414,6 +414,9 @@ class FakeTransportProtocol(TPLinkSmartHomeProtocol):
             "get_monthstat": None,
             "erase_emeter_state": None,
         },
+        "smartlife.iot.common.anti_theft": {
+            "get_next_action": {"err_code": -2, "err_msg": "member not support"}
+        },
         "smartlife.iot.common.emeter": {
             "get_realtime": None,
             "get_daystat": None,

--- a/kasa/tests/test_lightstrip.py
+++ b/kasa/tests/test_lightstrip.py
@@ -70,3 +70,8 @@ async def test_effects_lightstrip_set_effect_transition(
 async def test_effects_lightstrip_has_effects(dev: SmartLightStrip):
     assert dev.has_effects is True
     assert dev.effect_list
+
+
+@lightstrip
+async def test_antitheft_not_supported(dev: SmartLightStrip):
+    assert dev.modules["antitheft"].is_supported is False


### PR DESCRIPTION
unsupported looks like

```
{'smartlife.iot.common.anti_theft': {'get_next_action': {'err_code': -2,
                                                         'err_msg': 'member '
                                                                    'not '
                                                                    'support'},
```