### PR TITLE
Ship CHANGELOG only in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,9 @@ readme = "README.md"
 packages = [
   { include = "kasa" }
 ]
-include = ["CHANGELOG.md"]
+include = [
+  { path= "CHANGELOG.md", format = "sdist" }
+]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/python-kasa/python-kasa/issues"


### PR DESCRIPTION
Otherwise, the file would be extracted into the main site-packages which is rather unexpected..

```
Uninstalling python-kasa-0.6.0.dev0:
  Would remove:
    /home/tpr/.virtualenvs/default/bin/kasa
    /home/tpr/.virtualenvs/default/lib/python3.11/site-packages/CHANGELOG.md
    /home/tpr/.virtualenvs/default/lib/python3.11/site-packages/kasa/*
    /home/tpr/.virtualenvs/default/lib/python3.11/site-packages/python_kasa-0.6.0.dev0.dist-info/*
Proceed (Y/n)?
```