### PR TITLE
Fix connection indeterminate state on cancellation

### DIFF
--- a/kasa/tests/test_protocol.py
+++ b/kasa/tests/test_protocol.py
@@ -151,7 +151,8 @@ async def test_protocol_handles_cancellation_during_write(mocker):
         mocker.patch.object(reader, "readexactly", _mock_read)
         return reader, writer
 
-    protocol = TPLinkSmartHomeProtocol("127.0.0.1")
+    config = DeviceConfig("127.0.0.1")
+    protocol = TPLinkSmartHomeProtocol(transport=_XorTransport(config=config))
     mocker.patch("asyncio.open_connection", side_effect=aio_mock_writer)
     with pytest.raises(asyncio.CancelledError):
         await protocol.query({})
@@ -185,7 +186,8 @@ async def test_protocol_handles_cancellation_during_connection(mocker):
         mocker.patch.object(reader, "readexactly", _mock_read)
         return reader, writer
 
-    protocol = TPLinkSmartHomeProtocol("127.0.0.1")
+    config = DeviceConfig("127.0.0.1")
+    protocol = TPLinkSmartHomeProtocol(transport=_XorTransport(config=config))
     mocker.patch("asyncio.open_connection", side_effect=aio_mock_writer)
     with pytest.raises(asyncio.CancelledError):
         await protocol.query({})


### PR DESCRIPTION
If the task the query is running in it cancelled, we do know the state of the connection so we must close. Previously we would not close on BaseException which could result in reading the previous response if the previous query was cancelled after the request had been sent

aiohttp cancels tasks when the connection drops so its possible for the task that the query is running in to get cancelled 

related issue https://github.com/home-assistant/core/issues/107202