### PR TITLE
Implement wifi interface for tapodevice

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -345,10 +345,10 @@ async def scan(dev):
 
 @wifi.command()
 @click.argument("ssid")
+@click.option("--keytype", prompt=True)
 @click.option("--password", prompt=True, hide_input=True)
-@click.option("--keytype", default=3)
 @pass_dev
-async def join(dev: SmartDevice, ssid, password, keytype):
+async def join(dev: SmartDevice, ssid: str, password: str, keytype: str):
     """Join the given wifi network."""
     echo(f"Asking the device to connect to {ssid}..")
     res = await dev.wifi_join(ssid, password, keytype=keytype)

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -42,6 +42,9 @@ class WifiNetwork:
     channel: Optional[int] = None
     rssi: Optional[int] = None
 
+    # For SMART devices
+    signal_level: Optional[int] = None
+
 
 def merge(d, u):
     """Update dict recursively."""
@@ -687,7 +690,7 @@ class SmartDevice:
 
         return [WifiNetwork(**x) for x in info["ap_list"]]
 
-    async def wifi_join(self, ssid, password, keytype=3):  # noqa: D202
+    async def wifi_join(self, ssid: str, password: str, keytype: str = "3"):  # noqa: D202
         """Join the given wifi network.
 
         If joining the network fails, the device will return to AP mode after a while.
@@ -696,7 +699,7 @@ class SmartDevice:
         async def _join(target, payload):
             return await self._query_helper(target, "set_stainfo", payload)
 
-        payload = {"ssid": ssid, "password": password, "key_type": keytype}
+        payload = {"ssid": ssid, "password": password, "key_type": int(keytype)}
         try:
             return await _join("netif", payload)
         except SmartDeviceException as ex:

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -6,8 +6,8 @@ from typing import Any, Dict, List, Optional, Set, cast
 
 from ..aestransport import AesTransport
 from ..deviceconfig import DeviceConfig
-from ..exceptions import AuthenticationException, SmartDeviceException
 from ..emeterstatus import EmeterStatus
+from ..exceptions import AuthenticationException, SmartDeviceException
 from ..modules import Emeter
 from ..protocol import TPLinkProtocol
 from ..smartdevice import SmartDevice, WifiNetwork


### PR DESCRIPTION
Implement `wifi_scan` and `wifi_join` for SMART devices, allows to change the wifi settings using the cli.

This maybe helpful for #565 if some of those known hardcoded creds work for non-provisioned setups.
Tested to work on P110.
