### PR TITLE
Fix overly greedy _strip_rich_formatting

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -37,6 +37,9 @@ except ImportError:
 try:
     from rich import print as _do_echo
 except ImportError:
+    # Remove 7-bit C1 ANSI sequences
+    # https://stackoverflow.com/questions/14693701/how-can-i-remove-the-ansi-escape-sequences-from-a-string-in-python
+    ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 
     def _strip_rich_formatting(echo_func):
         """Strip rich formatting from messages."""
@@ -44,7 +47,7 @@ except ImportError:
         @wraps(echo_func)
         def wrapper(message=None, *args, **kwargs):
             if message is not None:
-                message = re.sub(r"\[/?.+?]", "", message)
+                message = ansi_escape.sub("", message)
             echo_func(message, *args, **kwargs)
 
         return wrapper


### PR DESCRIPTION
https://github.com/python-kasa/python-kasa/pull/680 and https://github.com/python-kasa/python-kasa/pull/694 were failing because this was consuming part of the payload
