### PR TITLE
Unignore F401 for tests

### DIFF
--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -5,8 +5,8 @@ import os
 from dataclasses import dataclass
 from json import dumps as json_dumps
 from os.path import basename
-from pathlib import Path, PurePath
-from typing import Dict, Optional, Set
+from pathlib import Path
+from typing import Dict, Optional
 from unittest.mock import MagicMock
 
 import pytest  # type: ignore # see https://github.com/pytest-dev/pytest/issues/3342

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -6,7 +6,7 @@ import time
 from contextlib import nullcontext as does_not_raise
 from json import dumps as json_dumps
 from json import loads as json_loads
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 import aiohttp
 import pytest
@@ -18,8 +18,6 @@ from ..aestransport import AesEncyptionSession, AesTransport, TransportState
 from ..credentials import Credentials
 from ..deviceconfig import DeviceConfig
 from ..exceptions import (
-    SMART_RETRYABLE_ERRORS,
-    SMART_TIMEOUT_ERRORS,
     AuthenticationException,
     SmartDeviceException,
     SmartErrorCode,

--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -1,11 +1,7 @@
 import pytest
 from voluptuous import (
-    REMOVE_EXTRA,
     All,
-    Any,
     Boolean,
-    Coerce,  # type: ignore
-    Invalid,
     Optional,
     Range,
     Schema,

--- a/kasa/tests/test_childdevice.py
+++ b/kasa/tests/test_childdevice.py
@@ -1,5 +1,4 @@
 from kasa.smartprotocol import _ChildProtocolWrapper
-from kasa.tapo import ChildDevice
 
 from .conftest import strip_smart
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -7,7 +7,6 @@ from asyncclick.testing import CliRunner
 
 from kasa import (
     AuthenticationException,
-    Credentials,
     EmeterStatus,
     SmartDevice,
     SmartDeviceException,
@@ -28,7 +27,6 @@ from kasa.cli import (
     wifi,
 )
 from kasa.discover import Discover, DiscoveryResult
-from kasa.smartprotocol import SmartProtocol
 
 from .conftest import device_iot, device_smart, handle_turn_on, new_discovery, turn_on
 

--- a/kasa/tests/test_device_factory.py
+++ b/kasa/tests/test_device_factory.py
@@ -1,20 +1,14 @@
 # type: ignore
 import logging
-from typing import Type
 
 import aiohttp
 import pytest  # type: ignore # https://github.com/pytest-dev/pytest/issues/3342
 
 from kasa import (
     Credentials,
-    DeviceType,
     Discover,
-    SmartBulb,
     SmartDevice,
     SmartDeviceException,
-    SmartDimmer,
-    SmartLightStrip,
-    SmartPlug,
 )
 from kasa.device_factory import connect, get_protocol
 from kasa.deviceconfig import (

--- a/kasa/tests/test_deviceconfig.py
+++ b/kasa/tests/test_deviceconfig.py
@@ -6,10 +6,7 @@ import pytest
 
 from kasa.credentials import Credentials
 from kasa.deviceconfig import (
-    ConnectionType,
     DeviceConfig,
-    DeviceFamilyType,
-    EncryptType,
 )
 from kasa.exceptions import SmartDeviceException
 

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -1,6 +1,5 @@
 # type: ignore
 import asyncio
-import logging
 import re
 import socket
 from unittest.mock import MagicMock
@@ -15,26 +14,21 @@ from kasa import (
     Discover,
     SmartDevice,
     SmartDeviceException,
-    protocol,
 )
 from kasa.deviceconfig import (
     ConnectionType,
     DeviceConfig,
-    DeviceFamilyType,
-    EncryptType,
 )
 from kasa.discover import DiscoveryResult, _DiscoverProtocol, json_dumps
 from kasa.exceptions import AuthenticationException, UnsupportedDeviceException
 from kasa.xortransport import XorEncryption
 
 from .conftest import (
-    bulb,
     bulb_iot,
     dimmer,
     lightstrip,
     new_discovery,
     plug,
-    strip,
     strip_iot,
 )
 

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -3,12 +3,9 @@ from unittest.mock import Mock
 
 import pytest
 from voluptuous import (
-    REMOVE_EXTRA,
     All,
     Any,
     Coerce,  # type: ignore
-    Invalid,
-    Optional,
     Range,
     Schema,
 )

--- a/kasa/tests/test_klapprotocol.py
+++ b/kasa/tests/test_klapprotocol.py
@@ -1,12 +1,8 @@
-import errno
 import json
 import logging
 import secrets
-import struct
-import sys
 import time
 from contextlib import nullcontext as does_not_raise
-from unittest.mock import PropertyMock
 
 import aiohttp
 import pytest

--- a/kasa/tests/test_protocol.py
+++ b/kasa/tests/test_protocol.py
@@ -461,8 +461,6 @@ def test_decrypt_unicode(decrypt_class):
 
 
 def _get_subclasses(of_class):
-    import kasa
-
     package = sys.modules["kasa"]
     subclasses = set()
     for _, modname, _ in pkgutil.iter_modules(package.__path__):

--- a/kasa/tests/test_readme_examples.py
+++ b/kasa/tests/test_readme_examples.py
@@ -1,7 +1,5 @@
 import asyncio
-import sys
 
-import pytest
 import xdoctest
 
 from kasa.tests.conftest import get_device_for_file

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -1,5 +1,4 @@
 from itertools import chain
-from typing import Dict
 
 import pytest
 
@@ -11,8 +10,7 @@ from ..exceptions import (
     SmartDeviceException,
     SmartErrorCode,
 )
-from ..protocol import BaseTransport
-from ..smartprotocol import SmartProtocol, _ChildProtocolWrapper
+from ..smartprotocol import _ChildProtocolWrapper
 
 DUMMY_QUERY = {"foobar": {"foo": "bar", "bar": "foo"}}
 DUMMY_MULTIPLE_QUERY = {

--- a/kasa/tests/test_usage.py
+++ b/kasa/tests/test_usage.py
@@ -1,8 +1,6 @@
 import datetime
 from unittest.mock import Mock
 
-import pytest
-
 from kasa.modules import Usage
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,6 @@ convention = "pep257"
     "D102",
     "D103",
     "D104",
-    "F401",
     "S101", # allow asserts
     "E501", # ignore line-too-longs
 ]


### PR DESCRIPTION
Re-enables https://docs.astral.sh/ruff/rules/unused-import/ for tests to clean up unused imports.