### PR TITLE
Avoid rebuilding urls for every request

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -104,7 +104,7 @@ class AesTransport(BaseTransport):
         self._login_token: Optional[str] = None
 
         self._key_pair: Optional[KeyPair] = None
-        self._app_url = URL("http://{self._host}/app")
+        self._app_url = URL(f"http://{self._host}/app")
         self._token_url = URL(f"{self._app_url}?token={self._login_token}")
 
         _LOGGER.debug("Created AES transport for %s", self._host)

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -226,7 +226,7 @@ class AesTransport(BaseTransport):
         resp_dict = await self.send_secure_passthrough(request)
         self._handle_response_error_code(resp_dict, "Error logging in")
         login_token = resp_dict["result"]["token"]
-        self._token_url = URL(f"{self._app_url}?token={login_token}")
+        self._token_url = self._app_url.with_query(f"token={login_token}")
         self._state = TransportState.ESTABLISHED
 
     async def _generate_key_pair_payload(self) -> AsyncGenerator:

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -103,7 +103,7 @@ class AesTransport(BaseTransport):
 
         self._key_pair: Optional[KeyPair] = None
         self._app_url = URL(f"http://{self._host}/app")
-        self._token_url: Optional[str] = None
+        self._token_url: Optional[URL] = None
 
         _LOGGER.debug("Created AES transport for %s", self._host)
 

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -1,13 +1,13 @@
 """python-kasa exceptions."""
 from asyncio import TimeoutError
 from enum import IntEnum
-from typing import Optional
+from typing import Any, Optional
 
 
 class SmartDeviceException(Exception):
     """Base exception for device errors."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.error_code: Optional["SmartErrorCode"] = kwargs.get("error_code", None)
         super().__init__(*args)
 
@@ -15,7 +15,7 @@ class SmartDeviceException(Exception):
 class UnsupportedDeviceException(SmartDeviceException):
     """Exception for trying to connect to unsupported devices."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.discovery_result = kwargs.get("discovery_result")
         super().__init__(*args, **kwargs)
 

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -26,7 +26,7 @@ class HttpClient:
         self._config = config
         self._client_session: aiohttp.ClientSession = None
         self._jar = aiohttp.CookieJar(unsafe=True, quote_cookie=False)
-        self._last_url = f"http://{self._config.host}/"
+        self._last_url = URL(f"http://{self._config.host}/")
 
     @property
     def client(self) -> aiohttp.ClientSession:
