### PR TITLE
Enable multiple requests in smartprotocol

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -130,14 +130,14 @@ class AesTransport(BaseTransport):
             return
         msg = f"{msg}: {self._host}: {error_code.name}({error_code.value})"
         if error_code in SMART_TIMEOUT_ERRORS:
-            raise TimeoutException(msg, error_code=error_code)
+            raise TimeoutException(msg)
         if error_code in SMART_RETRYABLE_ERRORS:
-            raise RetryableException(msg, error_code=error_code)
+            raise RetryableException(msg)
         if error_code in SMART_AUTHENTICATION_ERRORS:
             self._handshake_done = False
             self._login_token = None
-            raise AuthenticationException(msg, error_code=error_code)
-        raise SmartDeviceException(msg, error_code=error_code)
+            raise AuthenticationException(msg)
+        raise SmartDeviceException(msg)
 
     async def send_secure_passthrough(self, request: str):
         """Send encrypted message as passthrough."""

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -125,19 +125,19 @@ class AesTransport(BaseTransport):
         return resp.status_code, response_data
 
     def _handle_response_error_code(self, resp_dict: dict, msg: str):
-        if (
-            error_code := SmartErrorCode(resp_dict.get("error_code"))  # type: ignore[arg-type]
-        ) != SmartErrorCode.SUCCESS:
-            msg = f"{msg}: {self._host}: {error_code.name}({error_code.value})"
-            if error_code in SMART_TIMEOUT_ERRORS:
-                raise TimeoutException(msg)
-            if error_code in SMART_RETRYABLE_ERRORS:
-                raise RetryableException(msg)
-            if error_code in SMART_AUTHENTICATION_ERRORS:
-                self._handshake_done = False
-                self._login_token = None
-                raise AuthenticationException(msg)
-            raise SmartDeviceException(msg)
+        error_code = SmartErrorCode(resp_dict.get("error_code"))  # type: ignore[arg-type]
+        if error_code == SmartErrorCode.SUCCESS:
+            return
+        msg = f"{msg}: {self._host}: {error_code.name}({error_code.value})"
+        if error_code in SMART_TIMEOUT_ERRORS:
+            raise TimeoutException(msg, error_code=error_code)
+        if error_code in SMART_RETRYABLE_ERRORS:
+            raise RetryableException(msg, error_code=error_code)
+        if error_code in SMART_AUTHENTICATION_ERRORS:
+            self._handshake_done = False
+            self._login_token = None
+            raise AuthenticationException(msg, error_code=error_code)
+        raise SmartDeviceException(msg, error_code=error_code)
 
     async def send_secure_passthrough(self, request: str):
         """Send encrypted message as passthrough."""

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -1,9 +1,14 @@
 """python-kasa exceptions."""
 from enum import IntEnum
+from typing import Optional
 
 
 class SmartDeviceException(Exception):
     """Base exception for device errors."""
+
+    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
+        self.error_code = error_code
+        super().__init__(args)
 
 
 class UnsupportedDeviceException(SmartDeviceException):
@@ -17,13 +22,22 @@ class UnsupportedDeviceException(SmartDeviceException):
 class AuthenticationException(SmartDeviceException):
     """Base exception for device authentication errors."""
 
+    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
+        super().__init__(args, error_code)
+
 
 class RetryableException(SmartDeviceException):
     """Retryable exception for device errors."""
 
+    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
+        super().__init__(args, error_code)
+
 
 class TimeoutException(SmartDeviceException):
     """Timeout exception for device errors."""
+
+    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
+        super().__init__(args, error_code)
 
 
 class SmartErrorCode(IntEnum):

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -1,14 +1,9 @@
 """python-kasa exceptions."""
 from enum import IntEnum
-from typing import Optional
 
 
 class SmartDeviceException(Exception):
     """Base exception for device errors."""
-
-    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
-        self.error_code = error_code
-        super().__init__(args)
 
 
 class UnsupportedDeviceException(SmartDeviceException):
@@ -22,22 +17,13 @@ class UnsupportedDeviceException(SmartDeviceException):
 class AuthenticationException(SmartDeviceException):
     """Base exception for device authentication errors."""
 
