### PR TITLE
Make close behaviour consistent across new protocols and transports

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -265,10 +265,12 @@ class AesTransport(BaseTransport):
         return await self.send_secure_passthrough(request)
 
     async def close(self) -> None:
-        """Close the transport."""
+        """Mark the handshake and login as not done.
+
+        Since we likely lost the connection.
+        """
         self._handshake_done = False
         self._login_token = None
-        await self._http_client.close()
 
 
 class AesEncyptionSession:

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -66,8 +66,8 @@ class SmartProtocol(TPLinkProtocol):
             try:
                 return await self._execute_query(request, retry)
             except ConnectionException as sdex:
+                await self.close()
                 if retry >= retry_count:
-                    await self.close()
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise sdex
                 continue
@@ -78,8 +78,8 @@ class SmartProtocol(TPLinkProtocol):
                 )
                 raise auex
             except RetryableException as ex:
+                await self.close()
                 if retry >= retry_count:
-                    await self.close()
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise ex
                 continue


### PR DESCRIPTION
- Call close on each try for `ConnectionException` and `RetryableException` in `SmartProtocol` consistent with `TimeoutException`.
- Update `IotProtocol` and `AesTransport` to match the changes above and those made by https://github.com/python-kasa/python-kasa/pull/654 (including docstrings)