### PR TITLE
Pass timeout parameters to discover_single

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -216,7 +216,7 @@ def json_formatter_cb(result, **kwargs):
 @click.option(
     "--discovery-timeout",
     envvar="KASA_DISCOVERY_TIMEOUT",
-    default=3,
+    default=5,
     required=False,
     show_default=True,
     help="Timeout for discovery.",
@@ -348,11 +348,16 @@ async def cli(
         )
         dev = await Device.connect(config=config)
     else:
-        echo("No --type or --device-family and --encrypt-type defined, discovering..")
+        echo(
+            "No --type or --device-family and --encrypt-type defined, "
+            + f"discovering for {discovery_timeout} seconds.."
+        )
         dev = await Discover.discover_single(
             host,
             port=port,
             credentials=credentials,
+            timeout=timeout,
+            discovery_timeout=discovery_timeout,
         )
 
     # Skip update on specific commands, or if device factory,

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -7,6 +7,7 @@ from asyncclick.testing import CliRunner
 
 from kasa import (
     AuthenticationException,
+    Credentials,
     Device,
     EmeterStatus,
     SmartDeviceException,
@@ -341,7 +342,9 @@ async def test_credentials(discovery_mock, mocker):
 async def test_without_device_type(dev, mocker):
     """Test connecting without the device type."""
     runner = CliRunner()
-    mocker.patch("kasa.discover.Discover.discover_single", return_value=dev)
+    discovery_mock = mocker.patch(
+        "kasa.discover.Discover.discover_single", return_value=dev
+    )
     res = await runner.invoke(
         cli,
         [
@@ -351,9 +354,18 @@ async def test_without_device_type(dev, mocker):
             "foo",
             "--password",
             "bar",
+            "--discovery-timeout",
+            "7",
         ],
     )
     assert res.exit_code == 0
+    assert discovery_mock.called_once_with(
+        host="127.0.0.1",
+        port=None,
+        credentials=Credentials("foo", "bar"),
+        timeout=5,
+        discovery_timeout=7,
+    )
 
 
 @pytest.mark.parametrize("auth_param", ["--username", "--password"])


### PR DESCRIPTION
Related to https://github.com/python-kasa/python-kasa/issues/743.  Will fix the issue with the timeout parameter not having an effect .