### PR TITLE
Allow serializing and passing of credentials_hashes in DeviceConfig

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -67,7 +67,7 @@ class AesTransport(BaseTransport):
         if not self._credentials and not self._credentials_hash:
             self._credentials = Credentials()
         if self._credentials:
-            self._login_params = self.get_login_params()
+            self._login_params = self._get_login_params()
         else:
             self._login_params = json_loads(
                 base64.b64decode(self._credentials_hash.encode()).decode()  # type: ignore[union-attr]
@@ -92,7 +92,7 @@ class AesTransport(BaseTransport):
         return self.DEFAULT_PORT
 
     @property
-    def credentials_hash(self) -> Optional[str]:
+    def credentials_hash(self) -> str:
         """The hashed credentials used by the transport."""
         return base64.b64encode(json_dumps(self._login_params).encode()).decode()
 
@@ -104,7 +104,7 @@ class AesTransport(BaseTransport):
             self._default_http_client = httpx.AsyncClient()
         return self._default_http_client
 
-    def get_login_params(self):
+    def _get_login_params(self):
         """Get the login parameters based on the login_version."""
         un, pw = self.hash_credentials(self._login_version == 2)
         password_field_name = "password2" if self._login_version == 2 else "password"

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -224,6 +224,7 @@ def json_formatter_cb(result, **kwargs):
     "--credentials-hash",
     default=None,
     required=False,
+    envvar="KASA_CREDENTIALS_HASH",
     help="Hashed credentials used to authenticate to the device.",
 )
 @click.version_option(package_name="python-kasa")
