### PR TITLE
Improve CLI Discovery output

### DIFF
--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -8,6 +8,10 @@ class SmartDeviceException(Exception):
 class UnsupportedDeviceException(SmartDeviceException):
     """Exception for trying to connect to unsupported devices."""
 
+    def __init__(self, *args, discovery_result=None):
+        self.discovery_result = discovery_result
+        super().__init__(args)
+
 
 class AuthenticationException(SmartDeviceException):
     """Base exception for device authentication errors."""

--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -291,6 +291,13 @@ class FakeSmartProtocol(SmartProtocol):
     def __init__(self, info):
         super().__init__("127.0.0.123", transport=FakeSmartTransport(info))
 
+    async def query(self, request, retry_count: int = 3):
+        """Implement query here so can still patch SmartProtocol.query."""
+        resp_dict = await self._query(request, retry_count)
+        if "result" in resp_dict:
+            return resp_dict["result"]
+        return {}
+
 
 class FakeSmartTransport(BaseTransport):
     def __init__(self, info):

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -202,7 +202,7 @@ async def test_discover_datagram_received(mocker, discovery_data):
     # Check that device in discovered_devices is initialized correctly
     assert len(proto.discovered_devices) == 1
     # Check that unsupported device is 1
-    assert len(proto.unsupported_devices) == 1
+    assert len(proto.unsupported_device_exceptions) == 1
     dev = proto.discovered_devices[addr]
     assert issubclass(dev.__class__, SmartDevice)
     assert dev.host == addr


### PR DESCRIPTION
- Show discovery results for unsupported devices and devices that fail to authenticate.
- Rename `--show-unsupported` to `--verbose`.
- Remove separate `--timeout` parameter from cli discovery so it's not confused with `--timeout` now [added to cli command](https://github.com/python-kasa/python-kasa/commit/347cbfe3bdaa4c492ef74508bbe47bdfdc49e587)
- Add tests.