### PR TITLE
Add generic interface for accessing device features

### DIFF
--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -33,7 +33,7 @@ from kasa.exceptions import (
     TimeoutException,
     UnsupportedDeviceException,
 )
-from kasa.feature import Feature, FeatureCategory, FeatureType
+from kasa.feature import Feature, FeatureType
 from kasa.iot.iotbulb import BulbPreset, TurnOnBehavior, TurnOnBehaviors
 from kasa.iotprotocol import (
     IotProtocol,
@@ -57,7 +57,6 @@ __all__ = [
     "DeviceType",
     "Feature",
     "FeatureType",
-    "FeatureCategory",
     "EmeterStatus",
     "Device",
     "Bulb",

--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -17,7 +17,6 @@ from warnings import warn
 
 from kasa.bulb import Bulb
 from kasa.credentials import Credentials
-from kasa.descriptors import Descriptor, DescriptorCategory, DescriptorType
 from kasa.device import Device
 from kasa.device_type import DeviceType
 from kasa.deviceconfig import (
@@ -34,6 +33,7 @@ from kasa.exceptions import (
     TimeoutException,
     UnsupportedDeviceException,
 )
+from kasa.feature import Feature, FeatureCategory, FeatureType
 from kasa.iot.iotbulb import BulbPreset, TurnOnBehavior, TurnOnBehaviors
 from kasa.iotprotocol import (
     IotProtocol,
@@ -55,9 +55,9 @@ __all__ = [
     "TurnOnBehaviors",
     "TurnOnBehavior",
     "DeviceType",
-    "Descriptor",
-    "DescriptorType",
-    "DescriptorCategory",
+    "Feature",
+    "FeatureType",
+    "FeatureCategory",
     "EmeterStatus",
     "Device",
     "Bulb",

--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -17,6 +17,7 @@ from warnings import warn
 
 from kasa.bulb import Bulb
 from kasa.credentials import Credentials
+from kasa.descriptors import Descriptor, DescriptorCategory, DescriptorType
 from kasa.device import Device
 from kasa.device_type import DeviceType
 from kasa.deviceconfig import (
@@ -54,6 +55,9 @@ __all__ = [
     "TurnOnBehaviors",
     "TurnOnBehavior",
     "DeviceType",
+    "Descriptor",
+    "DescriptorType",
+    "DescriptorCategory",
     "EmeterStatus",
     "Device",
     "Bulb",

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -101,6 +101,7 @@ class ExceptionHandlerGroup(click.Group):
             asyncio.get_event_loop().run_until_complete(self.main(*args, **kwargs))
         except Exception as ex:
             echo(f"Got error: {ex!r}")
+            raise
 
 
 def json_formatter_cb(result, **kwargs):
@@ -565,9 +566,9 @@ async def state(ctx, dev: Device):
         else:
             echo(f"\t{info_name}: {info_data}")
 
-    echo("\n\t[bold]== Descriptors == [/bold]")
-    for id_, descriptor in dev.descriptors.items():
-        echo(f"\t{descriptor.name} ({id_}): {descriptor.value}")
+    echo("\n\t[bold]== Features == [/bold]")
+    for id_, feature in dev.features.items():
+        echo(f"\t{feature.name} ({id_}): {feature.value}")
 
     if dev.has_emeter:
         echo("\n\t[bold]== Current State ==[/bold]")
@@ -585,8 +586,6 @@ async def state(ctx, dev: Device):
         echo("\n\t[bold]== Verbose information ==[/bold]")
         echo(f"\tCredentials hash:  {dev.credentials_hash}")
         echo(f"\tDevice ID:         {dev.device_id}")
-        for feature in dev.features:
-            echo(f"\tFeature:           {feature}")
         echo()
         _echo_discovery_info(dev._discovery_info)
     return dev.internal_state
@@ -1106,11 +1105,11 @@ async def shell(dev: Device):
         loop.stop()
 
 
-@cli.command(name="descriptor")
+@cli.command(name="feature")
 @click.argument("name", required=False)
 @click.argument("value", required=False)
 @pass_dev
-async def descriptor(dev, name: str, value):
+async def feature(dev, name: str, value):
     """Access and modify descriptor values.
 
     If no *name* is given, lists available descriptors and their values.
@@ -1118,24 +1117,24 @@ async def descriptor(dev, name: str, value):
     If both *name* and *value* are set, the described setting is changed.
     """
     if not name:
-        echo("[bold]== Descriptors ==[/bold]")
-        for name, desc in dev.descriptors.items():
-            echo(f"{desc.name} ({name}): {desc.value}")
+        echo("[bold]== Feature ==[/bold]")
+        for name, feat in dev.features.items():
+            echo(f"{feat.name} ({name}): {feat.value}")
         return
 
-    if name not in dev.descriptors:
+    if name not in dev.features:
         echo(f"No descriptor by name {name}")
         return
 
-    desc = dev.descriptors[name]
+    feat = dev.features[name]
 
     if value is None:
-        echo(f"{desc.name} ({name}): {desc.value}")
-        return desc.value
+        echo(f"{feat.name} ({name}): {feat.value}")
+        return feat.value
 
     echo(f"Setting {name} to {value}")
     value = ast.literal_eval(value)
-    return await dev.descriptors[name].set_value(value)
+    return await dev.features[name].set_value(value)
 
 
 if __name__ == "__main__":

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -1117,7 +1117,7 @@ async def feature(dev, name: str, value):
     If both *name* and *value* are set, the described setting is changed.
     """
     if not name:
-        echo("[bold]== Feature ==[/bold]")
+        echo("[bold]== Features ==[/bold]")
         for name, feat in dev.features.items():
             echo(f"{feat.name} ({name}): {feat.value}")
         return

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -1110,10 +1110,10 @@ async def shell(dev: Device):
 @click.argument("value", required=False)
 @pass_dev
 async def feature(dev, name: str, value):
-    """Access and modify descriptor values.
+    """Access and modify features.
 
-    If no *name* is given, lists available descriptors and their values.
-    If only *name* is given, the value of named descriptor is returned.
+    If no *name* is given, lists available features and their values.
+    If only *name* is given, the value of named feature is returned.
     If both *name* and *value* are set, the described setting is changed.
     """
     if not name:
@@ -1123,7 +1123,7 @@ async def feature(dev, name: str, value):
         return
 
     if name not in dev.features:
-        echo(f"No descriptor by name {name}")
+        echo(f"No feature by name {name}")
         return
 
     feat = dev.features[name]

--- a/kasa/descriptors.py
+++ b/kasa/descriptors.py
@@ -1,0 +1,54 @@
+"""Generic interface for defining device features."""
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Callable
+
+
+class DescriptorCategory(Enum):
+    """Descriptor category."""
+
+    # TODO: we could probably do better than using the scheme homeassistant is using
+    Config = auto()
+    Diagnostic = auto()
+
+
+class DescriptorType(Enum):
+    """Type of the information defined by the descriptor."""
+
+    Sensor = auto()
+    BinarySensor = auto()
+    Switch = auto()
+    Button = auto()
+
+
+@dataclass
+class Descriptor:
+    """Descriptor defines a generic interface for device features."""
+
+    device: Any  # TODO: rename to something else, this can also be a module.
+    #: User-friendly short description
+    name: str
+    #: Name of the property that allows accessing the value
+    attribute_getter: str | Callable
+    #: Name of the method that allows changing the value
+    attribute_setter: str | None = None
+    #: Type of the information
+    icon: str | None = None
+    #: Unit of the descriptor
+    unit: str | None = None
+    #: Hint for homeassistant
+    #: TODO: Replace with a set of flags to allow homeassistant make its own decision?
+    show_in_hass: bool = True
+    category: DescriptorCategory = DescriptorCategory.Diagnostic
+    type: DescriptorType = DescriptorType.Sensor
+
+    @property
+    def value(self):
+        """Return the current value."""
+        if isinstance(self.attribute_getter, Callable):
+            return self.attribute_getter(self.device)
+        return getattr(self.device, self.attribute_getter)
+
+    async def set_value(self, value):
+        """Set the value."""
+        return await getattr(self.device, self.attribute_setter)(value)

--- a/kasa/device.py
+++ b/kasa/device.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Sequence, Set, Union
 
 from .credentials import Credentials
+from .descriptors import Descriptor
 from .device_type import DeviceType
 from .deviceconfig import DeviceConfig
 from .emeterstatus import EmeterStatus
@@ -69,6 +70,7 @@ class Device(ABC):
         self._discovery_info: Optional[Dict[str, Any]] = None
 
         self.modules: Dict[str, Any] = {}
+        self._descriptors: Dict[str, Descriptor] = {}
 
     @staticmethod
     async def connect(
@@ -342,6 +344,18 @@ class Device(ABC):
     @abstractmethod
     async def set_alias(self, alias: str):
         """Set the device name (alias)."""
+
+    @property
+    def descriptors(self) -> Dict[str, Descriptor]:
+        """Return the list of descriptors."""
+        return self._descriptors
+
+    def add_descriptor(self, descriptor: "Descriptor"):
+        """Add a new descriptor to the device."""
+        desc_name = descriptor.name.lower().replace(" ", "_")
+        if desc_name in self._descriptors:
+            raise SmartDeviceException("Duplicate descriptor name %s" % desc_name)
+        self._descriptors[desc_name] = descriptor
 
     def __repr__(self):
         if self._last_update is None:

--- a/kasa/device.py
+++ b/kasa/device.py
@@ -3,14 +3,14 @@ import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Sequence, Set, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 from .credentials import Credentials
-from .descriptors import Descriptor
 from .device_type import DeviceType
 from .deviceconfig import DeviceConfig
 from .emeterstatus import EmeterStatus
 from .exceptions import SmartDeviceException
+from .feature import Feature
 from .iotprotocol import IotProtocol
 from .protocol import BaseProtocol
 from .xortransport import XorTransport
@@ -70,7 +70,7 @@ class Device(ABC):
         self._discovery_info: Optional[Dict[str, Any]] = None
 
         self.modules: Dict[str, Any] = {}
-        self._descriptors: Dict[str, Descriptor] = {}
+        self._features: Dict[str, Feature] = {}
 
     @staticmethod
     async def connect(
@@ -298,9 +298,16 @@ class Device(ABC):
         """Return the key state information."""
 
     @property
-    @abstractmethod
-    def features(self) -> Set[str]:
+    def features(self) -> Dict[str, Feature]:
         """Return the list of supported features."""
+        return self._features
+
+    def add_feature(self, feature: Feature):
+        """Add a new feature to the device."""
+        desc_name = feature.name.lower().replace(" ", "_")
+        if desc_name in self._features:
+            raise SmartDeviceException("Duplicate feature name %s" % desc_name)
+        self._features[desc_name] = feature
 
     @property
     @abstractmethod
@@ -344,18 +351,6 @@ class Device(ABC):
     @abstractmethod
     async def set_alias(self, alias: str):
         """Set the device name (alias)."""
-
-    @property
-    def descriptors(self) -> Dict[str, Descriptor]:
-        """Return the list of descriptors."""
-        return self._descriptors
-
-    def add_descriptor(self, descriptor: "Descriptor"):
-        """Add a new descriptor to the device."""
-        desc_name = descriptor.name.lower().replace(" ", "_")
-        if desc_name in self._descriptors:
-            raise SmartDeviceException("Duplicate descriptor name %s" % desc_name)
-        self._descriptors[desc_name] = descriptor
 
     def __repr__(self):
         if self._last_update is None:

--- a/kasa/device.py
+++ b/kasa/device.py
@@ -302,7 +302,7 @@ class Device(ABC):
         """Return the list of supported features."""
         return self._features
 
-    def add_feature(self, feature: Feature):
+    def _add_feature(self, feature: Feature):
         """Add a new feature to the device."""
         desc_name = feature.name.lower().replace(" ", "_")
         if desc_name in self._features:

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -7,14 +7,6 @@ if TYPE_CHECKING:
     from .device import Device
 
 
-class FeatureCategory(Enum):
-    """Feature category."""
-
-    # TODO: we could probably do better than using the scheme homeassistant is using
-    Config = auto()
-    Diagnostic = auto()
-
-
 class FeatureType(Enum):
     """Type to help decide how to present the feature."""
 
@@ -40,10 +32,7 @@ class Feature:
     container: Any = None
     #: Icon suggestion
     icon: str | None = None
-    #: Hint for homeassistant
-    #: TODO: Replace with a set of flags to allow homeassistant make its own decision?
-    show_in_hass: bool = True
-    category: FeatureCategory = FeatureCategory.Diagnostic
+    #: Type of the feature
     type: FeatureType = FeatureType.Sensor
 
     @property

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -1,7 +1,7 @@
 """Generic interface for defining device features."""
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 if TYPE_CHECKING:
     from .device import Device
@@ -25,13 +25,13 @@ class Feature:
     #: User-friendly short description
     name: str
     #: Name of the property that allows accessing the value
-    attribute_getter: str | Callable
+    attribute_getter: Union[str, Callable]
     #: Name of the method that allows changing the value
-    attribute_setter: str | None = None
+    attribute_setter: Optional[str] = None
     #: Container storing the data, this overrides 'device' for getters
     container: Any = None
     #: Icon suggestion
-    icon: str | None = None
+    icon: Optional[str] = None
     #: Type of the feature
     type: FeatureType = FeatureType.Sensor
 

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 
 class FeatureCategory(Enum):
-    """Descriptor category."""
+    """Feature category."""
 
     # TODO: we could probably do better than using the scheme homeassistant is using
     Config = auto()
@@ -40,8 +40,6 @@ class Feature:
     container: Any = None
     #: Icon suggestion
     icon: str | None = None
-    #: Unit of the descriptor
-    unit: str | None = None
     #: Hint for homeassistant
     #: TODO: Replace with a set of flags to allow homeassistant make its own decision?
     show_in_hass: bool = True

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -313,11 +313,6 @@ class IotDevice(Device):
                 device=self, name="RSSI", attribute_getter="rssi", icon="mdi:signal"
             )
         )
-        self._add_feature(
-            Feature(
-                device=self, name="Time", attribute_getter="time", show_in_hass=False
-            )
-        )
         if "on_time" in self._sys_info:
             self._add_feature(
                 Feature(

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -308,18 +308,18 @@ class IotDevice(Device):
         self._set_sys_info(self._last_update["system"]["get_sysinfo"])
 
     async def _initialize_features(self):
-        self.add_feature(
+        self._add_feature(
             Feature(
                 device=self, name="RSSI", attribute_getter="rssi", icon="mdi:signal"
             )
         )
-        self.add_feature(
+        self._add_feature(
             Feature(
                 device=self, name="Time", attribute_getter="time", show_in_hass=False
             )
         )
         if "on_time" in self._sys_info:
-            self.add_feature(
+            self._add_feature(
                 Feature(
                     device=self,
                     name="On since",
@@ -344,7 +344,7 @@ class IotDevice(Device):
                 if module.is_supported:
                     supported[module._module] = module
                 for module_feat in module._module_features.values():
-                    self.add_feature(module_feat)
+                    self._add_feature(module_feat)
 
             self._supported_modules = supported
 

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -302,12 +302,12 @@ class IotDevice(Device):
             self._set_sys_info(response["system"]["get_sysinfo"])
 
         if not self._features:
-            await self._initialize_descriptors()
+            await self._initialize_features()
 
         await self._modular_update(req)
         self._set_sys_info(self._last_update["system"]["get_sysinfo"])
 
-    async def _initialize_descriptors(self):
+    async def _initialize_features(self):
         self.add_feature(
             Feature(
                 device=self, name="RSSI", attribute_getter="rssi", icon="mdi:signal"

--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -2,9 +2,9 @@
 import logging
 from typing import Any, Dict, Optional
 
-from ..descriptors import Descriptor, DescriptorCategory, DescriptorType
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
+from ..feature import Feature, FeatureCategory, FeatureType
 from ..protocol import BaseProtocol
 from .iotdevice import IotDevice, requires_update
 from .modules import Antitheft, Cloud, Schedule, Time, Usage
@@ -57,15 +57,15 @@ class IotPlug(IotDevice):
         self.add_module("time", Time(self, "time"))
         self.add_module("cloud", Cloud(self, "cnCloud"))
 
-        self.add_descriptor(
-            Descriptor(
+        self.add_feature(
+            Feature(
                 device=self,
                 name="LED",
                 icon="mdi:led-{state}",
                 attribute_getter="led",
                 attribute_setter="set_led",
-                category=DescriptorCategory.Config,
-                type=DescriptorType.Switch,
+                category=FeatureCategory.Config,
+                type=FeatureType.Switch,
             )
         )
 

--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
-from ..feature import Feature, FeatureCategory, FeatureType
+from ..feature import Feature, FeatureType
 from ..protocol import BaseProtocol
 from .iotdevice import IotDevice, requires_update
 from .modules import Antitheft, Cloud, Schedule, Time, Usage
@@ -64,7 +64,6 @@ class IotPlug(IotDevice):
                 icon="mdi:led-{state}",
                 attribute_getter="led",
                 attribute_setter="set_led",
-                category=FeatureCategory.Config,
                 type=FeatureType.Switch,
             )
         )

--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -2,6 +2,7 @@
 import logging
 from typing import Any, Dict, Optional
 
+from ..descriptors import Descriptor, DescriptorCategory, DescriptorType
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
 from ..protocol import BaseProtocol
@@ -56,6 +57,18 @@ class IotPlug(IotDevice):
         self.add_module("time", Time(self, "time"))
         self.add_module("cloud", Cloud(self, "cnCloud"))
 
+        self.add_descriptor(
+            Descriptor(
+                device=self,
+                name="LED",
+                icon="mdi:led-{state}",
+                attribute_getter="led",
+                attribute_setter="set_led",
+                category=DescriptorCategory.Config,
+                type=DescriptorType.Switch,
+            )
+        )
+
     @property  # type: ignore
     @requires_update
     def is_on(self) -> bool:
@@ -88,5 +101,4 @@ class IotPlug(IotDevice):
     @requires_update
     def state_information(self) -> Dict[str, Any]:
         """Return switch-specific state information."""
-        info = {"LED state": self.led, "On since": self.on_since}
-        return info
+        return {}

--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -57,7 +57,7 @@ class IotPlug(IotDevice):
         self.add_module("time", Time(self, "time"))
         self.add_module("cloud", Cloud(self, "cnCloud"))
 
-        self.add_feature(
+        self._add_feature(
             Feature(
                 device=self,
                 name="LED",

--- a/kasa/iot/modules/cloud.py
+++ b/kasa/iot/modules/cloud.py
@@ -28,7 +28,7 @@ class Cloud(IotModule):
 
     def __init__(self, device, module):
         super().__init__(device, module)
-        self.add_feature(
+        self._add_feature(
             Feature(
                 device=device,
                 container=self,

--- a/kasa/iot/modules/cloud.py
+++ b/kasa/iot/modules/cloud.py
@@ -4,7 +4,7 @@ try:
 except ImportError:
     from pydantic import BaseModel
 
-from ...descriptors import Descriptor, DescriptorType
+from ...feature import Feature, FeatureType
 from .module import IotModule
 
 
@@ -28,13 +28,14 @@ class Cloud(IotModule):
 
     def __init__(self, device, module):
         super().__init__(device, module)
-        self.add_descriptor(
-            Descriptor(
-                device=self,
-                name="Cloud Connection",
+        self.add_feature(
+            Feature(
+                device=device,
+                container=self,
+                name="Cloud connection",
                 icon="mdi:cloud",
                 attribute_getter="is_connected",
-                type=DescriptorType.BinarySensor,
+                type=FeatureType.BinarySensor,
             )
         )
 

--- a/kasa/iot/modules/cloud.py
+++ b/kasa/iot/modules/cloud.py
@@ -4,6 +4,7 @@ try:
 except ImportError:
     from pydantic import BaseModel
 
+from ...descriptors import Descriptor, DescriptorType
 from .module import IotModule
 
 
@@ -24,6 +25,23 @@ class CloudInfo(BaseModel):
 
 class Cloud(IotModule):
     """Module implementing support for cloud services."""
+
+    def __init__(self, device, module):
+        super().__init__(device, module)
+        self.add_descriptor(
+            Descriptor(
+                device=self,
+                name="Cloud Connection",
+                icon="mdi:cloud",
+                attribute_getter="is_connected",
+                type=DescriptorType.BinarySensor,
+            )
+        )
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if device is connected to the cloud."""
+        return self.info.binded
 
     def query(self):
         """Request cloud connectivity info."""

--- a/kasa/iot/modules/module.py
+++ b/kasa/iot/modules/module.py
@@ -37,7 +37,7 @@ class IotModule(ABC):
         self._module = module
         self._module_features: Dict[str, Feature] = {}
 
-    def add_feature(self, feature: Feature):
+    def _add_feature(self, feature: Feature):
         """Add module feature."""
         feature_name = f"{self._module}_{feature.name}"
         if feature_name in self._module_features:

--- a/kasa/iot/modules/module.py
+++ b/kasa/iot/modules/module.py
@@ -4,8 +4,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Dict
 
-from ...descriptors import Descriptor
 from ...exceptions import SmartDeviceException
+from ...feature import Feature
 
 if TYPE_CHECKING:
     from kasa.iot import IotDevice
@@ -35,14 +35,14 @@ class IotModule(ABC):
     def __init__(self, device: "IotDevice", module: str):
         self._device = device
         self._module = module
-        self._module_descriptors: Dict[str, Descriptor] = {}
+        self._module_features: Dict[str, Feature] = {}
 
-    def add_descriptor(self, desc):
+    def add_feature(self, feature: Feature):
         """Add module descriptor."""
-        module_desc_name = f"{self._module}_{desc.name}"
-        if module_desc_name in self._module_descriptors:
-            raise Exception("Duplicate name detected %s" % module_desc_name)
-        self._module_descriptors[module_desc_name] = desc
+        feature_name = f"{self._module}_{feature.name}"
+        if feature_name in self._module_features:
+            raise SmartDeviceException("Duplicate name detected %s" % feature_name)
+        self._module_features[feature_name] = feature
 
     @abstractmethod
     def query(self):

--- a/kasa/iot/modules/module.py
+++ b/kasa/iot/modules/module.py
@@ -38,7 +38,7 @@ class IotModule(ABC):
         self._module_features: Dict[str, Feature] = {}
 
     def add_feature(self, feature: Feature):
-        """Add module descriptor."""
+        """Add module feature."""
         feature_name = f"{self._module}_{feature.name}"
         if feature_name in self._module_features:
             raise SmartDeviceException("Duplicate name detected %s" % feature_name)

--- a/kasa/iot/modules/module.py
+++ b/kasa/iot/modules/module.py
@@ -2,8 +2,9 @@
 import collections
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
+from ...descriptors import Descriptor
 from ...exceptions import SmartDeviceException
 
 if TYPE_CHECKING:
@@ -34,6 +35,14 @@ class IotModule(ABC):
     def __init__(self, device: "IotDevice", module: str):
         self._device = device
         self._module = module
+        self._module_descriptors: Dict[str, Descriptor] = {}
+
+    def add_descriptor(self, desc):
+        """Add module descriptor."""
+        module_desc_name = f"{self._module}_{desc.name}"
+        if module_desc_name in self._module_descriptors:
+            raise Exception("Duplicate name detected %s" % module_desc_name)
+        self._module_descriptors[module_desc_name] = desc
 
     @abstractmethod
     def query(self):

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -150,11 +150,6 @@ class SmartDevice(Device):
             )
         )
         self._add_feature(
-            Feature(
-                device=self, name="Time", attribute_getter="time", show_in_hass=False
-            )
-        )
-        self._add_feature(
             Feature(device=self, name="SSID", attribute_getter="ssid", icon="mdi:wifi")
         )
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -143,6 +143,14 @@ class SmartDevice(Device):
         )
         self.add_descriptor(
             Descriptor(
+                self,
+                "RSSI",
+                attribute_getter=lambda x: x._info["rssi"],
+                icon="mdi:signal",
+            )
+        )
+        self.add_descriptor(
+            Descriptor(
                 device=self, name="Time", attribute_getter="time", show_in_hass=False
             )
         )

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -119,10 +119,10 @@ class SmartDevice(Device):
             for info in child_info["child_device_list"]:
                 self._children[info["device_id"]].update_internal_state(info)
 
-        # We can first initialize the descriptors after the first update.
-        # We make here an assumption that every device has at least a single descriptor.
+        # We can first initialize the features after the first update.
+        # We make here an assumption that every device has at least a single feature.
         if not self._features:
-            await self._initialize_descriptors()
+            await self._initialize_features()
 
         _LOGGER.debug("Got an update: %s", self._last_update)
 
@@ -131,8 +131,8 @@ class SmartDevice(Device):
         if "energy_monitoring" in self._components:
             self.emeter_type = "emeter"
 
-    async def _initialize_descriptors(self):
-        """Initialize device descriptors."""
+    async def _initialize_features(self):
+        """Initialize device features."""
         self.add_feature(
             Feature(
                 self,

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -133,7 +133,7 @@ class SmartDevice(Device):
 
     async def _initialize_features(self):
         """Initialize device features."""
-        self.add_feature(
+        self._add_feature(
             Feature(
                 self,
                 "Signal Level",
@@ -141,7 +141,7 @@ class SmartDevice(Device):
                 icon="mdi:signal",
             )
         )
-        self.add_feature(
+        self._add_feature(
             Feature(
                 self,
                 "RSSI",
@@ -149,17 +149,17 @@ class SmartDevice(Device):
                 icon="mdi:signal",
             )
         )
-        self.add_feature(
+        self._add_feature(
             Feature(
                 device=self, name="Time", attribute_getter="time", show_in_hass=False
             )
         )
-        self.add_feature(
+        self._add_feature(
             Feature(device=self, name="SSID", attribute_getter="ssid", icon="mdi:wifi")
         )
 
         if "overheated" in self._info:
-            self.add_feature(
+            self._add_feature(
                 Feature(
                     self,
                     "Overheated",
@@ -172,7 +172,7 @@ class SmartDevice(Device):
         # We check for the key available, and not for the property truthiness,
         # as the value is falsy when the device is off.
         if "on_time" in self._info:
-            self.add_feature(
+            self._add_feature(
                 Feature(
                     device=self,
                     name="On since",

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -173,7 +173,7 @@ class SmartDevice(Device):
 
         # We check for the key available, and not for the property truthiness,
         # as the value is falsy when the device is off.
-        if "on_since" in self._info:
+        if "on_time" in self._info:
             self.add_descriptor(
                 Descriptor(
                     device=self,

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -36,6 +36,11 @@ async def test_update_called_by_cli(dev, mocker):
     """Test that device update is called on main."""
     runner = CliRunner()
     update = mocker.patch.object(dev, "update")
+
+    # These will mock the features to avoid accessing non-existing
+    mocker.patch("kasa.device.Device.features", return_value={})
+    mocker.patch("kasa.iot.iotdevice.IotDevice.features", return_value={})
+
     mocker.patch("kasa.discover.Discover.discover_single", return_value=dev)
 
     res = await runner.invoke(
@@ -48,6 +53,7 @@ async def test_update_called_by_cli(dev, mocker):
             "--password",
             "bar",
         ],
+        catch_exceptions=False,
     )
     assert res.exit_code == 0
     update.assert_called()
@@ -291,6 +297,10 @@ async def test_brightness(dev):
 async def test_json_output(dev: Device, mocker):
     """Test that the json output produces correct output."""
     mocker.patch("kasa.Discover.discover", return_value={"127.0.0.1": dev})
+    # These will mock the features to avoid accessing non-existing
+    mocker.patch("kasa.device.Device.features", return_value={})
+    mocker.patch("kasa.iot.iotdevice.IotDevice.features", return_value={})
+
     runner = CliRunner()
     res = await runner.invoke(cli, ["--json", "state"], obj=dev)
     assert res.exit_code == 0
@@ -342,6 +352,10 @@ async def test_without_device_type(dev, mocker):
     """Test connecting without the device type."""
     runner = CliRunner()
     mocker.patch("kasa.discover.Discover.discover_single", return_value=dev)
+    # These will mock the features to avoid accessing non-existing
+    mocker.patch("kasa.device.Device.features", return_value={})
+    mocker.patch("kasa.iot.iotdevice.IotDevice.features", return_value={})
+
     res = await runner.invoke(
         cli,
         [
@@ -398,6 +412,10 @@ async def test_duplicate_target_device():
 
 async def test_discover(discovery_mock, mocker):
     """Test discovery output."""
+    # These will mock the features to avoid accessing non-existing
+    mocker.patch("kasa.device.Device.features", return_value={})
+    mocker.patch("kasa.iot.iotdevice.IotDevice.features", return_value={})
+
     runner = CliRunner()
     res = await runner.invoke(
         cli,
@@ -417,6 +435,10 @@ async def test_discover(discovery_mock, mocker):
 
 async def test_discover_host(discovery_mock, mocker):
     """Test discovery output."""
+    # These will mock the features to avoid accessing non-existing
+    mocker.patch("kasa.device.Device.features", return_value={})
+    mocker.patch("kasa.iot.iotdevice.IotDevice.features", return_value={})
+
     runner = CliRunner()
     res = await runner.invoke(
         cli,

--- a/kasa/tests/test_feature.py
+++ b/kasa/tests/test_feature.py
@@ -1,0 +1,79 @@
+import pytest
+
+from kasa import Feature, FeatureType
+
+
+@pytest.fixture
+def dummy_feature() -> Feature:
+    # create_autospec for device slows tests way too much, so we use a dummy here
+    class DummyDevice:
+        pass
+
+    feat = Feature(
+        device=DummyDevice(),  # type: ignore[arg-type]
+        name="dummy_feature",
+        attribute_getter="dummygetter",
+        attribute_setter="dummysetter",
+        container=None,
+        icon="mdi:dummy",
+        type=FeatureType.BinarySensor,
+    )
+    return feat
+
+
+def test_feature_api(dummy_feature: Feature):
+    """Test all properties of a dummy feature."""
+    assert dummy_feature.device is not None
+    assert dummy_feature.name == "dummy_feature"
+    assert dummy_feature.attribute_getter == "dummygetter"
+    assert dummy_feature.attribute_setter == "dummysetter"
+    assert dummy_feature.container is None
+    assert dummy_feature.icon == "mdi:dummy"
+    assert dummy_feature.type == FeatureType.BinarySensor
+
+
+def test_feature_value(dummy_feature: Feature):
+    """Verify that property gets accessed on *value* access."""
+    dummy_feature.attribute_getter = "test_prop"
+    dummy_feature.device.test_prop = "dummy"  # type: ignore[attr-defined]
+    assert dummy_feature.value == "dummy"
+
+
+def test_feature_value_container(mocker, dummy_feature: Feature):
+    """Test that container's attribute is accessed when expected."""
+
+    class DummyContainer:
+        @property
+        def test_prop(self):
+            return "dummy"
+
+    dummy_feature.container = DummyContainer()
+    dummy_feature.attribute_getter = "test_prop"
+
+    mock_dev_prop = mocker.patch.object(
+        dummy_feature, "test_prop", new_callable=mocker.PropertyMock, create=True
+    )
+
+    assert dummy_feature.value == "dummy"
+    mock_dev_prop.assert_not_called()
+
+
+def test_feature_value_callable(dev, dummy_feature: Feature):
+    """Verify that callables work as *attribute_getter*."""
+    dummy_feature.attribute_getter = lambda x: "dummy value"
+    assert dummy_feature.value == "dummy value"
+
+
+async def test_feature_setter(dev, mocker, dummy_feature: Feature):
+    """Verify that *set_value* calls the defined method."""
+    mock_set_dummy = mocker.patch.object(dummy_feature.device, "set_dummy", create=True)
+    dummy_feature.attribute_setter = "set_dummy"
+    await dummy_feature.set_value("dummy value")
+    mock_set_dummy.assert_called_with("dummy value")
+
+
+async def test_feature_setter_read_only(dummy_feature):
+    """Verify that read-only feature raises an exception when trying to change it."""
+    dummy_feature.attribute_setter = None
+    with pytest.raises(ValueError):
+        await dummy_feature.set_value("value for read only feature")

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -67,7 +67,7 @@ async def test_invalid_connection(dev):
 async def test_initial_update_emeter(dev, mocker):
     """Test that the initial update performs second query if emeter is available."""
     dev._last_update = None
-    dev._features = set()
+    dev._legacy_features = set()
     spy = mocker.spy(dev.protocol, "query")
     await dev.update()
     # Devices with small buffers may require 3 queries
@@ -79,7 +79,7 @@ async def test_initial_update_emeter(dev, mocker):
 async def test_initial_update_no_emeter(dev, mocker):
     """Test that the initial update performs second query if emeter is available."""
     dev._last_update = None
-    dev._features = set()
+    dev._legacy_features = set()
     spy = mocker.spy(dev.protocol, "query")
     await dev.update()
     # 2 calls are necessary as some devices crash on unexpected modules
@@ -218,9 +218,9 @@ async def test_features(dev):
     """Make sure features is always accessible."""
     sysinfo = dev._last_update["system"]["get_sysinfo"]
     if "feature" in sysinfo:
-        assert dev.features == set(sysinfo["feature"].split(":"))
+        assert dev._legacy_features == set(sysinfo["feature"].split(":"))
     else:
-        assert dev.features == set()
+        assert dev._legacy_features == set()
 
 
 @device_iot


### PR DESCRIPTION
## Breaking change

`Device.features()` does not return a set of strings but a mapping (`Dict[str, Feature]`).
The earlier behavior can be implemented by using `set(dev.sys_info["feature"].split(":"))`.

---

This adds a generic interface for all device classes to introspect available device features,
that is necessary to make it easier to support a wide variety of supported devices with different set of features.
This will allow constructing generic interfaces (e.g., in homeassistant) that fetch and change these features without hard-coding the API calls.

`Device.features()` now returns a mapping of `<identifier, Feature>` where the `Feature` contains all necessary information (like the name, the icon, a way to get and change the setting) to present and change the defined feature through its interface.

![image](https://github.com/python-kasa/python-kasa/assets/3705853/9b1e8c6c-d5b6-442a-8c61-79f164781218)


TBD:
* [x] Naming of things
* [x] Support for defining units - TBD in a separate PR
* [x] Tests

https://github.com/rytilahti/home-assistant/tree/tplink/feat/descriptors contains the homeassistant changes.