### PR TITLE
Let caller handle SMART errors on multi-requests

### DIFF
--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -45,6 +45,9 @@ class ConnectionException(SmartDeviceException):
 class SmartErrorCode(IntEnum):
     """Enum for SMART Error Codes."""
 
+    def __str__(self):
+        return f"{self.name}({self.value})"
+
     SUCCESS = 0
 
     # Transport Errors

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -139,7 +139,7 @@ class SmartProtocol(BaseProtocol):
             self._handle_response_error_code(response_step)
             responses = response_step["result"]["responses"]
             for response in responses:
-                self._handle_response_error_code(response)
+                self._handle_response_error_code(response, raise_on_error=False)
                 result = response.get("result", None)
                 multi_result[response["method"]] = result
         return multi_result
@@ -179,9 +179,12 @@ class SmartProtocol(BaseProtocol):
         result = response_data.get("result")
         return {smart_method: result}
 
-    def _handle_response_error_code(self, resp_dict: dict):
+    def _handle_response_error_code(self, resp_dict: dict, raise_on_error=True):
         error_code = SmartErrorCode(resp_dict.get("error_code"))  # type: ignore[arg-type]
         if error_code == SmartErrorCode.SUCCESS:
+            return
+        if not raise_on_error:
+            resp_dict["result"] = error_code
             return
         msg = (
             f"Error querying device: {self._host}: "

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -1,5 +1,6 @@
 import importlib
 import inspect
+import logging
 import pkgutil
 import re
 import sys
@@ -21,10 +22,18 @@ from voluptuous import (
 
 import kasa
 from kasa import Credentials, Device, DeviceConfig, SmartDeviceException
+from kasa.exceptions import SmartErrorCode
 from kasa.iot import IotDevice
 from kasa.smart import SmartChildDevice, SmartDevice
 
-from .conftest import device_iot, handle_turn_on, has_emeter_iot, no_emeter_iot, turn_on
+from .conftest import (
+    device_iot,
+    device_smart,
+    handle_turn_on,
+    has_emeter_iot,
+    no_emeter_iot,
+    turn_on,
+)
 from .fakeprotocol_iot import FakeIotProtocol
 
 
@@ -298,6 +307,33 @@ async def test_modules_not_supported(dev: IotDevice):
     await dev.update()
     for module in dev.modules.values():
         assert module.is_supported is not None
+
+
+@device_smart
+async def test_update_sub_errors(dev: SmartDevice, caplog):
+    mock_response: dict = {
+        "get_device_info": {},
+        "get_device_usage": SmartErrorCode.PARAMS_ERROR,
+        "get_device_time": {},
+    }
+    caplog.set_level(logging.DEBUG)
+    with patch.object(dev.protocol, "query", return_value=mock_response):
+        await dev.update()
+    msg = "Error PARAMS_ERROR(-1008) getting request get_device_usage for device 127.0.0.123"
+    assert msg in caplog.text
+
+
+@device_smart
+async def test_update_no_device_info(dev: SmartDevice):
+    mock_response: dict = {
+        "get_device_usage": {},
+        "get_device_time": {},
+    }
+    msg = f"get_device_info not found in {mock_response} for device 127.0.0.123"
+    with patch.object(dev.protocol, "query", return_value=mock_response), pytest.raises(
+        SmartDeviceException, match=msg
+    ):
+        await dev.update()
 
 
 @pytest.mark.parametrize(

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -40,7 +40,7 @@ async def test_smart_device_errors(dummy_protocol, mocker, error_code):
 
 @pytest.mark.parametrize("error_code", ERRORS, ids=lambda e: e.name)
 async def test_smart_device_errors_in_multiple_request(
-    dummy_protocol, mocker, error_code, caplog
+    dummy_protocol, mocker, error_code
 ):
     mock_response = {
         "result": {

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -40,7 +40,7 @@ async def test_smart_device_errors(dummy_protocol, mocker, error_code):
 
 @pytest.mark.parametrize("error_code", ERRORS, ids=lambda e: e.name)
 async def test_smart_device_errors_in_multiple_request(
-    dummy_protocol, mocker, error_code
+    dummy_protocol, mocker, error_code, caplog
 ):
     mock_response = {
         "result": {
@@ -60,13 +60,10 @@ async def test_smart_device_errors_in_multiple_request(
     send_mock = mocker.patch.object(
         dummy_protocol._transport, "send", return_value=mock_response
     )
-    with pytest.raises(SmartDeviceException):
-        await dummy_protocol.query(DUMMY_MULTIPLE_QUERY, retry_count=2)
-    if error_code in chain(SMART_TIMEOUT_ERRORS, SMART_RETRYABLE_ERRORS):
-        expected_calls = 3
-    else:
-        expected_calls = 1
-    assert send_mock.call_count == expected_calls
+
+    resp_dict = await dummy_protocol.query(DUMMY_MULTIPLE_QUERY, retry_count=2)
+    assert resp_dict["foobar2"] == error_code
+    assert send_mock.call_count == 1
 
 
 @pytest.mark.parametrize("request_size", [1, 3, 5, 10])


### PR DESCRIPTION
Handle errors within multipleRequests more robustly by not raising every time and passing the error back to the device to handle.