### PR TITLE
Add debug_level to deviceconfig to allow http tracing

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -155,8 +155,8 @@ def json_formatter_cb(result, **kwargs):
     "-d",
     "--debug",
     envvar="KASA_DEBUG",
-    default=False,
-    is_flag=True,
+    default=0,
+    count=True,
     help="Print debug output",
 )
 @click.option(
@@ -342,6 +342,9 @@ async def cli(
         await dev.update()
 
     ctx.obj = dev
+
+    # TODO: this is too late, as discovery has already initialized httpclient
+    dev.config.debug_level = debug
 
     if ctx.invoked_subcommand is None:
         return await ctx.invoke(state)

--- a/kasa/deviceconfig.py
+++ b/kasa/deviceconfig.py
@@ -158,6 +158,9 @@ class DeviceConfig:
     #: Set a custom http_client for the device to use.
     http_client: Optional["ClientSession"] = field(default=None, compare=False)
 
+    #: Debug level for the device. Can be used to increase the logging verbosity.
+    debug_level: int = 0
+
     def __post_init__(self):
         if self.connection_type is None:
             self.connection_type = ConnectionType(


### PR DESCRIPTION
This allows seeing the full http comms including headers with the protocols using  httpclient.

Marked as draft as the http session gets initialized by homeassistant (or by discovery) which is too early to set it,
so this just always sets up the tracing no matter whether it's requested.