-    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
-        super().__init__(args, error_code)
-
 
 class RetryableException(SmartDeviceException):
     """Retryable exception for device errors."""
 
-    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
-        super().__init__(args, error_code)
-
 
 class TimeoutException(SmartDeviceException):
     """Timeout exception for device errors."""
-
-    def __init__(self, *args, error_code: Optional["SmartErrorCode"] = None):
-        super().__init__(args, error_code)
 
 
 class SmartErrorCode(IntEnum):

--- a/kasa/iotprotocol.py
+++ b/kasa/iotprotocol.py
@@ -62,6 +62,13 @@ class IotProtocol(TPLinkProtocol):
                     "Unable to authenticate with %s, not retrying", self._host
                 )
                 raise auex
+            except SmartDeviceException as ex:
+                _LOGGER.debug(
+                    "Unable to connect to the device: %s, not retrying: %s",
+                    self._host,
+                    ex,
+                )
+                raise ex
             except Exception as ex:
                 await self.close()
                 if retry >= retry_count:

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -186,12 +186,12 @@ class SmartProtocol(TPLinkProtocol):
         if method := resp_dict.get("method"):
             msg += f" for method: {method}"
         if error_code in SMART_TIMEOUT_ERRORS:
-            raise TimeoutException(msg, error_code=error_code)
+            raise TimeoutException(msg)
         if error_code in SMART_RETRYABLE_ERRORS:
-            raise RetryableException(msg, error_code=error_code)
+            raise RetryableException(msg)
         if error_code in SMART_AUTHENTICATION_ERRORS:
-            raise AuthenticationException(msg, error_code=error_code)
-        raise SmartDeviceException(msg, error_code=error_code)
+            raise AuthenticationException(msg)
+        raise SmartDeviceException(msg)
 
     async def close(self) -> None:
         """Close the protocol."""

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -41,11 +41,18 @@ class TapoDevice(SmartDevice):
             raise AuthenticationException("Tapo plug requires authentication.")
 
         if self._components is None:
-            self._components = await self.protocol.query("component_nego")
+            resp = await self.protocol.query("component_nego")
+            self._components = resp["component_nego"]
 
-        self._info = await self.protocol.query("get_device_info")
-        self._usage = await self.protocol.query("get_device_usage")
-        self._time = await self.protocol.query("get_device_time")
+        req = {
+            "get_device_info": None,
+            "get_device_usage": None,
+            "get_device_time": None,
+        }
+        resp = await self.protocol.query(req)
+        self._info = resp["get_device_info"]
+        self._usage = resp["get_device_usage"]
+        self._time = resp["get_device_time"]
 
         self._last_update = self._data = {
             "components": self._components,

--- a/kasa/tapo/tapoplug.py
+++ b/kasa/tapo/tapoplug.py
@@ -39,8 +39,13 @@ class TapoPlug(TapoDevice):
         """Call the device endpoint and update the device data."""
         await super().update(update_children)
 
-        self._energy = await self.protocol.query("get_energy_usage")
-        self._emeter = await self.protocol.query("get_current_power")
+        req = {
+            "get_energy_usage": None,
+            "get_current_power": None,
+        }
+        resp = await self.protocol.query(req)
+        self._energy = resp["get_energy_usage"]
+        self._emeter = resp["get_current_power"]
 
         self._data["energy"] = self._energy
         self._data["emeter"] = self._emeter
@@ -70,6 +75,13 @@ class TapoPlug(TapoDevice):
                 ),
             }
         )
+
+    async def get_emeter_realtime(self) -> EmeterStatus:
+        """Retrieve current energy readings."""
+        self._verify_emeter()
+        resp = await self.protocol.query("get_energy_usage")
+        self._energy = resp["get_energy_usage"]
+        return self.emeter_realtime
 
     @property
     def emeter_today(self) -> Optional[float]:

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -196,9 +196,13 @@ def parametrize(desc, devices, protocol_filter=None, ids=None):
     )
 
 
