### PR TITLE
Do login entirely within AesTransport

### DIFF
--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -74,7 +74,12 @@ async def connect(
             host=host, port=port, credentials=credentials, timeout=timeout
         )
         if protocol_class is not None:
-            dev.protocol = protocol_class(host, credentials=credentials)
+            dev.protocol = protocol_class(
+                host,
+                transport=AesTransport(
+                    host, port=port, credentials=credentials, timeout=timeout
+                ),
+            )
         await dev.update()
         if debug_enabled:
             end_time = time.perf_counter()
@@ -90,7 +95,13 @@ async def connect(
         host=host, port=port, credentials=credentials, timeout=timeout
     )
     if protocol_class is not None:
-        unknown_dev.protocol = protocol_class(host, credentials=credentials)
+        # TODO this will be replaced with connection params
+        unknown_dev.protocol = protocol_class(
+            host,
+            transport=AesTransport(
+                host, port=port, credentials=credentials, timeout=timeout
+            ),
+        )
     await unknown_dev.update()
     device_class = get_device_class_from_sys_info(unknown_dev.internal_state)
     dev = device_class(host=host, port=port, credentials=credentials, timeout=timeout)
@@ -163,7 +174,5 @@ def get_protocol_from_connection_name(
 
     protocol_class, transport_class = supported_device_protocols.get(connection_name)  # type: ignore
     transport: BaseTransport = transport_class(host, credentials=credentials)
-    protocol: TPLinkProtocol = protocol_class(
-        host, credentials=credentials, transport=transport
-    )
+    protocol: TPLinkProtocol = protocol_class(host, transport=transport)
     return protocol

--- a/kasa/iotprotocol.py
+++ b/kasa/iotprotocol.py
@@ -85,14 +85,6 @@ class IotProtocol(TPLinkProtocol):
         raise SmartDeviceException("Query reached somehow to unreachable")
 
     async def _execute_query(self, request: str, retry_count: int) -> Dict:
-        if self._transport.needs_handshake:
-            await self._transport.handshake()
-
-        if self._transport.needs_login:  # This shouln't happen
-            raise SmartDeviceException(
-                "IOT Protocol needs to login to transport but is not login aware"
-            )
-
         return await self._transport.send(request)
 
     async def close(self) -> None:

--- a/kasa/iotprotocol.py
+++ b/kasa/iotprotocol.py
@@ -1,14 +1,12 @@
 """Module for the IOT legacy IOT KASA protocol."""
 import asyncio
 import logging
-from typing import Dict, Optional, Union
+from typing import Dict, Union
 
 import httpx
 
-from .credentials import Credentials
 from .exceptions import AuthenticationException, SmartDeviceException
 from .json import dumps as json_dumps
-from .klaptransport import KlapTransport
 from .protocol import BaseTransport, TPLinkProtocol
 
 _LOGGER = logging.getLogger(__name__)
@@ -17,24 +15,14 @@ _LOGGER = logging.getLogger(__name__)
 class IotProtocol(TPLinkProtocol):
     """Class for the legacy TPLink IOT KASA Protocol."""
 
-    DEFAULT_PORT = 80
-
     def __init__(
         self,
         host: str,
         *,
-        transport: Optional[BaseTransport] = None,
-        credentials: Optional[Credentials] = None,
-        timeout: Optional[int] = None,
+        transport: BaseTransport,
     ) -> None:
-        super().__init__(host=host, port=self.DEFAULT_PORT)
-
-        self._credentials: Credentials = credentials or Credentials(
-            username="", password=""
-        )
-        self._transport: BaseTransport = transport or KlapTransport(
-            host, credentials=self._credentials, timeout=timeout
-        )
+        """Create a protocol object."""
+        super().__init__(host, transport=transport)
 
         self._query_lock = asyncio.Lock()
 
@@ -54,30 +42,32 @@ class IotProtocol(TPLinkProtocol):
             except httpx.CloseError as sdex:
                 await self.close()
                 if retry >= retry_count:
-                    _LOGGER.debug("Giving up on %s after %s retries", self.host, retry)
+                    _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise SmartDeviceException(
-                        f"Unable to connect to the device: {self.host}: {sdex}"
+                        f"Unable to connect to the device: {self._host}: {sdex}"
                     ) from sdex
                 continue
             except httpx.ConnectError as cex:
                 await self.close()
                 raise SmartDeviceException(
-                    f"Unable to connect to the device: {self.host}: {cex}"
+                    f"Unable to connect to the device: {self._host}: {cex}"
                 ) from cex
             except TimeoutError as tex:
                 await self.close()
                 raise SmartDeviceException(
-                    f"Unable to connect to the device, timed out: {self.host}: {tex}"
+                    f"Unable to connect to the device, timed out: {self._host}: {tex}"
                 ) from tex
             except AuthenticationException as auex:
-                _LOGGER.debug("Unable to authenticate with %s, not retrying", self.host)
+                _LOGGER.debug(
+                    "Unable to authenticate with %s, not retrying", self._host
+                )
                 raise auex
             except Exception as ex:
                 await self.close()
                 if retry >= retry_count:
-                    _LOGGER.debug("Giving up on %s after %s retries", self.host, retry)
+                    _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise SmartDeviceException(
-                        f"Unable to connect to the device: {self.host}: {ex}"
+                        f"Unable to connect to the device: {self._host}: {ex}"
                     ) from ex
                 continue
 

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -118,7 +118,7 @@ class KlapTransport(BaseTransport):
         self._session_cookie = None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient()
 
-        _LOGGER.debug("Created KLAP object for %s", self._host)
+        _LOGGER.debug("Created KLAP transport for %s", self._host)
 
     async def client_post(self, url, params=None, data=None):
         """Send an http post request to the device."""

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -82,7 +82,7 @@ class KlapTransport(BaseTransport):
     protocol, used by newer firmware versions.
     """
 
-    DEFAULT_TIMEOUT = 5
+    DEFAULT_PORT = 80
     DISCOVERY_QUERY = {"system": {"get_sysinfo": None}}
     KASA_SETUP_EMAIL = "kasa@tp-link.net"
     KASA_SETUP_PASSWORD = "kasaSetup"  # noqa: S105
@@ -92,12 +92,17 @@ class KlapTransport(BaseTransport):
         self,
         host: str,
         *,
+        port: Optional[int] = None,
         credentials: Optional[Credentials] = None,
         timeout: Optional[int] = None,
     ) -> None:
-        super().__init__(host=host)
+        super().__init__(
+            host,
+            port=port or self.DEFAULT_PORT,
+            credentials=credentials,
+            timeout=timeout,
+        )
 
-        self._credentials = credentials or Credentials(username="", password="")
         self._local_seed: Optional[bytes] = None
         self._local_auth_hash = self.generate_auth_hash(self._credentials)
         self._local_auth_owner = self.generate_owner_hash(self._credentials).hex()
@@ -110,11 +115,10 @@ class KlapTransport(BaseTransport):
         self._encryption_session: Optional[KlapEncryptionSession] = None
         self._session_expire_at: Optional[float] = None
 
-        self._timeout = timeout if timeout else self.DEFAULT_TIMEOUT
         self._session_cookie = None
         self._http_client: httpx.AsyncClient = httpx.AsyncClient()
 
-        _LOGGER.debug("Created KLAP object for %s", self.host)
+        _LOGGER.debug("Created KLAP object for %s", self._host)
 
     async def client_post(self, url, params=None, data=None):
         """Send an http post request to the device."""
@@ -148,7 +152,7 @@ class KlapTransport(BaseTransport):
 
         payload = local_seed
 
-        url = f"http://{self.host}/app/handshake1"
+        url = f"http://{self._host}/app/handshake1"
 
         response_status, response_data = await self.client_post(url, data=payload)
 
@@ -157,14 +161,14 @@ class KlapTransport(BaseTransport):
                 "Handshake1 posted at %s. Host is %s, Response"
                 + "status is %s, Request was %s",
                 datetime.datetime.now(),
-                self.host,
+                self._host,
                 response_status,
                 payload.hex(),
             )
 
         if response_status != 200:
             raise AuthenticationException(
-                f"Device {self.host} responded with {response_status} to handshake1"
+                f"Device {self._host} responded with {response_status} to handshake1"
             )
 
         remote_seed: bytes = response_data[0:16]
@@ -175,7 +179,7 @@ class KlapTransport(BaseTransport):
                 "Handshake1 success at %s. Host is %s, "
                 + "Server remote_seed is: %s, server hash is: %s",
                 datetime.datetime.now(),
-                self.host,
+                self._host,
                 remote_seed.hex(),
                 server_hash.hex(),
             )
@@ -207,7 +211,7 @@ class KlapTransport(BaseTransport):
             _LOGGER.debug(
                 "Server response doesn't match our expected hash on ip %s"
                 + " but an authentication with kasa setup credentials matched",
-                self.host,
+                self._host,
             )
             return local_seed, remote_seed, self._kasa_setup_auth_hash  # type: ignore
 
@@ -226,11 +230,11 @@ class KlapTransport(BaseTransport):
                 _LOGGER.debug(
                     "Server response doesn't match our expected hash on ip %s"
                     + " but an authentication with blank credentials matched",
-                    self.host,
+                    self._host,
                 )
                 return local_seed, remote_seed, self._blank_auth_hash  # type: ignore
 
-        msg = f"Server response doesn't match our challenge on ip {self.host}"
+        msg = f"Server response doesn't match our challenge on ip {self._host}"
         _LOGGER.debug(msg)
         raise AuthenticationException(msg)
 
@@ -241,7 +245,7 @@ class KlapTransport(BaseTransport):
         # Handshake 2 has the following payload:
         #    sha256(serverBytes | authenticator)
 
-        url = f"http://{self.host}/app/handshake2"
+        url = f"http://{self._host}/app/handshake2"
 
         payload = self.handshake2_seed_auth_hash(local_seed, remote_seed, auth_hash)
 
@@ -252,14 +256,14 @@ class KlapTransport(BaseTransport):
                 "Handshake2 posted %s.  Host is %s, Response status is %s, "
                 + "Request was %s",
                 datetime.datetime.now(),
-                self.host,
+                self._host,
                 response_status,
                 payload.hex(),
             )
 
         if response_status != 200:
             raise AuthenticationException(
-                f"Device {self.host} responded with {response_status} to handshake2"
+                f"Device {self._host} responded with {response_status} to handshake2"
             )
 
         return KlapEncryptionSession(local_seed, remote_seed, auth_hash)
@@ -269,7 +273,7 @@ class KlapTransport(BaseTransport):
 
         Sets the encryption_session if successful.
         """
-        _LOGGER.debug("Starting handshake with %s", self.host)
+        _LOGGER.debug("Starting handshake with %s", self._host)
         self._handshake_done = False
         self._session_expire_at = None
         self._session_cookie = None
@@ -287,7 +291,7 @@ class KlapTransport(BaseTransport):
         )
         self._handshake_done = True
 
