### PR TITLE
Use trusted publisher for publishing to pypi

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,13 +7,15 @@ jobs:
   build-n-publish:
     name: Build release packages
     runs-on: ubuntu-latest
+    permissions:  # for trusted publishing
+      id-token: write
 
     steps:
     - uses: actions/checkout@master
     - name: Setup python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.x"
 
     - name: Install pypa/build
       run: >-
@@ -30,6 +32,4 @@ jobs:
         --outdir dist/
         .
     - name: Publish release on pypi
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
See https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/ and https://docs.pypi.org/trusted-publishers/using-a-publisher/