### PR TITLE
Add python3.12 and pypy-3.10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.12"]
 
     steps:
       - uses: "actions/checkout@v2"
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.10]
         os: [ubuntu-latest, macos-latest, windows-latest]
         extras: [false, true]
         exclude:
@@ -67,6 +67,9 @@ jobs:
             python-version: "pypy-3.8"
             extras: true
           - os: ubuntu-latest
+            python-version: "pypy-3.10"
+            extras: true
+          - os: ubuntu-latest
             python-version: "3.8"
             extras: true
           - os: ubuntu-latest
@@ -75,16 +78,10 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
             extras: true
-        # exclude pypy on windows, as the poetry install seems to be very flaky:
-        # PermissionError(13, 'The process cannot access the file because it is being used by another process'))
-        # at C:\hostedtoolcache\windows\PyPy\3.7.10\x86\site-packages\requests\models.py:761 in generate
-        # exclude:
-        # - python-version: pypy-3.8
-        #  os: windows-latest
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v3"
+      - uses: "actions/setup-python@v4"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies (no speedups)"
@@ -101,7 +98,6 @@ jobs:
         run: |
           poetry run pytest --cov kasa --cov-report xml
       - name: "Upload coverage to Codecov"
-        uses: "codecov/codecov-action@v2"
+        uses: "codecov/codecov-action@v3"
         with:
-          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.10]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.10"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         extras: [false, true]
         exclude:


### PR DESCRIPTION
Adds python 3.12 and pypy-3.10 to CI.
We test currently for all supported cpython versions, and the oldest and the latest pypy versions.

Also, cleanup the action file a bit:
* Update action versions
* Remove commented out yaml
* Disable fail_ci_if_error for codecov