### PR TITLE
Avoid linear search for emeter realtime and emeter_today

### DIFF
--- a/kasa/modules/usage.py
+++ b/kasa/modules/usage.py
@@ -10,8 +10,9 @@ class Usage(Module):
 
     def query(self):
         """Return the base query."""
-        year = datetime.now().year
-        month = datetime.now().month
+        now = datetime.now()
+        year = now.year
+        month = now.month
 
         req = self.query_for_command("get_realtime")
         req = merge(
@@ -40,21 +41,21 @@ class Usage(Module):
     def usage_today(self):
         """Return today's usage in minutes."""
         today = datetime.now().day
-        converted = [x["time"] for x in self.daily_data if x["day"] == today]
-        if not converted:
-            return None
-
-        return converted.pop()
+        # Traverse the list in reverse order to find the latest entry.
+        for entry in reversed(self.daily_data):
+            if entry["day"] == today:
+                return entry["time"]
+        return None
 
     @property
     def usage_this_month(self):
         """Return usage in this month in minutes."""
         this_month = datetime.now().month
-        converted = [x["time"] for x in self.monthly_data if x["month"] == this_month]
-        if not converted:
-            return None
-
-        return converted.pop()
+        # Traverse the list in reverse order to find the latest entry.
+        for entry in reversed(self.monthly_data):
+            if entry["month"] == this_month:
+                return entry["time"]
+        return None
 
     async def get_raw_daystat(self, *, year=None, month=None) -> Dict:
         """Return raw daily stats for the given year & month."""

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -123,7 +123,7 @@ async def test_emeterstatus_missing_current():
 
 
 async def test_emeter_daily():
-    """Test that the emeter daily data is sorted by day.
+    """Test fetching the emeter for today.
 
     This test uses inline data since the fixtures
     will not have data for the current day.

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -1,6 +1,10 @@
+import datetime
+from unittest.mock import Mock
+
 import pytest
 
 from kasa import EmeterStatus, SmartDeviceException
+from kasa.modules.emeter import Emeter
 
 from .conftest import has_emeter, has_emeter_iot, no_emeter
 from .newfakes import CURRENT_CONSUMPTION_SCHEMA
@@ -116,3 +120,32 @@ async def test_emeterstatus_missing_current():
 
     missing_current = EmeterStatus({"err_code": 0, "power_mw": 0, "total_wh": 13})
     assert missing_current["current"] is None
+
+
+async def test_emeter_daily():
+    """Test that the emeter daily data is sorted by day.
+
+    This test uses inline data since the fixtures
+    will not have data for the current day.
+    """
+    emeter_data = {
+        "get_daystat": {
+            "day_list": [{"day": 1, "energy_wh": 8, "month": 1, "year": 2023}],
+            "err_code": 0,
+        }
+    }
+
+    class MockEmeter(Emeter):
+        @property
+        def data(self):
+            return emeter_data
+
+    emeter = MockEmeter(Mock(), "emeter")
+    now = datetime.datetime.now()
+    day = now.day
+    month = now.month
+    year = now.year
+    emeter_data["get_daystat"]["day_list"].append(
+        {"day": day, "energy_wh": 500, "month": month, "year": year}
+    )
+    assert emeter.emeter_today == 0.500

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -142,10 +142,7 @@ async def test_emeter_daily():
 
     emeter = MockEmeter(Mock(), "emeter")
     now = datetime.datetime.now()
-    day = now.day
-    month = now.month
-    year = now.year
     emeter_data["get_daystat"]["day_list"].append(
-        {"day": day, "energy_wh": 500, "month": month, "year": year}
+        {"day": now.day, "energy_wh": 500, "month": now.month, "year": now.year}
     )
     assert emeter.emeter_today == 0.500

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -46,8 +46,12 @@ def test_usage_today():
     usage = MockUsage(Mock(), "usage")
     assert usage.usage_today is None
     now = datetime.datetime.now()
-    emeter_data["get_daystat"]["day_list"].append(
-        {"day": now.day, "time": 500, "month": now.month, "year": now.year}
+    emeter_data["get_daystat"]["day_list"].extend(
+        [
+            {"day": now.day - 1, "time": 200, "month": now.month - 1, "year": now.year},
+            {"day": now.day, "time": 500, "month": now.month, "year": now.year},
+            {"day": now.day + 1, "time": 100, "month": now.month + 1, "year": now.year},
+        ]
     )
     assert usage.usage_today == 500
 
@@ -73,7 +77,11 @@ def test_usage_this_month():
     usage = MockUsage(Mock(), "usage")
     assert usage.usage_this_month is None
     now = datetime.datetime.now()
-    emeter_data["get_monthstat"]["month_list"].append(
-        {"time": 500, "month": now.month, "year": now.year}
+    emeter_data["get_monthstat"]["month_list"].extend(
+        [
+            {"time": 200, "month": now.month - 1, "year": now.year},
+            {"time": 500, "month": now.month, "year": now.year},
+            {"time": 100, "month": now.month + 1, "year": now.year},
+        ]
     )
     assert usage.usage_this_month == 500

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -1,3 +1,6 @@
+import datetime
+from unittest.mock import Mock
+
 import pytest
 
 from kasa.modules import Usage
@@ -20,3 +23,60 @@ def test_usage_convert_stat_data():
     assert isinstance(k, int)
     assert isinstance(v, int)
     assert k == 4 and v == 30
+
+
+def test_usage_today():
+    """Test fetching the usage for today.
+
+    This test uses inline data since the fixtures
+    will not have data for the current day.
+    """
+    emeter_data = {
+        "get_daystat": {
+            "day_list": [{"day": 1, "time": 8, "month": 1, "year": 2023}],
+            "err_code": 0,
+        }
+    }
+
+    class MockUsage(Usage):
+        @property
+        def data(self):
+            return emeter_data
+
+    usage = MockUsage(Mock(), "usage")
+    now = datetime.datetime.now()
+    day = now.day
+    month = now.month
+    year = now.year
+    emeter_data["get_daystat"]["day_list"].append(
+        {"day": day, "time": 500, "month": month, "year": year}
+    )
+    assert usage.usage_today == 500
+
+
+def test_usage_this_month():
+    """Test fetching the usage for this month.
+
+    This test uses inline data since the fixtures
+    will not have data for the current month.
+    """
+    emeter_data = {
+        "get_monthstat": {
+            "month_list": [{"time": 8, "month": 1, "year": 2023}],
+            "err_code": 0,
+        }
+    }
+
+    class MockUsage(Usage):
+        @property
+        def data(self):
+            return emeter_data
+
+    usage = MockUsage(Mock(), "usage")
+    now = datetime.datetime.now()
+    month = now.month
+    year = now.year
+    emeter_data["get_monthstat"]["month_list"].append(
+        {"time": 500, "month": month, "year": year}
+    )
+    assert usage.usage_this_month == 500

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -45,11 +45,8 @@ def test_usage_today():
 
     usage = MockUsage(Mock(), "usage")
     now = datetime.datetime.now()
-    day = now.day
-    month = now.month
-    year = now.year
     emeter_data["get_daystat"]["day_list"].append(
-        {"day": day, "time": 500, "month": month, "year": year}
+        {"day": now.day, "time": 500, "month": now.month, "year": now.year}
     )
     assert usage.usage_today == 500
 
@@ -74,9 +71,7 @@ def test_usage_this_month():
 
     usage = MockUsage(Mock(), "usage")
     now = datetime.datetime.now()
-    month = now.month
-    year = now.year
     emeter_data["get_monthstat"]["month_list"].append(
-        {"time": 500, "month": month, "year": year}
+        {"time": 500, "month": now.month, "year": now.year}
     )
     assert usage.usage_this_month == 500

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -33,7 +33,7 @@ def test_usage_today():
     """
     emeter_data = {
         "get_daystat": {
-            "day_list": [{"day": 1, "time": 8, "month": 1, "year": 2023}],
+            "day_list": [],
             "err_code": 0,
         }
     }
@@ -44,6 +44,7 @@ def test_usage_today():
             return emeter_data
 
     usage = MockUsage(Mock(), "usage")
+    assert usage.usage_today is None
     now = datetime.datetime.now()
     emeter_data["get_daystat"]["day_list"].append(
         {"day": now.day, "time": 500, "month": now.month, "year": now.year}
@@ -59,7 +60,7 @@ def test_usage_this_month():
     """
     emeter_data = {
         "get_monthstat": {
-            "month_list": [{"time": 8, "month": 1, "year": 2023}],
+            "month_list": [],
             "err_code": 0,
         }
     }
@@ -70,6 +71,7 @@ def test_usage_this_month():
             return emeter_data
 
     usage = MockUsage(Mock(), "usage")
+    assert usage.usage_this_month is None
     now = datetime.datetime.now()
     emeter_data["get_monthstat"]["month_list"].append(
         {"time": 500, "month": now.month, "year": now.year}


### PR DESCRIPTION
Most of the time the data we want is at the end of the list so we now search backwards to avoid having to scale all the data and throw most of it away.

The longer the device is on and the later it is in the month, the slower the code would get.