### PR TITLE
Encapsulate http client dependency

### DIFF
--- a/devtools/helpers/smartrequests.py
+++ b/devtools/helpers/smartrequests.py
@@ -30,7 +30,6 @@ from dataclasses import asdict, dataclass
 from typing import List, Optional, Union
 
 _LOGGER = logging.getLogger(__name__)
-logging.getLogger("httpx").propagate = False
 
 
 class SmartRequest:

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -8,7 +8,7 @@ import base64
 import hashlib
 import logging
 import time
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 
 from cryptography.hazmat.primitives import padding, serialization
 from cryptography.hazmat.primitives.asymmetric import padding as asymmetric_padding
@@ -27,7 +27,7 @@ from .exceptions import (
     SmartErrorCode,
     TimeoutException,
 )
-from .httpclientsession import HttpClientSession
+from .httpclient import HttpClient
 from .json import dumps as json_dumps
 from .json import loads as json_loads
 from .protocol import BaseTransport
@@ -75,7 +75,7 @@ class AesTransport(BaseTransport):
                 base64.b64decode(self._credentials_hash.encode()).decode()  # type: ignore[union-attr]
             )
 
-        self._http_client: HttpClientSession = HttpClientSession(config)
+        self._http_client: HttpClient = HttpClient(config)
 
         self._handshake_done = False
 
@@ -160,6 +160,7 @@ class AesTransport(BaseTransport):
                 + f"status code {status_code} to passthrough"
             )
 
+        resp_dict = cast(Dict, resp_dict)
         self._handle_response_error_code(
             resp_dict, "Error sending secure_passthrough message"
         )

--- a/kasa/deviceconfig.py
+++ b/kasa/deviceconfig.py
@@ -2,10 +2,13 @@
 import logging
 from dataclasses import asdict, dataclass, field, fields, is_dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Dict, Optional, Union
 
 from .credentials import Credentials
 from .exceptions import SmartDeviceException
+
+if TYPE_CHECKING:
+    from httpx import AsyncClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -148,7 +151,7 @@ class DeviceConfig:
 
     # compare=False will be excluded from the serialization and object comparison.
     #: Set a custom http_client for the device to use.
-    http_client: Optional[Any] = field(default=None, compare=False)
+    http_client: Optional["AsyncClient"] = field(default=None, compare=False)
 
     def __post_init__(self):
         if self.connection_type is None:

--- a/kasa/deviceconfig.py
+++ b/kasa/deviceconfig.py
@@ -2,9 +2,7 @@
 import logging
 from dataclasses import asdict, dataclass, field, fields, is_dataclass
 from enum import Enum
-from typing import Dict, Optional, Union
-
-import httpx
+from typing import Any, Dict, Optional, Union
 
 from .credentials import Credentials
 from .exceptions import SmartDeviceException
@@ -150,7 +148,7 @@ class DeviceConfig:
 
     # compare=False will be excluded from the serialization and object comparison.
     #: Set a custom http_client for the device to use.
-    http_client: Optional[httpx.AsyncClient] = field(default=None, compare=False)
+    http_client: Optional[Any] = field(default=None, compare=False)
 
     def __post_init__(self):
         if self.connection_type is None:

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -31,6 +31,10 @@ class TimeoutException(SmartDeviceException):
     """Timeout exception for device errors."""
 
 
+class ConnectionException(SmartDeviceException):
+    """Connection exception for device errors."""
+
+
 class SmartErrorCode(IntEnum):
     """Enum for SMART Error Codes."""
 

