### PR TITLE
Add new cli command 'command' to execute arbitrary commands

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -70,6 +70,9 @@ DEVICE_FAMILY_TYPES = [
     device_family_type.value for device_family_type in DeviceFamilyType
 ]
 
+# Block list of commands which require no update
+SKIP_UPDATE_COMMANDS = ["wifi", "raw-command", "command"]
+
 click.anyio_backend = "asyncio"
 
 pass_dev = click.make_pass_decorator(SmartDevice)
@@ -340,8 +343,8 @@ async def cli(
             credentials=credentials,
         )
 
-    # Skip update for wifi & raw command, and if factory was used to connect
-    SKIP_UPDATE_COMMANDS = ["wifi", "raw-command", "command"]
+    # Skip update on specific commands, or if device factory,
+    # that performs an update was used for the device.
     if ctx.invoked_subcommand not in SKIP_UPDATE_COMMANDS and not device_family:
         await dev.update()
 

--- a/kasa/modules/emeter.py
+++ b/kasa/modules/emeter.py
@@ -63,7 +63,7 @@ class Emeter(Usage):
         self,
         data: List[Dict[str, Union[int, float]]],
         entry_key: str,
-        kwh: bool=True,
+        kwh: bool = True,
         key: Optional[int] = None,
     ) -> Dict[Union[int, float], Union[int, float]]:
         """Return emeter information keyed with the day/month.


### PR DESCRIPTION
Add new 'command' for arbitrary command execution, as SMART devices do not use modules for raw calls.
The 'raw-command' is now deprecated but remains working for the time being, while using 'command --module <module>' is the recommended way to make raw calls on legacy devices.