### PR TITLE
Fix port-override for aes&klap transports

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -102,7 +102,7 @@ class AesTransport(BaseTransport):
         self._session_cookie: Optional[Dict[str, str]] = None
 
         self._key_pair: Optional[KeyPair] = None
-        self._app_url = URL(f"http://{self._host}/app")
+        self._app_url = URL(f"http://{self._host}:{self._port}/app")
         self._token_url: Optional[URL] = None
 
         _LOGGER.debug("Created AES transport for %s", self._host)
@@ -257,7 +257,6 @@ class AesTransport(BaseTransport):
         self._session_expire_at = None
         self._session_cookie = None
 
-        url = f"http://{self._host}/app"
         # Device needs the content length or it will response with 500
         headers = {
             **self.COMMON_HEADERS,
@@ -266,7 +265,7 @@ class AesTransport(BaseTransport):
         http_client = self._http_client
 
         status_code, resp_dict = await http_client.post(
-            url,
+            self._app_url,
             json=self._generate_key_pair_payload(),
             headers=headers,
             cookies_dict=self._session_cookie,

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -334,6 +334,7 @@ async def cli(
         )
         config = DeviceConfig(
             host=host,
+            port_override=port,
             credentials=credentials,
             credentials_hash=credentials_hash,
             timeout=timeout,

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -1,5 +1,6 @@
 """Module for HttpClientSession class."""
 import asyncio
+import logging
 from typing import Any, Dict, Optional, Tuple, Union
 
 import aiohttp
@@ -12,6 +13,8 @@ from .exceptions import (
     TimeoutException,
 )
 from .json import loads as json_loads
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def get_cookie_jar() -> aiohttp.CookieJar:
@@ -54,6 +57,7 @@ class HttpClient:
 
         If the request is provided via the json parameter json will be returned.
         """
+        _LOGGER.debug("Posting to %s", url)
         response_data = None
         self._last_url = url
         self.client.cookie_jar.clear()

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -121,7 +121,7 @@ class KlapTransport(BaseTransport):
         self._session_cookie: Optional[Dict[str, Any]] = None
 
         _LOGGER.debug("Created KLAP transport for %s", self._host)
-        self._app_url = URL(f"http://{self._host}/app")
+        self._app_url = URL(f"http://{self._host}:{self._port}/app")
         self._request_url = self._app_url / "request"
 
     @property

--- a/kasa/tests/test_aestransport.py
+++ b/kasa/tests/test_aestransport.py
@@ -209,6 +209,17 @@ async def test_passthrough_errors(mocker, error_code):
         await transport.send(json_dumps(request))
 
 
+async def test_port_override():
+    """Test that port override sets the app_url."""
+    host = "127.0.0.1"
+    config = DeviceConfig(
+        host, credentials=Credentials("foo", "bar"), port_override=12345
+    )
+    transport = AesTransport(config=config)
+
+    assert str(transport._app_url) == "http://127.0.0.1:12345/app"
+
+
 class MockAesDevice:
     class _mock_response:
         def __init__(self, status, json: dict):
@@ -256,7 +267,7 @@ class MockAesDevice:
         elif json["method"] == "login_device":
             return await self._return_login_response(url, json)
         else:
-            assert str(url) == f"http://{self.host}/app?token={self.token}"
+            assert str(url) == f"http://{self.host}:80/app?token={self.token}"
             return await self._return_send_response(url, json)
 
     async def _return_handshake_response(self, url: URL, json: Dict[str, Any]):


### PR DESCRIPTION
Makes it possible to use custom ports, needs tests.