--- a/kasa/httpclientsession.py
+++ b/kasa/httpclientsession.py
@@ -1,0 +1,88 @@
+"""Module for HttpClientSession class."""
+import logging
+from typing import Dict, Optional, Type
+
+import httpx
+
+from .deviceconfig import DeviceConfig
+from .exceptions import ConnectionException, SmartDeviceException, TimeoutException
+
+logging.getLogger("httpx").propagate = False
+
+InnerHttpType = Type[httpx.AsyncClient]
+
+
+class HttpClientSession:
+    """HttpClientSession Class."""
+
+    def __init__(self, config: DeviceConfig) -> None:
+        self._config = config
+        self._default_client: httpx.AsyncClient = None
+
+    @property
+    def client(self):
+        """Return the underlying http client."""
+        if self._config.http_client and issubclass(
+            self._config.http_client.__class__, httpx.AsyncClient
+        ):
+            return self._config.http_client
+
+        if not self._default_client:
+            self._default_client = httpx.AsyncClient()
+        return self._default_client
+
+    async def post(
+        self,
+        url,
+        params=None,
+        data=None,
+        json=None,
+        headers=None,
+        cookies_dict: Optional[Dict[str, str]] = None,
+    ):
+        """Send an http post request to the device."""
+        response_data = None
+        cookies = None
+        if cookies_dict:
+            cookies = httpx.Cookies()
+            for name, value in cookies_dict.items():
+                cookies.set(name, value)
+        self.client.cookies.clear()
+        try:
+            resp = await self.client.post(
+                url,
+                params=params,
+                data=data,
+                json=json,
+                timeout=self._config.timeout,
+                cookies=cookies,
+                headers=headers,
+            )
+        except httpx.ConnectError as ex:
+            raise ConnectionException(
+                f"Unable to connect to the device: {self._config.host}: {ex}"
+            ) from ex
+        except httpx.TimeoutException as ex:
+            raise TimeoutException(
+                "Unable to query the device, " + f"timed out: {self._config.host}: {ex}"
+            ) from ex
+        except Exception as ex:
+            raise SmartDeviceException(
+                f"Unable to query the device: {self._config.host}: {ex}"
+            ) from ex
+
+        if resp.status_code == 200:
+            response_data = resp.json() if json else resp.content
+
+        return resp.status_code, response_data
+
+    def get_cookie(self, cookie_name):
+        """Return the cookie with cookie_name."""
+        return self._default_client.cookies.get(cookie_name)
+
+    async def close(self) -> None:
+        """Close the protocol."""
+        client = self._default_client
+        self._default_client = None
+        if client:
+            await client.aclose()

--- a/kasa/iotprotocol.py
+++ b/kasa/iotprotocol.py
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 class IotProtocol(TPLinkProtocol):
     """Class for the legacy TPLink IOT KASA Protocol."""
 
