### PR TITLE
Kasa KP125M basic emeter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ If your device is unlisted but working, please open a pull request to update the
 * KP105
 * KP115
 * KP125
+* KP125M
 * KP401
 * EP10
 

--- a/kasa/tapo/tapoplug.py
+++ b/kasa/tapo/tapoplug.py
@@ -85,4 +85,3 @@ class TapoPlug(TapoDevice):
             return None
         on_time = cast(float, self._info.get("on_time"))
         return datetime.now().replace(microsecond=0) - timedelta(seconds=on_time)
-


### PR DESCRIPTION
Hi. I have a KP125M, and these changes make it produce plausible data that matches the Kasa mobile app.
I know these changes may conflict with how Tapo energy monitoring may work, but hopefully this will help other developers see what's needed to get KP125M energy monitoring operational.
Thanks for the latest Tapo protocol integration!

Example output with these changes:
$ kasa --type tapoplug --target $IPADDR --username $USERNAME --password $PASSWORD state
....
	== Current State ==
	<EmeterStatus power=1.35 voltage=None current=None total=0.582>

	== Modules ==
	+ <Module Emeter (emeter) for REDACTED>
$ kasa --type tapoplug --target $IPADDR --username $USERNAME --password $PASSWORD emeter
== Emeter ==
Current: None A
Voltage: None V
Power: 1.35 W
Total consumption: 0.582 kWh
Today: 0.582 kWh
This month: 5.737 kWh