### PR TITLE
Remove unneeded drain

### DIFF
--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -162,6 +162,7 @@ class TPLinkSmartHomeProtocol:
                 async with asyncio_timeout(timeout):
                     return await self._execute_query(request)
             except Exception as ex:
+                _LOGGER.debug("Exception while querying %s: %s", self.host, ex)
                 await self.close()
                 if retry >= retry_count:
                     _LOGGER.debug("Giving up on %s after %s retries", self.host, retry)

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -97,8 +97,6 @@ class TPLinkSmartHomeProtocol:
         if debug_log:
             _LOGGER.debug("%s >> %s", self.host, request)
         self.writer.write(TPLinkSmartHomeProtocol.encrypt(request))
-        await self.writer.drain()
-
         packed_block_size = await self.reader.readexactly(self.BLOCK_SIZE)
         length = struct.unpack(">I", packed_block_size)[0]
 


### PR DESCRIPTION
readexactly already waits for data to come in so
there is no need to wait for it to be written as
well since there will never be data there if the
write did not happen