@@ -317,7 +318,7 @@ async def cli(
     if type is not None:
         dev = TYPE_TO_CLASS[type](host)
         await dev.update()
-    elif device_family and encrypt_type and login_version:
+    elif device_family and encrypt_type:
         ctype = ConnectionType(
             DeviceFamilyType(device_family),
             EncryptType(encrypt_type),

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -422,7 +422,9 @@ class Discover:
 
         try:
             config.connection_type = ConnectionType.from_values(
-                type_, discovery_result.mgt_encrypt_schm.encrypt_type
+                type_,
+                discovery_result.mgt_encrypt_schm.encrypt_type,
+                discovery_result.mgt_encrypt_schm.lv,
             )
         except SmartDeviceException as ex:
             raise UnsupportedDeviceException(

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -126,7 +126,7 @@ class KlapTransport(BaseTransport):
         return self.DEFAULT_PORT
 
     @property
-    def credentials_hash(self) -> Optional[str]:
+    def credentials_hash(self) -> str:
         """The hashed credentials used by the transport."""
         return base64.b64encode(self._local_auth_hash).decode()
 

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -66,7 +66,7 @@ class BaseTransport(ABC):
 
     @property
     @abstractmethod
-    def credentials_hash(self) -> Optional[str]:
+    def credentials_hash(self) -> str:
         """The hashed credentials used by the transport."""
 
     @abstractmethod
@@ -127,9 +127,9 @@ class _XorTransport(BaseTransport):
         return self.DEFAULT_PORT
 
     @property
-    def credentials_hash(self) -> Optional[str]:
+    def credentials_hash(self) -> str:
         """The hashed credentials used by the transport."""
-        return None
+        return ""
 
     async def send(self, request: str) -> Dict:
         """Send a message to the device and return a response."""

--- a/kasa/protocol.py
+++ b/kasa/protocol.py
@@ -56,12 +56,18 @@ class BaseTransport(ABC):
         self._host = config.host
         self._port = config.port_override or self.default_port
         self._credentials = config.credentials
+        self._credentials_hash = config.credentials_hash
         self._timeout = config.timeout
 
     @property
     @abstractmethod
     def default_port(self) -> int:
         """The default port for the transport."""
+
+    @property
+    @abstractmethod
+    def credentials_hash(self) -> Optional[str]:
+        """The hashed credentials used by the transport."""
 
     @abstractmethod
     async def send(self, request: str) -> Dict:
@@ -119,6 +125,11 @@ class _XorTransport(BaseTransport):
     def default_port(self):
         """Default port for the transport."""
         return self.DEFAULT_PORT
+
+    @property
+    def credentials_hash(self) -> Optional[str]:
+        """The hashed credentials used by the transport."""
+        return None
 
     async def send(self, request: str) -> Dict:
         """Send a message to the device and return a response."""

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -242,6 +242,11 @@ class SmartDevice:
         """The device credentials."""
         return self.protocol._transport._credentials
 
+    @property
+    def credentials_hash(self) -> Optional[str]:
+        """Return the connection parameters the device is using."""
+        return self.protocol._transport.credentials_hash
+
     def add_module(self, name: str, module: Module):
         """Register a module."""
         if name in self.modules:

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -38,8 +38,8 @@ class TapoDevice(SmartDevice):
 
     async def update(self, update_children: bool = True):
         """Update the device."""
-        if self.credentials is None:
-            raise AuthenticationException("Device requires authentication.")
+        if self.credentials is None and self.credentials_hash is None:
+            raise AuthenticationException("Tapo plug requires authentication.")
 
         if self._components_raw is None:
             resp = await self.protocol.query("component_nego")

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -430,6 +430,7 @@ def discovery_mock(all_fixture_data, mocker):
         query_data: dict
         device_type: str
         encrypt_type: str
+        login_version: Optional[int] = None
         port_override: Optional[int] = None
 
     if "discovery_result" in all_fixture_data:
@@ -438,6 +439,9 @@ def discovery_mock(all_fixture_data, mocker):
         encrypt_type = all_fixture_data["discovery_result"]["mgt_encrypt_schm"][
             "encrypt_type"
         ]
+        login_version = all_fixture_data["discovery_result"]["mgt_encrypt_schm"].get(
+            "lv"
+        )
         datagram = (
             b"\x02\x00\x00\x01\x01[\x00\x00\x00\x00\x00\x00W\xcev\xf8"
             + json_dumps(discovery_data).encode()
@@ -450,12 +454,14 @@ def discovery_mock(all_fixture_data, mocker):
             all_fixture_data,
             device_type,
             encrypt_type,
+            login_version,
         )
     else:
         sys_info = all_fixture_data["system"]["get_sysinfo"]
         discovery_data = {"system": {"get_sysinfo": sys_info}}
         device_type = sys_info.get("mic_type") or sys_info.get("type")
         encrypt_type = "XOR"
+        login_version = None
         datagram = TPLinkSmartHomeProtocol.encrypt(json_dumps(discovery_data))[4:]
         dm = _DiscoveryMock(
             "127.0.0.123",
@@ -465,6 +471,7 @@ def discovery_mock(all_fixture_data, mocker):
             all_fixture_data,
             device_type,
             encrypt_type,
+            login_version,
         )
 
     def mock_discover(self):

--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -1,3 +1,4 @@
+import base64
 import copy
 import logging
 import re
@@ -319,6 +320,11 @@ class FakeSmartTransport(BaseTransport):
     def default_port(self):
         """Default port for the transport."""
         return 80
+
+    @property
+    def credentials_hash(self):
+        """The hashed credentials used by the transport."""
+        return self._credentials.username + self._credentials.password + "hash"
 
     async def send(self, request: str):
         request_dict = json_loads(request)

--- a/kasa/tests/test_deviceconfig.py
+++ b/kasa/tests/test_deviceconfig.py
@@ -19,3 +19,30 @@ def test_serialization():
     config2_dict = json_loads(config_json)
     config2 = DeviceConfig.from_dict(config2_dict)
     assert config == config2
+
+
+def test_credentials_hash():
+    config = DeviceConfig(
+        host="Foo",
+        http_client=httpx.AsyncClient(),
+        credentials=Credentials("foo", "bar"),
+    )
+    config_dict = config.to_dict(credentials_hash="credhash")
+    config_json = json_dumps(config_dict)
+    config2_dict = json_loads(config_json)
+    config2 = DeviceConfig.from_dict(config2_dict)
+    assert config2.credentials_hash == "credhash"
+    assert config2.credentials is None
+
+
+def test_no_credentials_serialization():
+    config = DeviceConfig(
+        host="Foo",
+        http_client=httpx.AsyncClient(),
+        credentials=Credentials("foo", "bar"),
+    )
+    config_dict = config.to_dict(exclude_credentials=True)
+    config_json = json_dumps(config_dict)
+    config2_dict = json_loads(config_json)
+    config2 = DeviceConfig.from_dict(config2_dict)
+    assert config2.credentials is None

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -110,11 +110,17 @@ async def test_discover_single(discovery_mock, custom_port, mocker):
     assert update_mock.call_count == 0
 
     ct = ConnectionType.from_values(
-        discovery_mock.device_type, discovery_mock.encrypt_type
+        discovery_mock.device_type,
+        discovery_mock.encrypt_type,
+        discovery_mock.login_version,
     )
     uses_http = discovery_mock.default_port == 80
     config = DeviceConfig(
-        host=host, port_override=custom_port, connection_type=ct, uses_http=uses_http
+        host=host,
+        port_override=custom_port,
+        connection_type=ct,
+        uses_http=uses_http,
+        credentials=Credentials(),
     )
     assert x.config == config
 

--- a/kasa/tests/test_protocol.py
+++ b/kasa/tests/test_protocol.py
@@ -9,8 +9,11 @@ import sys
 
 import pytest
 
+from ..aestransport import AesTransport
+from ..credentials import Credentials
 from ..deviceconfig import DeviceConfig
 from ..exceptions import SmartDeviceException
+from ..klaptransport import KlapTransport, KlapTransportV2
 from ..protocol import (
     BaseTransport,
     TPLinkProtocol,
@@ -298,3 +301,19 @@ def test_transport_init_signature(class_name_obj):
     assert (
         params[1].name == "config" and params[1].kind == inspect.Parameter.KEYWORD_ONLY
     )
+
+
+@pytest.mark.parametrize(
+    "transport_class", [AesTransport, KlapTransport, KlapTransportV2, _XorTransport]
+)
+async def test_transport_credentials_hash(mocker, transport_class):
+    host = "127.0.0.1"
+
+    credentials = Credentials("Foo", "Bar")
+    config = DeviceConfig(host, credentials=credentials)
+    transport = transport_class(config=config)
+    credentials_hash = transport.credentials_hash
+    config = DeviceConfig(host, credentials_hash=credentials_hash)
+    transport = transport_class(config=config)
+
+    assert transport.credentials_hash == credentials_hash


### PR DESCRIPTION
As per [HA PR discussion](https://github.com/home-assistant/core/pull/105143#discussion_r1439889873) this PR enables the retrieval of the credentials hash and passing back into the `DeviceConfig`.  This will allow devices to persist all of their config without storing clear text credentials for later retrieval and re-use.