-        _LOGGER.debug("Handshake with %s complete", self.host)
+        _LOGGER.debug("Handshake with %s complete", self._host)
 
     def _handshake_session_expired(self):
         """Return true if session has expired."""
@@ -305,7 +309,7 @@ class KlapTransport(BaseTransport):
         if self._encryption_session is not None:
             payload, seq = self._encryption_session.encrypt(request.encode())
 
-        url = f"http://{self.host}/app/request"
+        url = f"http://{self._host}/app/request"
 
         response_status, response_data = await self.client_post(
             url,
@@ -314,7 +318,7 @@ class KlapTransport(BaseTransport):
         )
 
         msg = (
-            f"at {datetime.datetime.now()}.  Host is {self.host}, "
+            f"at {datetime.datetime.now()}.  Host is {self._host}, "
             + f"Sequence is {seq}, "
             + f"Response status is {response_status}, Request was {request}"
         )
@@ -324,12 +328,12 @@ class KlapTransport(BaseTransport):
             if response_status == 403:
                 self._handshake_done = False
                 raise AuthenticationException(
-                    f"Got a security error from {self.host} after handshake "
+                    f"Got a security error from {self._host} after handshake "
                     + "completed"
                 )
             else:
                 raise SmartDeviceException(
-                    f"Device {self.host} responded with {response_status} to"
+                    f"Device {self._host} responded with {response_status} to"
                     + f"request with seq {seq}"
                 )
         else:
