### PR TITLE
Elevate --verbose to top-level option

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -128,7 +128,23 @@ def json_formatter_cb(result, **kwargs):
     show_default=True,
     help="The broadcast address to be used for discovery.",
 )
-@click.option("-d", "--debug", envvar="KASA_DEBUG", default=False, is_flag=True)
+@click.option(
+    "-v",
+    "--verbose",
+    envvar="KASA_VERBOSE",
+    required=False,
+    default=False,
+    is_flag=True,
+    help="Be more verbose on output",
+)
+@click.option(
+    "-d",
+    "--debug",
+    envvar="KASA_DEBUG",
+    default=False,
+    is_flag=True,
+    help="Print debug output",
+)
 @click.option(
     "--type",
     envvar="KASA_TYPE",
@@ -147,6 +163,7 @@ def json_formatter_cb(result, **kwargs):
     envvar="KASA_TIMEOUT",
     default=5,
     required=False,
+    show_default=True,
     help="Timeout for device communications.",
 )
 @click.option(
@@ -154,6 +171,7 @@ def json_formatter_cb(result, **kwargs):
     envvar="KASA_DISCOVERY_TIMEOUT",
     default=3,
     required=False,
+    show_default=True,
     help="Timeout for discovery.",
 )
 @click.option(
@@ -178,6 +196,7 @@ async def cli(
     port,
     alias,
     target,
+    verbose,
     debug,
     type,
     json,
@@ -307,21 +326,14 @@ async def join(dev: SmartDevice, ssid, password, keytype):
 
 
 @cli.command()
-@click.option(
-    "--verbose",
-    envvar="KASA_VERBOSE",
-    required=False,
-    default=False,
-    is_flag=True,
-    help="Be more verbose on output",
-)
 @click.pass_context
-async def discover(ctx, verbose):
+async def discover(ctx):
     """Discover devices in the network."""
     target = ctx.parent.params["target"]
     username = ctx.parent.params["username"]
     password = ctx.parent.params["password"]
     timeout = ctx.parent.params["discovery_timeout"]
+    verbose = ctx.parent.params["verbose"]
 
     credentials = Credentials(username, password)
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -236,8 +236,8 @@ async def test_discover(discovery_mock, mocker):
             "foo",
             "--password",
             "bar",
-            "discover",
             "--verbose",
+            "discover",
         ],
     )
     assert res.exit_code == 0
@@ -255,8 +255,8 @@ async def test_discover_unsupported(unsupported_device_info):
             "foo",
             "--password",
             "bar",
-            "discover",
             "--verbose",
+            "discover",
         ],
     )
     assert res.exit_code == 0
@@ -306,8 +306,8 @@ async def test_discover_auth_failed(discovery_mock, mocker):
             "foo",
             "--password",
             "bar",
-            "discover",
             "--verbose",
+            "discover",
         ],
     )
 


### PR DESCRIPTION
* `--verbose` is not anymore specific to discover command
* `-v` shortcut can be used to activate it, similarly as `-d` works for `--debug`