### PR TITLE
Get child emeters with CLI

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -642,7 +642,10 @@ async def emeter(dev: SmartDevice, index: int, name: str, year, month, erase):
         usage_data = await dev.get_emeter_daily(year=month.year, month=month.month)
     else:
         # Call with no argument outputs summary data and returns
-        emeter_status = await dev.get_emeter_realtime()
+        if index is not None or name is not None:
+            emeter_status = await dev.get_emeter_realtime()
+        else:
+            emeter_status = dev.emeter_realtime
 
         echo("Current: %s A" % emeter_status["current"])
         echo("Voltage: %s V" % emeter_status["voltage"])

--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -128,7 +128,7 @@ def get_device_class_from_sys_info(info: Dict[str, Any]) -> Type[SmartDevice]:
 
 def get_device_class_from_family(device_type: str) -> Optional[Type[SmartDevice]]:
     """Return the device class from the type name."""
-    supported_device_types: dict[str, Type[SmartDevice]] = {
+    supported_device_types: Dict[str, Type[SmartDevice]] = {
         "SMART.TAPOPLUG": TapoPlug,
         "SMART.TAPOBULB": TapoBulb,
         "SMART.KASAPLUG": TapoPlug,
@@ -147,7 +147,7 @@ def get_protocol(
     protocol_transport_key = (
         protocol_name + "." + config.connection_type.encryption_type.value
     )
-    supported_device_protocols: dict[
+    supported_device_protocols: Dict[
         str, Tuple[Type[TPLinkProtocol], Type[BaseTransport]]
     ] = {
         "IOT.XOR": (TPLinkSmartHomeProtocol, _XorTransport),


### PR DESCRIPTION
Support getting child plug emeter status from power strips such as the HS300 via the CLI.

Fixes https://github.com/python-kasa/python-kasa/issues/462