### PR TITLE
Parse features only during updates

### DIFF
--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -324,12 +324,10 @@ class SmartDevice:
         if self._last_update is None:
             _LOGGER.debug("Performing the initial update to obtain sysinfo")
             self._last_update = await self.protocol.query(req)
-            self._sys_info = self._last_update["system"]["get_sysinfo"]
-            self._features = _parse_features(self._sys_info.get("feature", ""))
+            self._set_sys_info(self._last_update["system"]["get_sysinfo"])
 
         await self._modular_update(req)
-        self._sys_info = self._last_update["system"]["get_sysinfo"]
-        self._features = _parse_features(self._sys_info.get("feature", ""))
+        self._set_sys_info(self._last_update["system"]["get_sysinfo"])
 
     async def _modular_update(self, req: dict) -> None:
         """Execute an update query."""
@@ -373,7 +371,12 @@ class SmartDevice:
     def update_from_discover_info(self, info):
         """Update state from info from the discover call."""
         self._last_update = info
-        self._sys_info = info["system"]["get_sysinfo"]
+        self._set_sys_info(info["system"]["get_sysinfo"])
+
+    def _set_sys_info(self, sys_info: Dict[str, Any]) -> None:
+        """Set sys_info."""
+        self._sys_info = sys_info
+        self._features = _parse_features(sys_info.get("feature", ""))
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -323,8 +323,9 @@ class SmartDevice:
         # See #105, #120, #161
         if self._last_update is None:
             _LOGGER.debug("Performing the initial update to obtain sysinfo")
-            self._last_update = await self.protocol.query(req)
-            self._set_sys_info(self._last_update["system"]["get_sysinfo"])
+            response = await self.protocol.query(req)
+            self._last_update = response
+            self._set_sys_info(response)
 
         await self._modular_update(req)
         self._set_sys_info(self._last_update["system"]["get_sysinfo"])

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -248,9 +248,7 @@ class SmartDevice:
         if not self.has_emeter:
             raise SmartDeviceException("Device has no emeter")
         if self.emeter_type not in self._last_update:
-            raise SmartDeviceException(
-                f"update() required prior accessing emeter: {self._last_update}"
-            )
+            raise SmartDeviceException("update() required prior accessing emeter")
 
     async def _query_helper(
         self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -248,7 +248,9 @@ class SmartDevice:
         if not self.has_emeter:
             raise SmartDeviceException("Device has no emeter")
         if self.emeter_type not in self._last_update:
-            raise SmartDeviceException("update() required prior accessing emeter")
+            raise SmartDeviceException(
+                f"update() required prior accessing emeter: {self._last_update}"
+            )
 
     async def _query_helper(
         self, target: str, cmd: str, arg: Optional[Dict] = None, child_ids=None
@@ -325,7 +327,7 @@ class SmartDevice:
             _LOGGER.debug("Performing the initial update to obtain sysinfo")
             response = await self.protocol.query(req)
             self._last_update = response
-            self._set_sys_info(response)
+            self._set_sys_info(response["system"]["get_sysinfo"])
 
         await self._modular_update(req)
         self._set_sys_info(self._last_update["system"]["get_sysinfo"])
@@ -369,7 +371,7 @@ class SmartDevice:
             update = {**update, **response}
         self._last_update = update
 
-    def update_from_discover_info(self, info):
+    def update_from_discover_info(self, info: Dict[str, Any]) -> None:
         """Update state from info from the discover call."""
         self._last_update = info
         self._set_sys_info(info["system"]["get_sysinfo"])
@@ -377,7 +379,10 @@ class SmartDevice:
     def _set_sys_info(self, sys_info: Dict[str, Any]) -> None:
         """Set sys_info."""
         self._sys_info = sys_info
-        self._features = _parse_features(sys_info.get("feature", ""))
+        if features := sys_info.get("feature"):
+            self._features = _parse_features(features)
+        else:
+            self._features = set()
 
     @property  # type: ignore
     @requires_update

--- a/kasa/smartstrip.py
+++ b/kasa/smartstrip.py
@@ -258,7 +258,7 @@ class SmartStripPlug(SmartPlug):
         self.parent = parent
         self.child_id = child_id
         self._last_update = parent._last_update
-        self._sys_info = parent._sys_info
+        self._set_sys_info(parent.sys_info)
         self._device_type = DeviceType.StripSocket
         self.modules = {}
         self.protocol = parent.protocol  # Must use the same connection as the parent

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -37,6 +37,7 @@ async def test_invalid_connection(dev):
 async def test_initial_update_emeter(dev, mocker):
     """Test that the initial update performs second query if emeter is available."""
     dev._last_update = None
+    dev._features = set()
     spy = mocker.spy(dev.protocol, "query")
     await dev.update()
     # Devices with small buffers may require 3 queries
@@ -48,6 +49,7 @@ async def test_initial_update_emeter(dev, mocker):
 async def test_initial_update_no_emeter(dev, mocker):
     """Test that the initial update performs second query if emeter is available."""
     dev._last_update = None
+    dev._features = set()
     spy = mocker.spy(dev.protocol, "query")
     await dev.update()
     # 2 calls are necessary as some devices crash on unexpected modules


### PR DESCRIPTION
Every time emeter functions were called features had to be re-parsed.  For power strips, thats a lot of re-parses. Only parse them when we update