### PR TITLE
Fix TapoBulb state information for non-dimmable SMARTSWITCH

### DIFF
--- a/kasa/tapo/tapobulb.py
+++ b/kasa/tapo/tapobulb.py
@@ -243,9 +243,10 @@ class TapoBulb(TapoDevice, SmartBulb):
         info: Dict[str, Any] = {
             # TODO: re-enable after we don't inherit from smartbulb
             # **super().state_information
-            "Brightness": self.brightness,
             "Is dimmable": self.is_dimmable,
         }
+        if self.is_dimmable:
+            info["Brightness"] = self.brightness
         if self.is_variable_color_temp:
             info["Color temperature"] = self.color_temp
             info["Valid temperature range"] = self.valid_temperature_range


### PR DESCRIPTION
Non dimmable SMARTSWITCHes raise exceptions on `state_information`