### PR TITLE
Update config to_dict to exclude credentials if the hash is empty string

### DIFF
--- a/kasa/deviceconfig.py
+++ b/kasa/deviceconfig.py
@@ -165,7 +165,7 @@ class DeviceConfig:
         exclude_credentials: bool = False,
     ) -> Dict[str, Dict[str, str]]:
         """Convert device config to dict."""
-        if credentials_hash or exclude_credentials:
+        if credentials_hash is not None or exclude_credentials:
             self.credentials = None
         if credentials_hash:
             self.credentials_hash = credentials_hash

--- a/kasa/tests/test_deviceconfig.py
+++ b/kasa/tests/test_deviceconfig.py
@@ -35,7 +35,21 @@ def test_credentials_hash():
     assert config2.credentials is None
 
 
-def test_no_credentials_serialization():
+def test_blank_credentials_hash():
+    config = DeviceConfig(
+        host="Foo",
+        http_client=httpx.AsyncClient(),
+        credentials=Credentials("foo", "bar"),
+    )
+    config_dict = config.to_dict(credentials_hash="")
+    config_json = json_dumps(config_dict)
+    config2_dict = json_loads(config_json)
+    config2 = DeviceConfig.from_dict(config2_dict)
+    assert config2.credentials_hash is None
+    assert config2.credentials is None
+
+
+def test_exclude_credentials():
     config = DeviceConfig(
         host="Foo",
         http_client=httpx.AsyncClient(),


### PR DESCRIPTION
This change will ensure that if an empty string is passed in as the `credential_hash` to `to_dict()` (i.e. the hash from the legacy protocol) that the resulting dict will exclude both the `credentials` and the `credentials_hash`.  This is needed for HA so it doesn't need to be aware of whether to persist the credentials or not and will avoid it saving the cached plain text credentials for legacy devices.