### PR TITLE
Log smartprotocol requests

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -122,7 +122,7 @@ class AesTransport(BaseTransport):
             "params": {"request": encrypted_payload.decode()},
         }
         status_code, resp_dict = await self.client_post(url, json=passthrough_request)
-        _LOGGER.debug(f"secure_passthrough response is {status_code}: {resp_dict}")
+        # _LOGGER.debug(f"secure_passthrough response is {status_code}: {resp_dict}")
         if status_code == 200 and resp_dict["error_code"] == 0:
             response = self._encryption_session.decrypt(  # type: ignore
                 resp_dict["result"]["response"].encode()

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -124,7 +124,11 @@ class SmartProtocol(TPLinkProtocol):
             await self._transport.login(login_request)
 
         smart_request = self.get_smart_request(smart_method, smart_params)
-        _LOGGER.debug("%s >> %s", self.host, _LOGGER.isEnabledFor(logging.DEBUG) and pf(smart_request))
+        _LOGGER.debug(
+            "%s >> %s",
+            self.host,
+            _LOGGER.isEnabledFor(logging.DEBUG) and pf(smart_request),
+        )
         response_data = await self._transport.send(smart_request)
 
         _LOGGER.debug(

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -124,6 +124,7 @@ class SmartProtocol(TPLinkProtocol):
             await self._transport.login(login_request)
 
         smart_request = self.get_smart_request(smart_method, smart_params)
+        _LOGGER.debug("%s >> %s", self.host, _LOGGER.isEnabledFor(logging.DEBUG) and pf(smart_request))
         response_data = await self._transport.send(smart_request)
 
         _LOGGER.debug(


### PR DESCRIPTION
Log raw smartprotocol requests to help debugging invalid queries.

Also, comment out the encrypted secure_passthrough response for the time being to avoid too much output. We might want to hide low-level protocol debug messages behind a separate debug level or something, as most of that may not be that useful?

@sdb9696, opinions on this?