@@ -42,7 +42,7 @@ class HttpClient:
 
     async def post(
         self,
-        url: str | URL,
+        url: URL,
         *,
         params: Optional[Dict[str, Any]] = None,
         data: Optional[bytes] = None,

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -3,6 +3,7 @@ import asyncio
 from typing import Any, Dict, Optional, Tuple, Union
 
 import aiohttp
+from yarl import URL
 
 from .deviceconfig import DeviceConfig
 from .exceptions import (
@@ -41,7 +42,7 @@ class HttpClient:
 
     async def post(
         self,
-        url: str,
+        url: str | URL,
         *,
         params: Optional[Dict[str, Any]] = None,
         data: Optional[bytes] = None,

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -121,7 +121,7 @@ class KlapTransport(BaseTransport):
         self._session_cookie: Optional[Dict[str, Any]] = None
 
         _LOGGER.debug("Created KLAP transport for %s", self._host)
-        self._app_url = URL("http://{self._host}/app")
+        self._app_url = URL(f"http://{self._host}/app")
         self._request_url = self._app_url / "request"
 
     @property

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -312,10 +312,8 @@ class KlapTransport(BaseTransport):
         if self._encryption_session is not None:
             payload, seq = self._encryption_session.encrypt(request.encode())
 
-        url = self._request_url
-
         response_status, response_data = await self._http_client.post(
-            url,
+            self._request_url,
             params={"seq": seq},
             data=payload,
             cookies_dict=self._session_cookie,

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -53,6 +53,7 @@ from typing import Any, Dict, Optional, Tuple, cast
 
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from yarl import URL
 
 from .credentials import Credentials
 from .deviceconfig import DeviceConfig
@@ -120,6 +121,8 @@ class KlapTransport(BaseTransport):
         self._session_cookie: Optional[Dict[str, Any]] = None
 
         _LOGGER.debug("Created KLAP transport for %s", self._host)
+        self._app_url = URL("http://{self._host}/app")
+        self._request_url = self._app_url / "request"
 
     @property
     def default_port(self):
@@ -141,7 +144,7 @@ class KlapTransport(BaseTransport):
 
         payload = local_seed
 
-        url = f"http://{self._host}/app/handshake1"
+        url = self._app_url / "handshake1"
 
         response_status, response_data = await self._http_client.post(url, data=payload)
 
@@ -236,7 +239,7 @@ class KlapTransport(BaseTransport):
         # Handshake 2 has the following payload:
         #    sha256(serverBytes | authenticator)
 
-        url = f"http://{self._host}/app/handshake2"
+        url = self._app_url / "handshake2"
 
         payload = self.handshake2_seed_auth_hash(local_seed, remote_seed, auth_hash)
 
@@ -309,7 +312,7 @@ class KlapTransport(BaseTransport):
         if self._encryption_session is not None:
             payload, seq = self._encryption_session.encrypt(request.encode())
 
-        url = f"http://{self._host}/app/request"
+        url = self._request_url
 
         response_status, response_data = await self._http_client.post(
             url,

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -166,7 +166,9 @@ async def test_send(mocker, status_code, error_code, inner_error_code, expectati
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._token_url =  transport._app_url.with_query(f"token={mock_aes_device.token}")
+    transport._token_url = transport._app_url.with_query(
+        f"token={mock_aes_device.token}"
+    )
 
     request = {
         "method": "get_device_info",
@@ -194,7 +196,9 @@ async def test_passthrough_errors(mocker, error_code):
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._token_url = transport._app_url.with_query(f"token={mock_aes_device.token}")
+    transport._token_url = transport._app_url.with_query(
+        f"token={mock_aes_device.token}"
+    )
 
     request = {
         "method": "get_device_info",

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -166,7 +166,7 @@ async def test_send(mocker, status_code, error_code, inner_error_code, expectati
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._token_url = URL(f"{transport._app_url}?token={mock_aes_device.token}")
+    transport._token_url =  transport._app_url.with_query(f"token={mock_aes_device.token}")
 
     request = {
         "method": "get_device_info",
@@ -194,7 +194,7 @@ async def test_passthrough_errors(mocker, error_code):
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._token_url = URL(f"{transport._app_url}?token={mock_aes_device.token}")
+    transport._token_url = transport._app_url.with_query(f"token={mock_aes_device.token}")
 
     request = {
         "method": "get_device_info",

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -90,10 +90,10 @@ async def test_login(mocker, status_code, error_code, inner_error_code, expectat
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
 
-    assert transport._login_token is None
+    assert transport._token_url is None
     with expectation:
         await transport.perform_login()
-        assert transport._login_token == mock_aes_device.token
+        assert mock_aes_device.token in str(transport._token_url)
 
 
 @pytest.mark.parametrize(
@@ -137,7 +137,7 @@ async def test_login_errors(mocker, inner_error_codes, expectation, call_count):
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
 
-    assert transport._login_token is None
+    assert transport._token_url is None
 
     request = {
         "method": "get_device_info",
@@ -149,7 +149,7 @@ async def test_login_errors(mocker, inner_error_codes, expectation, call_count):
 
     with expectation:
         await transport.send(json_dumps(request))
-        assert transport._login_token == mock_aes_device.token
+        assert mock_aes_device.token in str(transport._token_url)
         assert post_mock.call_count == call_count  # Login, Handshake, Login
         await transport.close()
 
@@ -166,7 +166,7 @@ async def test_send(mocker, status_code, error_code, inner_error_code, expectati
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._login_token = mock_aes_device.token
+    transport._token_url = URL(f"http://{host}/app?token={mock_aes_device.token}")
 
     request = {
         "method": "get_device_info",
@@ -194,7 +194,7 @@ async def test_passthrough_errors(mocker, error_code):
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._login_token = mock_aes_device.token
+    transport._token_url = URL(f"http://{host}/app?token={mock_aes_device.token}")
 
     request = {
         "method": "get_device_info",

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -166,7 +166,7 @@ async def test_send(mocker, status_code, error_code, inner_error_code, expectati
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._token_url = URL(f"http://{host}/app?token={mock_aes_device.token}")
+    transport._token_url = URL(f"{transport._app_url}?token={mock_aes_device.token}")
 
     request = {
         "method": "get_device_info",
@@ -194,7 +194,7 @@ async def test_passthrough_errors(mocker, error_code):
     transport._handshake_done = True
     transport._session_expire_at = time.time() + 86400
     transport._encryption_session = mock_aes_device.encryption_session
-    transport._token_url = URL(f"http://{host}/app?token={mock_aes_device.token}")
+    transport._token_url = URL(f"{transport._app_url}?token={mock_aes_device.token}")
 
     request = {
         "method": "get_device_info",

--- a/kasa/tests/test_httpclient.py
+++ b/kasa/tests/test_httpclient.py
@@ -84,7 +84,7 @@ async def test_httpclient_errors(mocker, error, error_raises, error_message, moc
     client = HttpClient(DeviceConfig(host))
     # Exceptions with parameters print with double quotes, without use single quotes
     full_msg = (
-        "\("
+        "\("  # type: ignore
         + "['\"]"
         + re.escape(f"{error_message}{host}: {error}")
         + "['\"]"


### PR DESCRIPTION
URLs with IP addresses are expensive to rebuild because an ip_address object has to be created each time. We don't need to rebuild them over and over

<img width="1303" alt="Screenshot 2024-01-26 at 8 54 16 AM" src="https://github.com/python-kasa/python-kasa/assets/663432/30db765a-9f5a-4cb0-b7b5-7529d8f110b7">
