### PR TITLE
Add a connect_single method to Discover to avoid the need for UDP

### DIFF
--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -256,6 +256,11 @@ class Discover:
     ) -> SmartDevice:
         """Discover a single device by the given IP address.
 
+        It is generally preferred to avoid :func:`discover_single()` and
+        use :func:`connect_single()` instead as it should perform better when
+        the WiFi network is congested or the device is not responding
+        to discovery requests.
+
         :param host: Hostname of device to query
         :rtype: SmartDevice
         :return: Object for querying/controlling found device.
@@ -309,7 +314,19 @@ class Discover:
     ) -> SmartDevice:
         """Connect to a single device by the given IP address.
 
+        This method avoids the UDP based discovery process and
+        will connect directly to the device to query its type.
+
+        It is generally preferred to avoid :func:`discover_single()` and
+        use this function instead as it should perform better when
+        the WiFi network is congested or the device is not responding
+        to discovery requests.
+
         The device type is discovered by querying the device.
+
+        :param host: Hostname of device to query
+        :rtype: SmartDevice
+        :return: Object for querying/controlling found device.
         """
         unknown_dev = SmartDevice(
             host=host, port=port, credentials=credentials, timeout=timeout

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -74,6 +74,26 @@ async def test_discover_single(discovery_data: dict, mocker, custom_port):
     assert x.port == custom_port or 9999
 
 
+@pytest.mark.parametrize("custom_port", [123, None])
+async def test_connect_single(discovery_data: dict, mocker, custom_port):
+    """Make sure that connect_single returns an initialized SmartDevice instance."""
+    host = "127.0.0.1"
+    mocker.patch("kasa.TPLinkSmartHomeProtocol.query", return_value=discovery_data)
+
+    dev = await Discover.connect_single(host, port=custom_port)
+    assert issubclass(dev.__class__, SmartDevice)
+    assert dev.port == custom_port or 9999
+
+
+async def test_connect_single_query_fails(discovery_data: dict, mocker):
+    """Make sure that connect_single fails when query fails."""
+    host = "127.0.0.1"
+    mocker.patch("kasa.TPLinkSmartHomeProtocol.query", side_effect=SmartDeviceException)
+
+    with pytest.raises(SmartDeviceException):
+        await Discover.connect_single(host)
+
+
 UNSUPPORTED = {
     "result": {
         "device_id": "xx",


### PR DESCRIPTION
This should equate to a significant reliability improvement for networks with poor wifi (edge of range)/udp.
<img width="722" alt="Screenshot 2023-10-07 at 9 02 00 AM" src="https://github.com/python-kasa/python-kasa/assets/663432/16d5621f-648b-429c-a588-5813a68d7e1d">



needs https://github.com/python-kasa/python-kasa/pull/494

related issue https://github.com/home-assistant/core/issues/99449

Can be tested with HA by doing

```diff
diff --git a/homeassistant/components/tplink/__init__.py b/homeassistant/components/tplink/__init__.py
index d8285cbed70..1c98c1e1ae1 100644
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up TPLink from a config entry."""
     host = entry.data[CONF_HOST]
     try:
-        device: SmartDevice = await Discover.discover_single(host)
+        device: SmartDevice = await Discover.connect_single(host)
     except SmartDeviceException as ex:
         raise ConfigEntryNotReady from ex
 
```