### PR TITLE
Generate AES KeyPair lazily

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -254,8 +254,8 @@ class AesTransport(BaseTransport):
             self._session_cookie = {self.SESSION_COOKIE_NAME: cookie}
 
         self._session_expire_at = time.time() + 86400
-        if TYPE_CHECKING:  # pragma: no cover
-            assert self._key_pair is not None
+        if TYPE_CHECKING:
+            assert self._key_pair is not None  # pragma: no cover
         self._encryption_session = AesEncyptionSession.create_from_keypair(
             handshake_key, self._key_pair
         )

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -56,7 +56,7 @@ class AesTransport(BaseTransport):
         "Accept": "application/json",
     }
     CONTENT_LENGTH = "Content-Length"
-    KEY_PAIR_CONTENT_LENGTH = 318
+    KEY_PAIR_CONTENT_LENGTH = 314
 
     def __init__(
         self,

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -193,8 +193,6 @@ class AesTransport(BaseTransport):
         This prevents the key pair being generated unless a connection
         can be made to the device.
         """
-        if self._key_pair:
-            return
         self._key_pair = KeyPair.create_key_pair()
         pub_key = (
             "-----BEGIN PUBLIC KEY-----\n"
@@ -251,7 +249,7 @@ class AesTransport(BaseTransport):
             self._session_cookie = {self.SESSION_COOKIE_NAME: cookie}
 
         self._session_expire_at = time.time() + 86400
-        if TYPE_CHECKING:
+        if TYPE_CHECKING:  # pragma: no cover
             assert self._key_pair is not None
         self._encryption_session = AesEncyptionSession.create_from_keypair(
             handshake_key, self._key_pair

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -49,6 +49,11 @@ class HttpClient:
         response_data = None
         self._last_url = url
         self.client.cookie_jar.clear()
+        return_json = bool(json)
+        # If json is not a dict send as data
+        if json and not isinstance(json, Dict):
+            data = json
+            json = None
         try:
             resp = await self.client.post(
                 url,
@@ -62,7 +67,7 @@ class HttpClient:
             async with resp:
                 if resp.status == 200:
                     response_data = await resp.read()
-                    if json:
+                    if return_json:
                         response_data = json_loads(response_data.decode())
 
         except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as ex:

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -41,16 +41,22 @@ class HttpClient:
         *,
         params: Optional[Dict[str, Any]] = None,
         data: Optional[bytes] = None,
-        json: Optional[Dict] = None,
+        json: Optional[Union[Dict, Any]] = None,
         headers: Optional[Dict[str, str]] = None,
         cookies_dict: Optional[Dict[str, str]] = None,
     ) -> Tuple[int, Optional[Union[Dict, bytes]]]:
-        """Send an http post request to the device."""
+        """Send an http post request to the device.
+
+        If the request is provided via the json parameter json will be returned.
+        """
         response_data = None
         self._last_url = url
         self.client.cookie_jar.clear()
         return_json = bool(json)
-        # If json is not a dict send as data
+        # If json is not a dict send as data.
+        # This allows the json parameter to be used to pass other
+        # types of data such as async_generator and still have json
+        # returned.
         if json and not isinstance(json, Dict):
             data = json
             json = None

--- a/kasa/json.py
+++ b/kasa/json.py
@@ -13,6 +13,7 @@ except ImportError:
 
     def dumps(obj, *, default=None):
         """Dump JSON."""
+        # Separators specified for consistency with orjson
         return json.dumps(obj, separators=(",", ":"))
 
     loads = json.loads

--- a/kasa/json.py
+++ b/kasa/json.py
@@ -11,5 +11,8 @@ try:
 except ImportError:
     import json
 
-    dumps = json.dumps
+    def dumps(obj, *, default=None):
+        """Dump JSON."""
+        return json.dumps(obj, separators=(",", ":"))
+
     loads = json.loads

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -169,7 +169,10 @@ class MockAesDevice:
         self.inner_error_code = inner_error_code
         self.http_client = HttpClient(DeviceConfig(self.host))
 
-    async def post(self, url, params=None, json=None, *_, **__):
+    async def post(self, url, params=None, json=None, data=None, *_, **__):
+        if data:
+            async for item in data:
+                json = json_loads(item.decode())
         return await self._post(url, json)
 
     async def _post(self, url, json):


### PR DESCRIPTION
To prevent the KeyPair being generated repeatedly for offline devices.

Fixes https://github.com/python-kasa/python-kasa/issues/675