-    SLEEP_SECONDS_AFTER_TIMEOUT = 1
+    BACKOFF_SECONDS_AFTER_TIMEOUT = 1
 
     def __init__(
         self,
@@ -67,7 +67,7 @@ class IotProtocol(TPLinkProtocol):
                     await self.close()
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise ex
-                await asyncio.sleep(self.SLEEP_SECONDS_AFTER_TIMEOUT)
+                await asyncio.sleep(self.BACKOFF_SECONDS_AFTER_TIMEOUT)
                 continue
             except SmartDeviceException as ex:
                 await self.close()

--- a/kasa/iotprotocol.py
+++ b/kasa/iotprotocol.py
@@ -3,9 +3,13 @@ import asyncio
 import logging
 from typing import Dict, Union
 
-import httpx
-
-from .exceptions import AuthenticationException, SmartDeviceException
+from .exceptions import (
+    AuthenticationException,
+    ConnectionException,
+    RetryableException,
+    SmartDeviceException,
+    TimeoutException,
+)
 from .json import dumps as json_dumps
 from .protocol import BaseTransport, TPLinkProtocol
 
@@ -14,6 +18,8 @@ _LOGGER = logging.getLogger(__name__)
 
 class IotProtocol(TPLinkProtocol):
     """Class for the legacy TPLink IOT KASA Protocol."""
+
+    SLEEP_SECONDS_AFTER_TIMEOUT = 1
 
     def __init__(
         self,
@@ -38,40 +44,39 @@ class IotProtocol(TPLinkProtocol):
         for retry in range(retry_count + 1):
             try:
                 return await self._execute_query(request, retry)
-            except httpx.ConnectError as sdex:
+            except ConnectionException as sdex:
                 if retry >= retry_count:
                     await self.close()
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
-                    raise SmartDeviceException(
-                        f"Unable to connect to the device: {self._host}: {sdex}"
-                    ) from sdex
+                    raise sdex
                 continue
-            except TimeoutError as tex:
-                await self.close()
-                raise SmartDeviceException(
-                    f"Unable to connect to the device, timed out: {self._host}: {tex}"
-                ) from tex
             except AuthenticationException as auex:
                 await self.close()
                 _LOGGER.debug(
                     "Unable to authenticate with %s, not retrying", self._host
                 )
                 raise auex
+            except RetryableException as ex:
+                if retry >= retry_count:
+                    await self.close()
+                    _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
+                    raise ex
+                continue
+            except TimeoutException as ex:
+                if retry >= retry_count:
+                    await self.close()
+                    _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
+                    raise ex
+                await asyncio.sleep(self.SLEEP_SECONDS_AFTER_TIMEOUT)
+                continue
             except SmartDeviceException as ex:
+                await self.close()
                 _LOGGER.debug(
-                    "Unable to connect to the device: %s, not retrying: %s",
+                    "Unable to query the device: %s, not retrying: %s",
                     self._host,
                     ex,
                 )
                 raise ex
-            except Exception as ex:
-                if retry >= retry_count:
-                    await self.close()
-                    _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
-                    raise SmartDeviceException(
-                        f"Unable to connect to the device: {self._host}: {ex}"
-                    ) from ex
-                continue
 
         # make mypy happy, this should never be reached..
         raise SmartDeviceException("Query reached somehow to unreachable")

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -50,18 +50,17 @@ import time
 from pprint import pformat as pf
 from typing import Any, Optional, Tuple
 
-import httpx
 from cryptography.hazmat.primitives import hashes, padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from .credentials import Credentials
 from .deviceconfig import DeviceConfig
 from .exceptions import AuthenticationException, SmartDeviceException
+from .httpclientsession import HttpClientSession
 from .json import loads as json_loads
 from .protocol import BaseTransport, md5
 
 _LOGGER = logging.getLogger(__name__)
-logging.getLogger("httpx").propagate = False
 
 
 def _sha256(payload: bytes) -> bytes:
@@ -98,7 +97,7 @@ class KlapTransport(BaseTransport):
     ) -> None:
         super().__init__(config=config)
 
-        self._default_http_client: Optional[httpx.AsyncClient] = None
+        self._http_client = HttpClientSession(config)
         self._local_seed: Optional[bytes] = None
         if (
             not self._credentials or self._credentials.username is None
@@ -132,34 +131,6 @@ class KlapTransport(BaseTransport):
         """The hashed credentials used by the transport."""
         return base64.b64encode(self._local_auth_hash).decode()
 
-    @property
-    def _http_client(self) -> httpx.AsyncClient:
-        if self._config.http_client:
-            return self._config.http_client
-        if not self._default_http_client:
-            self._default_http_client = httpx.AsyncClient()
-        return self._default_http_client
-
-    async def client_post(self, url, params=None, data=None):
-        """Send an http post request to the device."""
-        response_data = None
-        cookies = None
-        if self._session_cookie:
-            cookies = httpx.Cookies()
-            cookies.set(self.SESSION_COOKIE_NAME, self._session_cookie)
-        self._http_client.cookies.clear()
-        resp = await self._http_client.post(
-            url,
-            params=params,
-            data=data,
-            timeout=self._timeout,
-            cookies=cookies,
-        )
-        if resp.status_code == 200:
-            response_data = resp.content
-
-        return resp.status_code, response_data
-
     async def perform_handshake1(self) -> Tuple[bytes, bytes, bytes]:
         """Perform handshake1."""
         local_seed: bytes = secrets.token_bytes(16)
@@ -172,7 +143,7 @@ class KlapTransport(BaseTransport):
 
         url = f"http://{self._host}/app/handshake1"
 
-        response_status, response_data = await self.client_post(url, data=payload)
+        response_status, response_data = await self._http_client.post(url, data=payload)
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
@@ -268,7 +239,17 @@ class KlapTransport(BaseTransport):
 
         payload = self.handshake2_seed_auth_hash(local_seed, remote_seed, auth_hash)
 
-        response_status, response_data = await self.client_post(url, data=payload)
+        cookies_dict = (
+            {self.SESSION_COOKIE_NAME: self._session_cookie}
+            if self._session_cookie
+            else None
+        )
+
+        response_status, _ = await self._http_client.post(
+            url,
+            data=payload,
+            cookies_dict=cookies_dict,
+        )
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
@@ -298,7 +279,7 @@ class KlapTransport(BaseTransport):
         self._session_cookie = None
 
         local_seed, remote_seed, auth_hash = await self.perform_handshake1()
-        self._session_cookie = self._http_client.cookies.get(  # type: ignore
+        self._session_cookie = self._http_client.get_cookie(  # type: ignore
             self.SESSION_COOKIE_NAME
         )
         # The device returns a TIMEOUT cookie on handshake1 which
@@ -330,10 +311,16 @@ class KlapTransport(BaseTransport):
 
         url = f"http://{self._host}/app/request"
 
-        response_status, response_data = await self.client_post(
+        cookies_dict = (
+            {self.SESSION_COOKIE_NAME: self._session_cookie}
+            if self._session_cookie
+            else None
+        )
+        response_status, response_data = await self._http_client.post(
             url,
             params={"seq": seq},
             data=payload,
+            cookies_dict=cookies_dict,
         )
 
         msg = (
@@ -374,11 +361,8 @@ class KlapTransport(BaseTransport):
 
     async def close(self) -> None:
         """Close the transport."""
-        client = self._default_http_client
-        self._default_http_client = None
         self._handshake_done = False
-        if client:
-            await client.aclose()
+        await self._http_client.close()
 
     @staticmethod
     def generate_auth_hash(creds: Credentials):

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -48,7 +48,7 @@ import logging
 import secrets
 import time
 from pprint import pformat as pf
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, cast
 
 from cryptography.hazmat.primitives import hashes, padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -56,7 +56,7 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from .credentials import Credentials
 from .deviceconfig import DeviceConfig
 from .exceptions import AuthenticationException, SmartDeviceException
-from .httpclientsession import HttpClientSession
+from .httpclient import HttpClient
 from .json import loads as json_loads
 from .protocol import BaseTransport, md5
 
@@ -97,7 +97,7 @@ class KlapTransport(BaseTransport):
     ) -> None:
         super().__init__(config=config)
 
-        self._http_client = HttpClientSession(config)
+        self._http_client = HttpClient(config)
         self._local_seed: Optional[bytes] = None
         if (
             not self._credentials or self._credentials.username is None
@@ -160,6 +160,7 @@ class KlapTransport(BaseTransport):
                 f"Device {self._host} responded with {response_status} to handshake1"
             )
 
+        response_data = cast(bytes, response_data)
         remote_seed: bytes = response_data[0:16]
         server_hash = response_data[16:]
 

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 class SmartProtocol(TPLinkProtocol):
     """Class for the new TPLink SMART protocol."""
 
-    SLEEP_SECONDS_AFTER_TIMEOUT = 1
+    BACKOFF_SECONDS_AFTER_TIMEOUT = 1
 
     def __init__(
         self,
@@ -88,7 +88,7 @@ class SmartProtocol(TPLinkProtocol):
                     await self.close()
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise ex
-                await asyncio.sleep(self.SLEEP_SECONDS_AFTER_TIMEOUT)
+                await asyncio.sleep(self.BACKOFF_SECONDS_AFTER_TIMEOUT)
                 continue
             except SmartDeviceException as ex:
                 await self.close()

--- a/kasa/tests/test_device_factory.py
+++ b/kasa/tests/test_device_factory.py
@@ -145,7 +145,7 @@ async def test_connect_http_client(all_fixture_data, mocker):
     )
     dev = await connect(config=config)
     if ctype.encryption_type != EncryptType.Xor:
-        assert dev.protocol._transport._http_client != http_client
+        assert dev.protocol._transport._http_client.client != http_client
 
     config = DeviceConfig(
         host=host,
@@ -155,4 +155,4 @@ async def test_connect_http_client(all_fixture_data, mocker):
     )
     dev = await connect(config=config)
     if ctype.encryption_type != EncryptType.Xor:
-        assert dev.protocol._transport._http_client == http_client
+        assert dev.protocol._transport._http_client.client == http_client

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -321,9 +321,9 @@ async def test_discover_single_http_client(discovery_mock, mocker):
     assert x.config.uses_http == (discovery_mock.default_port == 80)
 
     if discovery_mock.default_port == 80:
-        assert x.protocol._transport._http_client != http_client
+        assert x.protocol._transport._http_client.client != http_client
         x.config.http_client = http_client
-        assert x.protocol._transport._http_client == http_client
+        assert x.protocol._transport._http_client.client == http_client
 
 
 async def test_discover_http_client(discovery_mock, mocker):
@@ -338,6 +338,6 @@ async def test_discover_http_client(discovery_mock, mocker):
     assert x.config.uses_http == (discovery_mock.default_port == 80)
 
     if discovery_mock.default_port == 80:
-        assert x.protocol._transport._http_client != http_client
+        assert x.protocol._transport._http_client.client != http_client
         x.config.http_client = http_client
-        assert x.protocol._transport._http_client == http_client
+        assert x.protocol._transport._http_client.client == http_client

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -18,7 +18,7 @@ from ..exceptions import (
     ConnectionException,
     SmartDeviceException,
 )
-from ..httpclientsession import HttpClientSession
+from ..httpclient import HttpClient
 from ..iotprotocol import IotProtocol
 from ..klaptransport import (
     KlapEncryptionSession,
@@ -160,7 +160,7 @@ async def test_protocol_logging(mocker, caplog, log_level):
     protocol._transport._handshake_done = True
     protocol._transport._session_expire_at = time.time() + 86400
     protocol._transport._encryption_session = encryption_session
-    mocker.patch.object(HttpClientSession, "post", side_effect=_return_encrypted)
+    mocker.patch.object(HttpClient, "post", side_effect=_return_encrypted)
 
     response = await protocol.query({})
     assert response == {"great": "success"}

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -13,7 +13,12 @@ import pytest
 from ..aestransport import AesTransport
 from ..credentials import Credentials
 from ..deviceconfig import DeviceConfig
-from ..exceptions import AuthenticationException, SmartDeviceException
+from ..exceptions import (
+    AuthenticationException,
+    ConnectionException,
+    SmartDeviceException,
+)
+from ..httpclientsession import HttpClientSession
 from ..iotprotocol import IotProtocol
 from ..klaptransport import (
     KlapEncryptionSession,
@@ -35,8 +40,8 @@ class _mock_response:
 @pytest.mark.parametrize(
     "error, retry_expectation",
     [
-        (Exception("dummy exception"), True),
-        (SmartDeviceException("dummy exception"), False),
+        (Exception("dummy exception"), False),
+        (httpx.TimeoutException("dummy exception"), True),
         (httpx.ConnectError("dummy exception"), True),
     ],
     ids=("Exception", "SmartDeviceException", "httpx.ConnectError"),
@@ -89,7 +94,7 @@ async def test_protocol_retry_recoverable_error(
     conn = mocker.patch.object(
         httpx.AsyncClient,
         "post",
-        side_effect=httpx.CloseError("foo"),
+        side_effect=httpx.ConnectError("foo"),
     )
     config = DeviceConfig(host)
     with pytest.raises(SmartDeviceException):
@@ -112,7 +117,7 @@ async def test_protocol_reconnect(mocker, retry_count, protocol_class, transport
         nonlocal remaining
         remaining -= 1
         if remaining:
-            raise Exception("Simulated post failure")
+            raise ConnectionException("Simulated connection failure")
 
         return mock_response
 
@@ -155,7 +160,7 @@ async def test_protocol_logging(mocker, caplog, log_level):
     protocol._transport._handshake_done = True
     protocol._transport._session_expire_at = time.time() + 86400
     protocol._transport._encryption_session = encryption_session
-    mocker.patch.object(KlapTransport, "client_post", side_effect=_return_encrypted)
+    mocker.patch.object(HttpClientSession, "post", side_effect=_return_encrypted)
 
     response = await protocol.query({})
     assert response == {"great": "success"}


### PR DESCRIPTION
Allows for easier migration between async `http` implementations and makes retry logic more consistent between protocols.