### PR TITLE
Update transport close/reset behaviour

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -306,10 +306,12 @@ class AesTransport(BaseTransport):
         return await self.send_secure_passthrough(request)
 
     async def close(self) -> None:
-        """Mark the handshake and login as not done.
+        """Close the http client and reset internal state."""
+        await self.reset()
+        await self._http_client.close()
 
-        Since we likely lost the connection.
-        """
+    async def reset(self) -> None:
+        """Reset internal handshake and login state."""
         self._handshake_done = False
         self._login_token = None
 

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -42,6 +42,10 @@ class ConnectionException(SmartDeviceException):
     """Connection exception for device errors."""
 
 
+class DisconnectedException(SmartDeviceException):
+    """Disconnected exception for device errors."""
+
+
 class SmartErrorCode(IntEnum):
     """Enum for SMART Error Codes."""
 

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -5,7 +5,12 @@ from typing import Any, Dict, Optional, Tuple, Union
 import aiohttp
 
 from .deviceconfig import DeviceConfig
-from .exceptions import ConnectionException, SmartDeviceException, TimeoutException
+from .exceptions import (
+    ConnectionException,
+    DisconnectedException,
+    SmartDeviceException,
+    TimeoutException,
+)
 from .json import loads as json_loads
 
 
@@ -76,7 +81,11 @@ class HttpClient:
                     if return_json:
                         response_data = json_loads(response_data.decode())
 
-        except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as ex:
+        except aiohttp.ServerDisconnectedError as ex:
+            raise DisconnectedException(
+                f"Disconnected from the device: {self._config.host}: {ex}", ex
+            ) from ex
+        except aiohttp.ClientOSError as ex:
             raise ConnectionException(
                 f"Unable to connect to the device: {self._config.host}: {ex}", ex
             ) from ex

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -348,7 +348,12 @@ class KlapTransport(BaseTransport):
             return json_payload
 
     async def close(self) -> None:
-        """Mark the handshake as not done since we likely lost the connection."""
+        """Close the http client and reset internal state."""
+        await self.reset()
+        await self._http_client.close()
+
+    async def reset(self) -> None:
+        """Reset internal handshake state."""
         self._handshake_done = False
 
     @staticmethod

--- a/kasa/smartdevice.py
+++ b/kasa/smartdevice.py
@@ -806,6 +806,10 @@ class SmartDevice:
         """Return the device configuration."""
         return self.protocol.config
 
+    async def disconnect(self):
+        """Disconnect and close any underlying connection resources."""
+        await self.protocol.close()
+
     @staticmethod
     async def connect(
         *,

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -15,6 +15,7 @@ from kasa import (
     Credentials,
     Discover,
     SmartBulb,
+    SmartDevice,
     SmartDimmer,
     SmartLightStrip,
     SmartPlug,
@@ -416,9 +417,15 @@ async def dev(request):
             IP_MODEL_CACHE[ip] = model = d.model
         if model not in file:
             pytest.skip(f"skipping file {file}")
-        return d if d else await _discover_update_and_close(ip, username, password)
+        dev: SmartDevice = (
+            d if d else await _discover_update_and_close(ip, username, password)
+        )
+    else:
+        dev: SmartDevice = await get_device_for_file(file, protocol)
 
-    return await get_device_for_file(file, protocol)
+    yield dev
+
+    await dev.disconnect()
 
 
 @pytest.fixture

--- a/kasa/tests/newfakes.py
+++ b/kasa/tests/newfakes.py
@@ -377,6 +377,9 @@ class FakeSmartTransport(BaseTransport):
     async def close(self) -> None:
         pass
 
+    async def reset(self) -> None:
+        pass
+
 
 class FakeTransportProtocol(TPLinkSmartHomeProtocol):
     def __init__(self, info):

--- a/kasa/tests/test_httpclient.py
+++ b/kasa/tests/test_httpclient.py
@@ -7,6 +7,7 @@ import pytest
 from ..deviceconfig import DeviceConfig
 from ..exceptions import (
     ConnectionException,
+    DisconnectedException,
     SmartDeviceException,
     TimeoutException,
 )
@@ -18,8 +19,8 @@ from ..httpclient import HttpClient
     [
         (
             aiohttp.ServerDisconnectedError(),
-            ConnectionException,
-            "Unable to connect to the device: ",
+            DisconnectedException,
+            "Disconnected from the device: ",
         ),
         (
             aiohttp.ClientOSError(),

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -54,9 +54,10 @@ class _mock_response:
     [
         (Exception("dummy exception"), False),
         (aiohttp.ServerTimeoutError("dummy exception"), True),
+        (aiohttp.ServerDisconnectedError("dummy exception"), True),
         (aiohttp.ClientOSError("dummy exception"), True),
     ],
-    ids=("Exception", "SmartDeviceException", "ConnectError"),
+    ids=("Exception", "SmartDeviceException", "DisconnectError", "ConnectError"),
 )
 @pytest.mark.parametrize("transport_class", [AesTransport, KlapTransport])
 @pytest.mark.parametrize("protocol_class", [IotProtocol, SmartProtocol])


### PR DESCRIPTION
Separate out `close` and `reset` so that transports can `reset` on errors but be properly closed when finished with to avoid `aiohttp.Unclosed client session` errors. Also prevents `reset` on `ServerDisconnectErrors` for devices not supporting http keepalive.