### PR TITLE
Guard for empty responses from child devices

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -182,6 +182,9 @@ class AesTransport(BaseTransport):
             assert self._encryption_session is not None
 
         raw_response: str = resp_dict["result"]["response"]
+        if not raw_response:
+            raise SmartDeviceException("Unexpected empty response")
+
         response = self._encryption_session.decrypt(raw_response.encode())
         return json_loads(response)  # type: ignore[return-value]
 

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -130,6 +130,9 @@ class SmartProtocol(BaseProtocol):
             _LOGGER.isEnabledFor(logging.DEBUG) and pf(response_data),
         )
 
+        if not response_data:
+            raise SmartDeviceException("Unexpected empty response")
+
         self._handle_response_error_code(response_data)
 
         if (result := response_data.get("result")) is None:


### PR DESCRIPTION
Saw the device responding with '{}' for an invalid control_child commands, unsure if it's worth to guard against that so leaving this as a draft for now.