### PR TITLE
Avoid fetching time in the klap send success path

### DIFF
--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -356,11 +356,7 @@ class KlapTransport(BaseTransport):
             json_payload = json_loads(decrypted_response)
 
             if debug_enabled:
-                _LOGGER.debug(
-                    "%s << %s",
-                    self._host,
-                    pf(json_payload),
-                )
+                _LOGGER.debug("%s << %s", self._host, pf(json_payload))
 
             return json_payload
 


### PR DESCRIPTION
On success we did expensive log message formatting and threw it away. All the other functions already have guards to prevent this, but `send` was missing. Fetching time does a syscall on many arm systems including the Home Assistant Blue