-has_emeter = parametrize("has emeter", WITH_EMETER_IOT, protocol_filter={"IOT"})
+has_emeter = parametrize("has emeter", WITH_EMETER, protocol_filter={"SMART", "IOT"})
 no_emeter = parametrize(
-    "no emeter", ALL_DEVICES_IOT - WITH_EMETER_IOT, protocol_filter={"SMART", "IOT"}
+    "no emeter", ALL_DEVICES - WITH_EMETER, protocol_filter={"SMART", "IOT"}
+)
+has_emeter_iot = parametrize("has emeter iot", WITH_EMETER_IOT, protocol_filter={"IOT"})
+no_emeter_iot = parametrize(
+    "no emeter iot", ALL_DEVICES_IOT - WITH_EMETER_IOT, protocol_filter={"IOT"}
 )
 
 bulb = parametrize("bulbs", BULBS, protocol_filter={"SMART", "IOT"})

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -2,7 +2,7 @@ import pytest
 
 from kasa import EmeterStatus, SmartDeviceException
 
-from .conftest import has_emeter, no_emeter
+from .conftest import has_emeter, has_emeter_iot, no_emeter
 from .newfakes import CURRENT_CONSUMPTION_SCHEMA
 
 
@@ -20,7 +20,7 @@ async def test_no_emeter(dev):
         await dev.erase_emeter_stats()
 
 
-@has_emeter
+@has_emeter_iot
 async def test_get_emeter_realtime(dev):
     assert dev.has_emeter
 
@@ -28,7 +28,7 @@ async def test_get_emeter_realtime(dev):
     CURRENT_CONSUMPTION_SCHEMA(current_emeter)
 
 
-@has_emeter
+@has_emeter_iot
 @pytest.mark.requires_dummy
 async def test_get_emeter_daily(dev):
     assert dev.has_emeter
@@ -48,7 +48,7 @@ async def test_get_emeter_daily(dev):
     assert v * 1000 == v2
 
 
-@has_emeter
+@has_emeter_iot
 @pytest.mark.requires_dummy
 async def test_get_emeter_monthly(dev):
     assert dev.has_emeter
@@ -68,7 +68,7 @@ async def test_get_emeter_monthly(dev):
     assert v * 1000 == v2
 
 
