### PR TITLE
Fix transport retries after close

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -88,6 +88,8 @@ class AesTransport(BaseTransport):
 
     async def client_post(self, url, params=None, data=None, json=None, headers=None):
         """Send an http post request to the device."""
+        if not self._http_client:
+            self._http_client = httpx.AsyncClient()
         response_data = None
         cookies = None
         if self._session_cookie:

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -118,6 +118,8 @@ class KlapTransport(BaseTransport):
 
     async def client_post(self, url, params=None, data=None):
         """Send an http post request to the device."""
+        if not self._http_client:
+            self._http_client = httpx.AsyncClient()
         response_data = None
         cookies = None
         if self._session_cookie:

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -32,7 +32,7 @@ class _mock_response:
 async def test_protocol_retries(mocker, retry_count, protocol_class, transport_class):
     host = "127.0.0.1"
     conn = mocker.patch.object(
-        transport_class, "client_post", side_effect=Exception("dummy exception")
+        httpx.AsyncClient, "post", side_effect=Exception("dummy exception")
     )
     with pytest.raises(SmartDeviceException):
         await protocol_class(host, transport=transport_class(host)).query(
@@ -49,8 +49,8 @@ async def test_protocol_no_retry_on_connection_error(
 ):
     host = "127.0.0.1"
     conn = mocker.patch.object(
-        transport_class,
-        "client_post",
+        httpx.AsyncClient,
+        "post",
         side_effect=httpx.ConnectError("foo"),
     )
     with pytest.raises(SmartDeviceException):
@@ -68,8 +68,8 @@ async def test_protocol_retry_recoverable_error(
 ):
     host = "127.0.0.1"
     conn = mocker.patch.object(
-        transport_class,
-        "client_post",
+        httpx.AsyncClient,
+        "post",
         side_effect=httpx.CloseError("foo"),
     )
     with pytest.raises(SmartDeviceException):


### PR DESCRIPTION
Fixes an issue where the transport does not recover after `close()` is called by the protocol.

Tests are updated to mock the underlying `httpx.AsyncClient.post` instead of the transport `client_post` which would now catch the issue.