### PR TITLE
Enable batching of multiple requests

### DIFF
--- a/kasa/deviceconfig.py
+++ b/kasa/deviceconfig.py
@@ -146,6 +146,8 @@ class DeviceConfig:
     #: Credentials hash can be retrieved from :attr:`SmartDevice.credentials_hash`
     credentials_hash: Optional[str] = None
     #: The protocol specific type of connection.  Defaults to the legacy type.
+    batch_size: Optional[int] = None
+    #: The batch size for protoools supporting multiple request batches.
     connection_type: ConnectionType = field(
         default_factory=lambda: ConnectionType(
             DeviceFamilyType.IotSmartPlugSwitch, EncryptType.Xor, 1

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -33,7 +33,7 @@ class SmartProtocol(BaseProtocol):
     """Class for the new TPLink SMART protocol."""
 
     BACKOFF_SECONDS_AFTER_TIMEOUT = 1
-    MULTI_REQUEST_BATCH_SIZE = 5
+    DEFAULT_MULTI_REQUEST_BATCH_SIZE = 5
 
     def __init__(
         self,
@@ -111,8 +111,10 @@ class SmartProtocol(BaseProtocol):
         ]
 
         end = len(requests)
-        # Break the requests down as there seems to be a size limit
-        step = self.MULTI_REQUEST_BATCH_SIZE
+        # Break the requests down as there can be a size limit
+        step = (
+            self._transport._config.batch_size or self.DEFAULT_MULTI_REQUEST_BATCH_SIZE
+        )
         for i in range(0, end, step):
             requests_step = requests[i : i + step]
 

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -112,9 +112,8 @@ class SmartProtocol(BaseProtocol):
         ]
 
         end = len(requests)
-        step = (
-            self.MULTI_REQUEST_BATCH_SIZE
-        )  # Break the requests down as there seems to be a size limit
+        # Break the requests down as there seems to be a size limit
+        step = self.MULTI_REQUEST_BATCH_SIZE
         for i in range(0, end, step):
             requests_step = requests[i : i + step]
 

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -10,7 +10,7 @@ import logging
 import time
 import uuid
 from pprint import pformat as pf
-from typing import Dict, Union
+from typing import Dict, Union, Any
 
 from .exceptions import (
     SMART_AUTHENTICATION_ERRORS,
@@ -48,14 +48,13 @@ class SmartProtocol(BaseProtocol):
 
     def get_smart_request(self, method, params=None) -> str:
         """Get a request message as a string."""
-        request = {
+        return json_dumps({
             "method": method,
             "params": params,
             "requestID": self._request_id_generator.generate_id(),
             "request_time_milis": round(time.time() * 1000),
             "terminal_uuid": self._terminal_uuid,
-        }
-        return json_dumps(request)
+        })
 
     async def query(self, request: Union[str, Dict], retry_count: int = 3) -> Dict:
         """Query the device retrying for retry_count on failure."""
@@ -104,8 +103,7 @@ class SmartProtocol(BaseProtocol):
 
     async def _execute_multiple_query(self, request: Dict, retry_count: int) -> Dict:
         debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
-        requests = []
-        multi_result = {}
+        multi_result: Dict[str, Any] = {}
         smart_method = "multipleRequest"
         requests = [
             {"method": method, "params": params} for method, params in request.items()

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -10,7 +10,7 @@ import logging
 import time
 import uuid
 from pprint import pformat as pf
-from typing import Dict, Union, Any
+from typing import Any, Dict, Union
 
 from .exceptions import (
     SMART_AUTHENTICATION_ERRORS,
@@ -48,13 +48,15 @@ class SmartProtocol(BaseProtocol):
 
     def get_smart_request(self, method, params=None) -> str:
         """Get a request message as a string."""
-        return json_dumps({
-            "method": method,
-            "params": params,
-            "requestID": self._request_id_generator.generate_id(),
-            "request_time_milis": round(time.time() * 1000),
-            "terminal_uuid": self._terminal_uuid,
-        })
+        return json_dumps(
+            {
+                "method": method,
+                "params": params,
+                "requestID": self._request_id_generator.generate_id(),
+                "request_time_milis": round(time.time() * 1000),
+                "terminal_uuid": self._terminal_uuid,
+            }
+        )
 
     async def query(self, request: Union[str, Dict], retry_count: int = 3) -> Dict:
         """Query the device retrying for retry_count on failure."""

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -103,6 +103,7 @@ class SmartProtocol(BaseProtocol):
         raise SmartDeviceException("Query reached somehow to unreachable")
 
     async def _execute_multiple_query(self, request: Dict, retry_count: int) -> Dict:
+        debug_enabled = _LOGGER.isEnabledFor(logging.DEBUG)
         requests = []
         multi_result = {}
         smart_method = "multipleRequest"
@@ -123,14 +124,14 @@ class SmartProtocol(BaseProtocol):
                 "%s multi-request-batch-%s >> %s",
                 self._host,
                 i + 1,
-                _LOGGER.isEnabledFor(logging.DEBUG) and pf(smart_request),
+                debug_enabled and pf(smart_request),
             )
             response_step = await self._transport.send(smart_request)
             _LOGGER.debug(
                 "%s multi-request-batch-%s << %s",
                 self._host,
                 i + 1,
-                _LOGGER.isEnabledFor(logging.DEBUG) and pf(response_step),
+                debug_enabled and pf(response_step),
             )
             self._handle_response_error_code(response_step)
             responses = response_step["result"]["responses"]

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -48,15 +48,14 @@ class SmartProtocol(BaseProtocol):
 
     def get_smart_request(self, method, params=None) -> str:
         """Get a request message as a string."""
-        return json_dumps(
-            {
-                "method": method,
-                "params": params,
-                "requestID": self._request_id_generator.generate_id(),
-                "request_time_milis": round(time.time() * 1000),
-                "terminal_uuid": self._terminal_uuid,
-            }
-        )
+        request = {
+            "method": method,
+            "params": params,
+            "requestID": self._request_id_generator.generate_id(),
+            "request_time_milis": round(time.time() * 1000),
+            "terminal_uuid": self._terminal_uuid,
+        }
+        return json_dumps(request)
 
     async def query(self, request: Union[str, Dict], retry_count: int = 3) -> Dict:
         """Query the device retrying for retry_count on failure."""

--- a/kasa/tests/fixtures/smart/L510E(US)_3.0_1.0.5.json
+++ b/kasa/tests/fixtures/smart/L510E(US)_3.0_1.0.5.json
@@ -86,7 +86,7 @@
         "factory_default": false,
         "ip": "127.0.0.123",
         "is_support_iot_cloud": true,
-        "mac": "00-00-00-00-00-00",
+        "mac": "3C-52-A1-00-00-00",
         "mgt_encrypt_schm": {
             "encrypt_type": "AES",
             "http_port": 80,
@@ -102,7 +102,7 @@
         "rule_list": []
     },
     "get_auto_update_info": {
-        "enable": true,
+        "enable": false,
         "random_range": 120,
         "time": 180
     },
@@ -136,10 +136,10 @@
         "hw_id": "00000000000000000000000000000000",
         "hw_ver": "3.0",
         "ip": "127.0.0.123",
-        "lang": "",
+        "lang": "en_US",
         "latitude": 0,
         "longitude": 0,
-        "mac": "00-00-00-00-00-00",
+        "mac": "3C-52-A1-00-00-00",
         "model": "L510",
         "music_rhythm_enable": false,
         "music_rhythm_mode": "single_lamp",
@@ -147,7 +147,7 @@
         "oem_id": "00000000000000000000000000000000",
         "overheated": false,
         "region": "Pacific/Honolulu",
-        "rssi": -69,
+        "rssi": -65,
         "signal_level": 2,
         "specs": "",
         "ssid": "I01BU0tFRF9TU0lEIw==",
@@ -157,23 +157,23 @@
     "get_device_time": {
         "region": "Pacific/Honolulu",
         "time_diff": -600,
-        "timestamp": 1706060153
+        "timestamp": 1706121405
     },
     "get_device_usage": {
         "power_usage": {
-            "past30": 1,
-            "past7": 1,
-            "today": 1
-        },
-        "saved_power": {
-            "past30": 4,
-            "past7": 4,
-            "today": 4
-        },
-        "time_usage": {
             "past30": 5,
             "past7": 5,
             "today": 5
+        },
+        "saved_power": {
+            "past30": 26,
+            "past7": 26,
+            "today": 26
+        },
+        "time_usage": {
+            "past30": 31,
+            "past7": 31,
+            "today": 31
         }
     },
     "get_fw_download_state": {
@@ -226,14 +226,6 @@
                 "channel": 0,
                 "cipher_type": 2,
                 "key_type": "wpa2_psk",
-                "signal_level": 3,
-                "ssid": "I01BU0tFRF9TU0lEIw=="
-            },
-            {
-                "bssid": "000000000000",
-                "channel": 0,
-                "cipher_type": 2,
-                "key_type": "wpa2_psk",
                 "signal_level": 2,
                 "ssid": "I01BU0tFRF9TU0lEIw=="
             },
@@ -251,6 +243,22 @@
                 "cipher_type": 2,
                 "key_type": "wpa2_psk",
                 "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
                 "ssid": "I01BU0tFRF9TU0lEIw=="
             },
             {

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -84,3 +84,33 @@ async def test_smart_device_errors_in_multiple_request(mocker, error_code):
     else:
         expected_calls = 1
     assert send_mock.call_count == expected_calls
+
+
+@pytest.mark.parametrize("request_size", [1, 3, 5, 10])
+@pytest.mark.parametrize("batch_size", [1, 2, 3, 4, 5])
+async def test_smart_device_multiple_request(mocker, request_size, batch_size):
+    host = "127.0.0.1"
+    requests = {}
+    mock_response = {
+        "result": {"responses": []},
+        "error_code": 0,
+    }
+    for i in range(request_size):
+        method = f"get_method_{i}"
+        requests[method] = {"foo": "bar", "bar": "foo"}
+        mock_response["result"]["responses"].append(
+            {"method": method, "result": {"great": "success"}, "error_code": 0}
+        )
+
+    mocker.patch.object(AesTransport, "perform_handshake")
+    mocker.patch.object(AesTransport, "perform_login")
+
+    send_mock = mocker.patch.object(AesTransport, "send", return_value=mock_response)
+    config = DeviceConfig(
+        host, credentials=Credentials("foo", "bar"), batch_size=batch_size
+    )
+    protocol = SmartProtocol(transport=AesTransport(config=config))
+
+    await protocol.query(requests, retry_count=0)
+    expected_count = int(request_size / batch_size) + (request_size % batch_size > 0)
+    assert send_mock.call_count == expected_count

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -24,6 +24,10 @@ from ..klaptransport import KlapEncryptionSession, KlapTransport, _sha256
 from ..smartprotocol import SmartProtocol
 
 DUMMY_QUERY = {"foobar": {"foo": "bar", "bar": "foo"}}
+DUMMY_MULTIPLE_QUERY = {
+    "foobar": {"foo": "bar", "bar": "foo"},
+    "barfoo": {"foo": "bar", "bar": "foo"},
+}
 ERRORS = [e for e in SmartErrorCode if e != 0]
 
 
@@ -74,7 +78,7 @@ async def test_smart_device_errors_in_multiple_request(mocker, error_code):
     config = DeviceConfig(host, credentials=Credentials("foo", "bar"))
     protocol = SmartProtocol(transport=AesTransport(config=config))
     with pytest.raises(SmartDeviceException):
-        await protocol.query(DUMMY_QUERY, retry_count=2)
+        await protocol.query(DUMMY_MULTIPLE_QUERY, retry_count=2)
     if error_code in chain(SMART_TIMEOUT_ERRORS, SMART_RETRYABLE_ERRORS):
         expected_calls = 3
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,6 @@ omit = ["kasa/tests/*"]
 exclude_lines = [
   # ignore debug logging
   "if debug_enabled:",
-  # ignore abstract methods
   # Don't complain if tests don't hit defensive assertion code:
   "raise AssertionError",
   "raise NotImplementedError",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,8 @@ omit = ["kasa/tests/*"]
 
 [tool.coverage.report]
 exclude_lines = [
+  # ignore debug logging
+  "if debug_enabled:",
   # ignore abstract methods
   "raise NotImplementedError",
   "def __repr__"


### PR DESCRIPTION
`dumpdev_info` revealed that `multipleRequests` can cause timeouts if they're too large.  This PR introduces a batch size of 5 which currently is not exceeded in the api but will be in the future.