@@ -343,7 +347,7 @@ class KlapTransport(BaseTransport):
 
             _LOGGER.debug(
                 "%s << %s",
-                self.host,
+                self._host,
                 _LOGGER.isEnabledFor(logging.DEBUG) and pf(json_payload),
             )
 

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -56,24 +56,6 @@ class BaseTransport(ABC):
         self.port = port
         self.credentials = credentials
 
-    @property
-    @abstractmethod
-    def needs_handshake(self) -> bool:
-        """Return true if the transport needs to do a handshake."""
-
-    @property
-    @abstractmethod
-    def needs_login(self) -> bool:
-        """Return true if the transport needs to do a login."""
-
-    @abstractmethod
-    async def login(self, request: str) -> None:
-        """Login to the device."""
-
-    @abstractmethod
-    async def handshake(self) -> None:
-        """Perform the encryption handshake."""
-
     @abstractmethod
     async def send(self, request: str) -> Dict:
         """Send a message to the device and return a response."""

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -24,7 +24,7 @@ from .device_type import DeviceType
 from .emeterstatus import EmeterStatus
 from .exceptions import SmartDeviceException
 from .modules import Emeter, Module
-from .protocol import TPLinkProtocol, TPLinkSmartHomeProtocol
+from .protocol import TPLinkProtocol, TPLinkSmartHomeProtocol, _XorTransport
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -202,7 +202,7 @@ class SmartDevice:
         self.host = host
         self.port = port
         self.protocol: TPLinkProtocol = TPLinkSmartHomeProtocol(
-            host, port=port, timeout=timeout
+            host, transport=_XorTransport(host, port=port, timeout=timeout)
         )
         self.credentials = credentials
         _LOGGER.debug("Initializing %s of type %s", self.host, type(self))

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -160,16 +160,6 @@ class SmartProtocol(TPLinkProtocol):
             smart_method = request
             smart_params = None
 