-@has_emeter
+@has_emeter_iot
 async def test_emeter_status(dev):
     assert dev.has_emeter
 

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -109,7 +109,7 @@ async def test_protocol_reconnect(mocker, retry_count, protocol_class, transport
     response = await protocol_class(host, transport=transport_class(host)).query(
         DUMMY_QUERY, retry_count=retry_count
     )
-    assert "result" in response or "great" in response
+    assert "result" in response or "foobar" in response
     assert send_mock.call_count == retry_count
 
 

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -26,20 +26,29 @@ class _mock_response:
         self.content = content
 
 
+@pytest.mark.parametrize(
+    "error, retry_expectation",
+    [
+        (Exception("dummy exception"), True),
+        (SmartDeviceException("dummy exception"), False),
+    ],
+    ids=("Exception", "SmartDeviceException"),
+)
 @pytest.mark.parametrize("transport_class", [AesTransport, KlapTransport])
 @pytest.mark.parametrize("protocol_class", [IotProtocol, SmartProtocol])
 @pytest.mark.parametrize("retry_count", [1, 3, 5])
-async def test_protocol_retries(mocker, retry_count, protocol_class, transport_class):
+async def test_protocol_retries(
+    mocker, retry_count, protocol_class, transport_class, error, retry_expectation
+):
     host = "127.0.0.1"
-    conn = mocker.patch.object(
-        httpx.AsyncClient, "post", side_effect=Exception("dummy exception")
-    )
+    conn = mocker.patch.object(httpx.AsyncClient, "post", side_effect=error)
     with pytest.raises(SmartDeviceException):
         await protocol_class(host, transport=transport_class(host)).query(
             DUMMY_QUERY, retry_count=retry_count
         )
 
-    assert conn.call_count == retry_count + 1
+    expected_count = retry_count + 1 if retry_expectation else 1
+    assert conn.call_count == expected_count
 
 
 @pytest.mark.parametrize("transport_class", [AesTransport, KlapTransport])

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -8,7 +8,7 @@ import kasa
 from kasa import Credentials, SmartDevice, SmartDeviceException
 from kasa.smartdevice import DeviceType
 
-from .conftest import device_iot, handle_turn_on, has_emeter, no_emeter, turn_on
+from .conftest import device_iot, handle_turn_on, has_emeter, no_emeter_iot, turn_on
 from .newfakes import PLUG_SCHEMA, TZ_SCHEMA, FakeTransportProtocol
 
 # List of all SmartXXX classes including the SmartDevice base class
@@ -48,7 +48,7 @@ async def test_initial_update_emeter(dev, mocker):
     assert spy.call_count == expected_queries + len(dev.children)
 
 
-@no_emeter
+@no_emeter_iot
 async def test_initial_update_no_emeter(dev, mocker):
     """Test that the initial update performs second query if emeter is available."""
     dev._last_update = None

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -1,0 +1,81 @@
+import errno
+import json
+import logging
+import secrets
+import struct
+import sys
+import time
+from contextlib import nullcontext as does_not_raise
+from itertools import chain
+
+import httpx
+import pytest
+
+from ..aestransport import AesTransport
+from ..credentials import Credentials
+from ..exceptions import (
+    SMART_RETRYABLE_ERRORS,
+    SMART_TIMEOUT_ERRORS,
+    SmartDeviceException,
+    SmartErrorCode,
+)
+from ..iotprotocol import IotProtocol
+from ..klaptransport import KlapEncryptionSession, KlapTransport, _sha256
+from ..smartprotocol import SmartProtocol
+
+DUMMY_QUERY = {"foobar": {"foo": "bar", "bar": "foo"}}
+ERRORS = [e for e in SmartErrorCode if e != 0]
+
+
+@pytest.mark.parametrize("error_code", ERRORS, ids=lambda e: e.name)
+async def test_smart_device_errors(mocker, error_code):
+    host = "127.0.0.1"
+    mock_response = {"result": {"great": "success"}, "error_code": error_code.value}
+
+    mocker.patch.object(AesTransport, "perform_handshake")
+    mocker.patch.object(AesTransport, "perform_login")
+
+    send_mock = mocker.patch.object(AesTransport, "send", return_value=mock_response)
+
+    protocol = SmartProtocol(host, transport=AesTransport(host))
+    with pytest.raises(SmartDeviceException):
+        await protocol.query(DUMMY_QUERY, retry_count=2)
+
+    if error_code in chain(SMART_TIMEOUT_ERRORS, SMART_RETRYABLE_ERRORS):
+        expected_calls = 3
+    else:
+        expected_calls = 1
+    assert send_mock.call_count == expected_calls
+
+
+@pytest.mark.parametrize("error_code", ERRORS, ids=lambda e: e.name)
+async def test_smart_device_errors_in_multiple_request(mocker, error_code):
+    host = "127.0.0.1"
+    mock_response = {
+        "result": {
+            "responses": [
+                {"method": "foobar1", "result": {"great": "success"}, "error_code": 0},
+                {
+                    "method": "foobar2",
+                    "result": {"great": "success"},
+                    "error_code": error_code.value,
+                },
+                {"method": "foobar3", "result": {"great": "success"}, "error_code": 0},
+            ]
+        },
+        "error_code": 0,
+    }
+
+    mocker.patch.object(AesTransport, "perform_handshake")
+    mocker.patch.object(AesTransport, "perform_login")
+
+    send_mock = mocker.patch.object(AesTransport, "send", return_value=mock_response)
+
+    protocol = SmartProtocol(host, transport=AesTransport(host))
+    with pytest.raises(SmartDeviceException):
+        await protocol.query(DUMMY_QUERY, retry_count=2)
+    if error_code in chain(SMART_TIMEOUT_ERRORS, SMART_RETRYABLE_ERRORS):
+        expected_calls = 3
+    else:
+        expected_calls = 1
+    assert send_mock.call_count == expected_calls


### PR DESCRIPTION
Hopefully a nice and small PR to enable `multipleRequest` in `smartprotocol` and the test framework.

A subsequent PRs will introduce the smart request helper functions and use the `component_nego` result to determine which requests to make rather than hardcoding.