### PR TITLE
Do not crash on missing geolocation

### DIFF
--- a/kasa/tapo/tapodevice.py
+++ b/kasa/tapo/tapodevice.py
@@ -147,8 +147,8 @@ class TapoDevice(SmartDevice):
     def location(self) -> Dict:
         """Return the device location."""
         loc = {
-            "latitude": cast(float, self._info.get("latitude")) / 10_000,
-            "longitude": cast(float, self._info.get("longitude")) / 10_000,
+            "latitude": cast(float, self._info.get("latitude", 0)) / 10_000,
+            "longitude": cast(float, self._info.get("longitude", 0)) / 10_000,
         }
         return loc
 


### PR DESCRIPTION
If 'has_set_location_info' is false, the geolocation is missing, which causes cli's 'state' to crash.

```
  File "/home/tpr/code/python-kasa/kasa/cli.py", line 538, in state
    echo(f"\tLocation:     {dev.location}")
                            ^^^^^^^^^^^^
  File "/home/tpr/code/python-kasa/kasa/tapo/tapodevice.py", line 150, in location
    "latitude": cast(float, self._info.get("latitude")) / 10_000,
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```