-        if self._transport.needs_handshake:
-            await self._transport.handshake()
-
-        if self._transport.needs_login:
-            self._terminal_uuid = base64.b64encode(md5(uuid.uuid4().bytes)).decode(
-                "UTF-8"
-            )
-            login_request = self.get_smart_request("login_device")
-            await self._transport.login(login_request)
-
         smart_request = self.get_smart_request(smart_method, smart_params)
         _LOGGER.debug(
             "%s >> %s",

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -55,7 +55,7 @@ class SmartProtocol(TPLinkProtocol):
         self._transport: BaseTransport = transport or AesTransport(
             host, credentials=self._credentials, timeout=timeout
         )
-        self._terminal_uuid: Optional[str] = None
+        self._terminal_uuid: str = base64.b64encode(md5(uuid.uuid4().bytes)).decode()
         self._request_id_generator = SnowflakeId(1, 1)
         self._query_lock = asyncio.Lock()
 

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Set, cast
 
+from ..aestransport import AesTransport
 from ..credentials import Credentials
 from ..exceptions import AuthenticationException
 from ..smartdevice import SmartDevice
@@ -27,7 +28,12 @@ class TapoDevice(SmartDevice):
         self._components: Optional[Dict[str, Any]] = None
         self._state_information: Dict[str, Any] = {}
         self._discovery_info: Optional[Dict[str, Any]] = None
-        self.protocol = SmartProtocol(host, credentials=credentials, timeout=timeout)
+        self.protocol = SmartProtocol(
+            host,
+            transport=AesTransport(
+                host, credentials=credentials, timeout=timeout, port=port
+            ),
+        )
 
     async def update(self, update_children: bool = True):
         """Update the device."""

--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -301,6 +301,9 @@ class FakeSmartProtocol(SmartProtocol):
 
 class FakeSmartTransport(BaseTransport):
     def __init__(self, info):
+        super().__init__(
+            "127.0.0.123",
+        )
         self.info = info
 
     @property

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -1,0 +1,174 @@
+import base64
+import json
+import time
+from contextlib import nullcontext as does_not_raise
+from json import dumps as json_dumps
+from json import loads as json_loads
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padding
+
+from ..aestransport import AesEncyptionSession, AesTransport
+from ..credentials import Credentials
+from ..exceptions import SmartDeviceException
+
+DUMMY_QUERY = {"foobar": {"foo": "bar", "bar": "foo"}}
+
+key = b"8\x89\x02\xfa\xf5Xs\x1c\xa1 H\x9a\x82\xc7\xd9\t"
+iv = b"9=\xf8\x1bS\xcd0\xb5\x89i\xba\xfd^9\x9f\xfa"
+KEY_IV = key + iv
+
+
+def test_encrypt():
+    encryption_session = AesEncyptionSession(KEY_IV[:16], KEY_IV[16:])
+
+    d = json.dumps({"foo": 1, "bar": 2})
+    encrypted = encryption_session.encrypt(d.encode())
+    assert d == encryption_session.decrypt(encrypted)
+
+    # test encrypt unicode
+    d = "{'snowman': '\u2603'}"
+    encrypted = encryption_session.encrypt(d.encode())
+    assert d == encryption_session.decrypt(encrypted)
+
+
+status_parameters = pytest.mark.parametrize(
+    "status_code, error_code, inner_error_code, expectation",
+    [
+        (200, 0, 0, does_not_raise()),
+        (400, 0, 0, pytest.raises(SmartDeviceException)),
+        (200, -1, 0, pytest.raises(SmartDeviceException)),
+    ],
+    ids=("success", "status_code", "error_code"),
+)
+
+
+@status_parameters
+async def test_handshake(
+    mocker, status_code, error_code, inner_error_code, expectation
+):
+    host = "127.0.0.1"
+    mock_aes_device = MockAesDevice(host, status_code, error_code, inner_error_code)
+    mocker.patch.object(httpx.AsyncClient, "post", side_effect=mock_aes_device.post)
+
+    transport = AesTransport(host=host, credentials=Credentials("foo", "bar"))
+
+    assert transport._encryption_session is None
+    assert transport._handshake_done is False
+    with expectation:
+        await transport.perform_handshake()
+        assert transport._encryption_session is not None
+        assert transport._handshake_done is True
+
+
+@status_parameters
+async def test_login(mocker, status_code, error_code, inner_error_code, expectation):
+    host = "127.0.0.1"
+    mock_aes_device = MockAesDevice(host, status_code, error_code, inner_error_code)
+    mocker.patch.object(httpx.AsyncClient, "post", side_effect=mock_aes_device.post)
+
+    transport = AesTransport(host=host, credentials=Credentials("foo", "bar"))
+    transport._handshake_done = True
+    transport._session_expire_at = time.time() + 86400
+    transport._encryption_session = mock_aes_device.encryption_session
+
+    assert transport._login_token is None
+    with expectation:
+        await transport.perform_login()
+        assert transport._login_token == mock_aes_device.token
+
+
+@status_parameters
+async def test_send(mocker, status_code, error_code, inner_error_code, expectation):
+    host = "127.0.0.1"
+    mock_aes_device = MockAesDevice(host, status_code, error_code, inner_error_code)
+    mocker.patch.object(httpx.AsyncClient, "post", side_effect=mock_aes_device.post)
+
+    transport = AesTransport(host=host, credentials=Credentials("foo", "bar"))
+    transport._handshake_done = True
+    transport._session_expire_at = time.time() + 86400
+    transport._encryption_session = mock_aes_device.encryption_session
+    transport._login_token = mock_aes_device.token
+
+    un, pw = transport.hash_credentials(True)
+    request = {
+        "method": "get_device_info",
+        "params": None,
+        "request_time_milis": round(time.time() * 1000),
+        "requestID": 1,
+        "terminal_uuid": "foobar",
+    }
+    with expectation:
+        res = await transport.send(json_dumps(request))
+        assert "result" in res
+
+
+class MockAesDevice:
+    class _mock_response:
+        def __init__(self, status_code, json: dict):
+            self.status_code = status_code
+            self._json = json
+
+        def json(self):
+            return self._json
+
+    encryption_session = AesEncyptionSession(KEY_IV[:16], KEY_IV[16:])
+    token = "test_token"  # noqa
+
+    def __init__(self, host, status_code=200, error_code=0, inner_error_code=0):
+        self.host = host
+        self.status_code = status_code
+        self.error_code = error_code
+        self.inner_error_code = inner_error_code
+
+    async def post(self, url, params=None, json=None, *_, **__):
+        return await self._post(url, json)
+
+    async def _post(self, url, json):
+        if json["method"] == "handshake":
+            return await self._return_handshake_response(url, json)
+        elif json["method"] == "securePassthrough":
+            return await self._return_secure_passthrough_response(url, json)
+        elif json["method"] == "login_device":
+            return await self._return_login_response(url, json)
+        else:
+            assert url == f"http://{self.host}/app?token={self.token}"
+            return await self._return_send_response(url, json)
+
+    async def _return_handshake_response(self, url, json):
+        start = len("-----BEGIN PUBLIC KEY-----\n")
+        end = len("\n-----END PUBLIC KEY-----\n")
+        client_pub_key = json["params"]["key"][start:-end]
+
+        client_pub_key_data = base64.b64decode(client_pub_key.encode())
+        client_pub_key = serialization.load_der_public_key(client_pub_key_data, None)
+        encrypted_key = client_pub_key.encrypt(KEY_IV, asymmetric_padding.PKCS1v15())
+        key_64 = base64.b64encode(encrypted_key).decode()
+        return self._mock_response(
+            self.status_code, {"result": {"key": key_64}, "error_code": self.error_code}
+        )
+
+    async def _return_secure_passthrough_response(self, url, json):
+        encrypted_request = json["params"]["request"]
+        decrypted_request = self.encryption_session.decrypt(encrypted_request.encode())
+        decrypted_request_dict = json_loads(decrypted_request)
+        decrypted_response = await self._post(url, decrypted_request_dict)
+        decrypted_response_dict = decrypted_response.json()
+        encrypted_response = self.encryption_session.encrypt(
+            json_dumps(decrypted_response_dict).encode()
+        )
+        result = {
+            "result": {"response": encrypted_response.decode()},
+            "error_code": self.error_code,
+        }
+        return self._mock_response(self.status_code, result)
+
+    async def _return_login_response(self, url, json):
+        result = {"result": {"token": self.token}, "error_code": self.inner_error_code}
+        return self._mock_response(self.status_code, result)
+
+    async def _return_send_response(self, url, json):
+        result = {"result": {"method": None}, "error_code": self.inner_error_code}
+        return self._mock_response(self.status_code, result)

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -96,10 +96,9 @@ async def test_protocol_reconnect(mocker, retry_count, protocol_class, transport
 
         return mock_response
 
-    mocker.patch.object(
-        transport_class, "needs_handshake", property(lambda self: False)
-    )
-    mocker.patch.object(transport_class, "needs_login", property(lambda self: False))
+    mocker.patch.object(transport_class, "perform_handshake")
+    if hasattr(transport_class, "perform_login"):
+        mocker.patch.object(transport_class, "perform_login")
 
     send_mock = mocker.patch.object(
         transport_class,

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -127,7 +127,7 @@ async def test_protocol_logging(mocker, caplog, log_level):
     seed = secrets.token_bytes(16)
     auth_hash = KlapTransport.generate_auth_hash(Credentials("foo", "bar"))
     encryption_session = KlapEncryptionSession(seed, seed, auth_hash)
-    protocol = IotProtocol("127.0.0.1")
+    protocol = IotProtocol("127.0.0.1", transport=KlapTransport("127.0.0.1"))
 
     protocol._transport._handshake_done = True
     protocol._transport._session_expire_at = time.time() + 86400
@@ -205,7 +205,10 @@ async def test_handshake1(mocker, device_credentials, expectation):
         httpx.AsyncClient, "post", side_effect=_return_handshake1_response
     )
 
-    protocol = IotProtocol("127.0.0.1", credentials=client_credentials)
+    protocol = IotProtocol(
+        "127.0.0.1",
+        transport=KlapTransport("127.0.0.1", credentials=client_credentials),
+    )
 
     protocol._transport.http_client = httpx.AsyncClient()
     with expectation:
@@ -242,7 +245,10 @@ async def test_handshake(mocker):
         httpx.AsyncClient, "post", side_effect=_return_handshake_response
     )
 
-    protocol = IotProtocol("127.0.0.1", credentials=client_credentials)
+    protocol = IotProtocol(
+        "127.0.0.1",
+        transport=KlapTransport("127.0.0.1", credentials=client_credentials),
+    )
     protocol._transport.http_client = httpx.AsyncClient()
 
     response_status = 200
@@ -288,7 +294,10 @@ async def test_query(mocker):
 
     mocker.patch.object(httpx.AsyncClient, "post", side_effect=_return_response)
 
-    protocol = IotProtocol("127.0.0.1", credentials=client_credentials)
+    protocol = IotProtocol(
+        "127.0.0.1",
+        transport=KlapTransport("127.0.0.1", credentials=client_credentials),
+    )
 
     for _ in range(10):
         resp = await protocol.query({})
@@ -332,7 +341,10 @@ async def test_authentication_failures(mocker, response_status, expectation):
 
     mocker.patch.object(httpx.AsyncClient, "post", side_effect=_return_response)
 
-    protocol = IotProtocol("127.0.0.1", credentials=client_credentials)
+    protocol = IotProtocol(
+        "127.0.0.1",
+        transport=KlapTransport("127.0.0.1", credentials=client_credentials),
+    )
 
     with expectation:
         await protocol.query({})

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -232,7 +232,7 @@ async def test_modules_preserved(dev: SmartDevice):
 async def test_create_smart_device_with_timeout():
     """Make sure timeout is passed to the protocol."""
     dev = SmartDevice(host="127.0.0.1", timeout=100)
-    assert dev.protocol.timeout == 100
+    assert dev.protocol._transport._timeout == 100
 
 
 async def test_create_thin_wrapper():


### PR DESCRIPTION
Removes the `login` and `handshake` from the protocol class and does it entirely within the transport.
Also includes tests for aestransport and refactoring of the `__init__` signatures