### PR TITLE
Raise TimeoutException on discover_single timeout

### DIFF
--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -25,6 +25,7 @@ from kasa.emeterstatus import EmeterStatus
 from kasa.exceptions import (
     AuthenticationException,
     SmartDeviceException,
+    TimeoutException,
     UnsupportedDeviceException,
 )
 from kasa.iotprotocol import IotProtocol
@@ -60,6 +61,7 @@ __all__ = [
     "SmartLightStrip",
     "AuthenticationException",
     "UnsupportedDeviceException",
+    "TimeoutException",
     "Credentials",
     "DeviceConfig",
     "ConnectionType",

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -23,7 +23,7 @@ from kasa.device_factory import (
     get_protocol,
 )
 from kasa.deviceconfig import ConnectionType, DeviceConfig, EncryptType
-from kasa.exceptions import UnsupportedDeviceException
+from kasa.exceptions import TimeoutException, UnsupportedDeviceException
 from kasa.json import dumps as json_dumps
 from kasa.json import loads as json_loads
 from kasa.protocol import TPLinkSmartHomeProtocol
@@ -351,7 +351,7 @@ class Discover:
             async with asyncio_timeout(discovery_timeout):
                 await event.wait()
         except asyncio.TimeoutError as ex:
-            raise SmartDeviceException(
+            raise TimeoutException(
                 f"Timed out getting discovery response for {host}"
             ) from ex
         finally:


### PR DESCRIPTION
This is to allow consumers (i.e. HA) to handle and try to `SmartDevice.connect()` for legacy.  Raising `SmartDeviceException` is too broad as consumers could try to connect to unsupported devices etc.