### PR TITLE
Pull up emeter handling to tapodevice base class

### DIFF
--- a/kasa/tapo/tapobulb.py
+++ b/kasa/tapo/tapobulb.py
@@ -18,17 +18,6 @@ class TapoBulb(TapoDevice, SmartBulb):
     """
 
     @property
-    def has_emeter(self) -> bool:
-        """Bulbs have only historical emeter.
-
-        {'usage':
-        'power_usage': {'today': 6, 'past7': 106, 'past30': 106},
-        'saved_power': {'today': 35, 'past7': 529, 'past30': 529},
-        }
-        """
-        return False
-
-    @property
     def is_color(self) -> bool:
         """Whether the bulb supports color changes."""
         # TODO: this makes an assumption that only color bulbs report this

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -65,7 +65,7 @@ class TapoDevice(SmartDevice):
         }
 
         resp = await self.protocol.query(req)
-        
+
         self._info = resp["get_device_info"]
         self._usage = resp["get_device_usage"]
         self._time = resp["get_device_time"]
@@ -89,11 +89,6 @@ class TapoDevice(SmartDevice):
         if "energy_monitoring" in self._components:
             self.emeter_type = "emeter"
             self.modules["emeter"] = Emeter(self, self.emeter_type)
-
-    @property
-    def supported_modules(self) -> List[str]:
-        """Return list of components for now."""
-        return list(self._components.keys())
 
     @property
     def sys_info(self) -> Dict[str, Any]:

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -41,7 +41,6 @@ class TapoDevice(SmartDevice):
         if self.credentials is None or self.credentials.username is None:
             raise AuthenticationException("Tapo plug requires authentication.")
 
-        extra_reqs: Dict[str, Any] = {}
         if self._components_raw is None:
             resp = await self.protocol.query("component_nego")
             self._components_raw = resp["component_nego"]
@@ -51,6 +50,7 @@ class TapoDevice(SmartDevice):
             }
             await self._initialize_modules()
 
+        extra_reqs: Dict[str, Any] = {}
         if "energy_monitoring" in self._components:
             extra_reqs = {
                 **extra_reqs,

--- a/kasa/tapo/tapoplug.py
+++ b/kasa/tapo/tapoplug.py
@@ -5,9 +5,8 @@ from typing import Any, Dict, Optional, cast
 
 from ..deviceconfig import DeviceConfig
 from ..emeterstatus import EmeterStatus
-from ..modules import Emeter
 from ..protocol import TPLinkProtocol
-from ..smartdevice import DeviceType, requires_update
+from ..smartdevice import DeviceType
 from .tapodevice import TapoDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,15 +24,6 @@ class TapoPlug(TapoDevice):
     ) -> None:
         super().__init__(host=host, config=config, protocol=protocol)
         self._device_type = DeviceType.Plug
-        self.modules: Dict[str, Any] = {}
-        self.emeter_type = "emeter"
-        self.modules["emeter"] = Emeter(self, self.emeter_type)
-
-    @property  # type: ignore
-    @requires_update
-    def has_emeter(self) -> bool:
-        """Return that the plug has an emeter."""
-        return True
 
     async def update(self, update_children: bool = True):
         """Call the device endpoint and update the device data."""

--- a/kasa/tapo/tapoplug.py
+++ b/kasa/tapo/tapoplug.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, cast
 
 from ..deviceconfig import DeviceConfig
-from ..emeterstatus import EmeterStatus
 from ..protocol import TPLinkProtocol
 from ..smartdevice import DeviceType
 from .tapodevice import TapoDevice
@@ -25,23 +24,6 @@ class TapoPlug(TapoDevice):
         super().__init__(host=host, config=config, protocol=protocol)
         self._device_type = DeviceType.Plug
 
-    async def update(self, update_children: bool = True):
-        """Call the device endpoint and update the device data."""
-        await super().update(update_children)
-
-        req = {
-            "get_energy_usage": None,
-            "get_current_power": None,
-        }
-        resp = await self.protocol.query(req)
-        self._energy = resp["get_energy_usage"]
-        self._emeter = resp["get_current_power"]
-
-        self._data["energy"] = self._energy
-        self._data["emeter"] = self._emeter
-
-        _LOGGER.debug("Got an update: %s %s", self._energy, self._emeter)
-
     @property
     def state_information(self) -> Dict[str, Any]:
         """Return the key state information."""
@@ -55,42 +37,9 @@ class TapoPlug(TapoDevice):
         }
 
     @property
-    def emeter_realtime(self) -> EmeterStatus:
-        """Get the emeter status."""
-        return EmeterStatus(
-            {
-                "power_mw": self._energy.get("current_power"),
-                "total": self._convert_energy_data(
-                    self._energy.get("today_energy"), 1 / 1000
-                ),
-            }
-        )
-
-    async def get_emeter_realtime(self) -> EmeterStatus:
-        """Retrieve current energy readings."""
-        self._verify_emeter()
-        resp = await self.protocol.query("get_energy_usage")
-        self._energy = resp["get_energy_usage"]
-        return self.emeter_realtime
-
-    @property
-    def emeter_today(self) -> Optional[float]:
-        """Get the emeter value for today."""
-        return self._convert_energy_data(self._energy.get("today_energy"), 1 / 1000)
-
-    @property
-    def emeter_this_month(self) -> Optional[float]:
-        """Get the emeter value for this month."""
-        return self._convert_energy_data(self._energy.get("month_energy"), 1 / 1000)
-
-    @property
     def on_since(self) -> Optional[datetime]:
         """Return the time that the device was turned on or None if turned off."""
         if not self._info.get("device_on"):
             return None
         on_time = cast(float, self._info.get("on_time"))
         return datetime.now().replace(microsecond=0) - timedelta(seconds=on_time)
-
-    def _convert_energy_data(self, data, scale) -> Optional[float]:
-        """Return adjusted emeter information."""
-        return data if not data else data * scale

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -7,7 +7,7 @@ import pytest  # type: ignore # https://github.com/pytest-dev/pytest/issues/3342
 import kasa
 from kasa import Credentials, DeviceConfig, SmartDevice, SmartDeviceException
 
-from .conftest import device_iot, handle_turn_on, has_emeter, no_emeter_iot, turn_on
+from .conftest import device_iot, handle_turn_on, has_emeter_iot, no_emeter_iot, turn_on
 from .newfakes import PLUG_SCHEMA, TZ_SCHEMA, FakeTransportProtocol
 
 # List of all SmartXXX classes including the SmartDevice base class
@@ -35,7 +35,7 @@ async def test_invalid_connection(dev):
         await dev.update()
 
 
-@has_emeter
+@has_emeter_iot
 async def test_initial_update_emeter(dev, mocker):
     """Test that the initial update performs second query if emeter is available."""
     dev._last_update = None


### PR DESCRIPTION
This will also use the existence of energy_monitoring in the component_nego query to decide if the device has the service, making it accessible for non-plug devices which may have the feature.

The way how extra requests based on available components are handled requires some thinking, but I suppose this is better than what we had.