### PR TITLE
Add update-credentials command

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -999,11 +999,25 @@ async def turn_on_behavior(dev: SmartBulb, type, last, preset):
 
 @cli.command()
 @pass_dev
-@click.option("--username")
-@click.option("--password")
-async def change_credentials(dev, username, password):
-    """Change device credentials for authenticated devices."""
-    return await dev.change_credentials(username, password)
+@click.option(
+    "--username", required=True, prompt=True, help="New username to set on the device"
+)
+@click.option(
+    "--password", required=True, prompt=True, help="New password to set on the device"
+)
+async def update_credentials(dev, username, password):
+    """Update device credentials for authenticated devices."""
+    # Importing here as this is not really a public interface for now
+    from kasa.tapo import TapoDevice
+
+    if not isinstance(dev, TapoDevice):
+        raise NotImplementedError(
+            "Credentials can only be updated on authenticated devices."
+        )
+
+    click.confirm("Do you really want to replace the existing credentials?", abort=True)
+
+    return await dev.update_credentials(username, password)
 
 
 if __name__ == "__main__":

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -997,5 +997,14 @@ async def turn_on_behavior(dev: SmartBulb, type, last, preset):
     return await dev.set_turn_on_behavior(settings)
 
 
+@cli.command()
+@pass_dev
+@click.option("--username")
+@click.option("--password")
+async def change_credentials(dev, username, password):
+    """Change device credentials for authenticated devices."""
+    return await dev.change_credentials(username, password)
+
+
 if __name__ == "__main__":
     cli()

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -321,3 +321,15 @@ class TapoDevice(SmartDevice):
                 raise
 
             _LOGGER.debug("Received an expected for wifi join, but this is expected")
+
+    async def change_credentials(self, username: str, password: str):
+        """Change device credentials."""
+        t = self.internal_state["time"]
+        payload = {
+            "account": {
+                "username": base64.b64encode(username.encode()).decode(),
+                "password": base64.b64encode(password.encode()).decode(),
+            },
+            "time": t,
+        }
+        return await self.protocol.query({"set_qs_info": payload})

--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -322,8 +322,11 @@ class TapoDevice(SmartDevice):
 
             _LOGGER.debug("Received an expected for wifi join, but this is expected")
 
-    async def change_credentials(self, username: str, password: str):
-        """Change device credentials."""
+    async def update_credentials(self, username: str, password: str):
+        """Update device credentials.
+
+        This will replace the existing authentication credentials on the device.
+        """
         t = self.internal_state["time"]
         payload = {
             "account": {


### PR DESCRIPTION
This allows changing the credentials stored in the device, e.g., after provisioning the device. In my personal tests on L900, this changed the credentials from the provisioning creds to my own just fine while still returning a json decode error as response. Maybe some mandatory elements are missing there, but this might still be useful for someone.

As the side effects besides breaking connectivity using previous credentials are unknown, the cli will prompt for confirmation before proceeding.