### PR TITLE
Fix test_klapprotocol test duration

### DIFF
--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -6,6 +6,7 @@ import struct
 import sys
 import time
 from contextlib import nullcontext as does_not_raise
+from unittest.mock import PropertyMock
 
 import aiohttp
 import pytest
@@ -67,6 +68,7 @@ async def test_protocol_retries_via_client_session(
 ):
     host = "127.0.0.1"
     conn = mocker.patch.object(aiohttp.ClientSession, "post", side_effect=error)
+    mocker.patch.object(protocol_class, "BACKOFF_SECONDS_AFTER_TIMEOUT", 0)
 
     config = DeviceConfig(host)
     with pytest.raises(SmartDeviceException):
@@ -95,6 +97,7 @@ async def test_protocol_retries_via_httpclient(
 ):
     host = "127.0.0.1"
     conn = mocker.patch.object(HttpClient, "post", side_effect=error)
+    mocker.patch.object(protocol_class, "BACKOFF_SECONDS_AFTER_TIMEOUT", 0)
 
     config = DeviceConfig(host)
     with pytest.raises(SmartDeviceException):
@@ -117,6 +120,7 @@ async def test_protocol_no_retry_on_connection_error(
         "post",
         side_effect=AuthenticationException("foo"),
     )
+    mocker.patch.object(protocol_class, "BACKOFF_SECONDS_AFTER_TIMEOUT", 0)
     config = DeviceConfig(host)
     with pytest.raises(SmartDeviceException):
         await protocol_class(transport=transport_class(config=config)).query(


### PR DESCRIPTION
Reduces `test_klapprotocol` from 75 seconds to 1.5.