### PR TITLE
Query and initialize child components

### DIFF
--- a/kasa/tapo/childdevice.py
+++ b/kasa/tapo/childdevice.py
@@ -17,6 +17,7 @@ class ChildDevice(TapoDevice):
         self,
         parent: TapoDevice,
         child_id: str,
+        components: Dict,
         config: Optional[DeviceConfig] = None,
         protocol: Optional[SmartProtocol] = None,
     ) -> None:
@@ -24,6 +25,7 @@ class ChildDevice(TapoDevice):
         self._parent = parent
         self._id = child_id
         self.protocol = _ChildProtocolWrapper(child_id, parent.protocol)
+        self._components = components
 
     async def update(self, update_children: bool = True):
         """We just set the info here accordingly."""

--- a/kasa/tests/test_childdevice.py
+++ b/kasa/tests/test_childdevice.py
@@ -28,3 +28,15 @@ async def test_childdevice_update(dev, dummy_protocol, mocker):
 
     assert dev._last_update != first._last_update
     assert dev._last_update["child_info"]["child_device_list"][0] == first._last_update
+
+
+@strip_smart
+async def test_childdevice_components(dev, dummy_protocol, mocker):
+    """Test that childdevice components is correctly set."""
+    first = dev.children[0]
+    assert first._components
+    # TODO: Fix tests, awaiting dev.update() fails
+    return
+    query_mock = mocker.patch.object(dev.protocol, "query")
+    await dev.update()
+    query_mock.assert_called_with("get_child_device_component_list")


### PR DESCRIPTION
Initializes the list of available components for child devices.

Fixes the issue seen in homeassistant (#729), tests should be improved before this can be merged.