### PR TITLE
Fix cli discover bug with None username/password

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -64,7 +64,9 @@ class AesTransport(BaseTransport):
         super().__init__(config=config)
 
         self._login_version = config.connection_type.login_version
-        if not self._credentials and not self._credentials_hash:
+        if (
+            not self._credentials or self._credentials.username is None
+        ) and not self._credentials_hash:
             self._credentials = Credentials()
         if self._credentials:
             self._login_params = self._get_login_params()

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -395,7 +395,7 @@ async def discover(ctx):
     timeout = ctx.parent.params["timeout"]
     port = ctx.parent.params["port"]
 
-    credentials = Credentials(username, password)
+    credentials = Credentials(username, password) if username and password else None
 
     sem = asyncio.Semaphore()
     discovered = dict()

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -100,7 +100,9 @@ class KlapTransport(BaseTransport):
 
         self._default_http_client: Optional[httpx.AsyncClient] = None
         self._local_seed: Optional[bytes] = None
-        if not self._credentials and not self._credentials_hash:
+        if (
+            not self._credentials or self._credentials.username is None
+        ) and not self._credentials_hash:
             self._credentials = Credentials()
         if self._credentials:
             self._local_auth_hash = self.generate_auth_hash(self._credentials)


### PR DESCRIPTION
https://github.com/python-kasa/python-kasa/pull/607 introduced a bug when calling `kasa` without any `--username` and `--password` for devices requiring authentication.  This PR fixes the bug and ensures that `Credentials` created with `None` values will be replaced with empty string credentials.