### PR TITLE
Auto auto-off module for smartdevice

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -47,4 +47,5 @@ class Feature:
         """Set the value."""
         if self.attribute_setter is None:
             raise ValueError("Tried to set read-only feature.")
-        return await getattr(self.device, self.attribute_setter)(value)
+        container = self.container if self.container is not None else self.device
+        return await getattr(container, self.attribute_setter)(value)

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -2,6 +2,7 @@
 from .childdevicemodule import ChildDeviceModule
 from .devicemodule import DeviceModule
 from .energymodule import EnergyModule
+from .autooffmodule import AutoOffModule
 from .timemodule import TimeModule
 
-__all__ = ["TimeModule", "EnergyModule", "DeviceModule", "ChildDeviceModule"]
+__all__ = ["TimeModule", "EnergyModule", "DeviceModule", "ChildDeviceModule", "AutoOffModule"]

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -1,8 +1,14 @@
 """Modules for SMART devices."""
+from .autooffmodule import AutoOffModule
 from .childdevicemodule import ChildDeviceModule
 from .devicemodule import DeviceModule
 from .energymodule import EnergyModule
-from .autooffmodule import AutoOffModule
 from .timemodule import TimeModule
 
-__all__ = ["TimeModule", "EnergyModule", "DeviceModule", "ChildDeviceModule", "AutoOffModule"]
+__all__ = [
+    "TimeModule",
+    "EnergyModule",
+    "DeviceModule",
+    "ChildDeviceModule",
+    "AutoOffModule",
+]

--- a/kasa/smart/modules/autooffmodule.py
+++ b/kasa/smart/modules/autooffmodule.py
@@ -1,0 +1,36 @@
+"""Implementation of auto off module."""
+from typing import Dict
+
+from ..smartmodule import SmartModule
+
+
+class AutoOffModule(SmartModule):
+    """Implementation of auto off module."""
+
+    REQUIRED_COMPONENT = "auto_off"
+    QUERY_GETTER_NAME = "get_auto_off_config"
+
+    def query(self) -> Dict:
+        """Query to execute during the update cycle."""
+        return {self.QUERY_GETTER_NAME: {"start_index": 0}}
+
+    @property
+    def enabled(self) -> bool:
+        """Return True if enabled."""
+        return self.data["enable"]
+
+    def set_enabled(self, enable: bool):
+        """Enable/disable auto off."""
+        return self.call("set_auto_off_config", {"enable": enable})
+
+    @property
+    def delay(self) -> int:
+        """Return time until auto off."""
+        return self.data["delay_min"]
+
+    def set_delay(self, delay: int):
+        """Set time until auto off."""
+        return self.call("set_auto_off_config", {"delay_min": delay})
+
+    def __cli_output__(self):
+        return f"Auto off enabled: {self.enabled} (delay: {self.delay}min)"

--- a/kasa/smart/modules/autooffmodule.py
+++ b/kasa/smart/modules/autooffmodule.py
@@ -1,7 +1,12 @@
 """Implementation of auto off module."""
-from typing import Dict
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Dict, Optional
 
+from ...feature import Feature
 from ..smartmodule import SmartModule
+
+if TYPE_CHECKING:
+    from ..smartdevice import SmartDevice
 
 
 class AutoOffModule(SmartModule):
@@ -9,6 +14,32 @@ class AutoOffModule(SmartModule):
 
     REQUIRED_COMPONENT = "auto_off"
     QUERY_GETTER_NAME = "get_auto_off_config"
+
+    def __init__(self, device: "SmartDevice", module: str):
+        super().__init__(device, module)
+        self._add_feature(
+            Feature(
+                device,
+                "Auto off enabled",
+                container=self,
+                attribute_getter="enabled",
+                attribute_setter="set_enabled",
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                "Auto off minutes",
+                container=self,
+                attribute_getter="delay",
+                attribute_setter="set_delay",
+            )
+        )
+        self._add_feature(
+            Feature(
+                device, "Auto off at", container=self, attribute_getter="auto_off_at"
+            )
+        )
 
     def query(self) -> Dict:
         """Query to execute during the update cycle."""
@@ -21,7 +52,10 @@ class AutoOffModule(SmartModule):
 
     def set_enabled(self, enable: bool):
         """Enable/disable auto off."""
-        return self.call("set_auto_off_config", {"enable": enable})
+        return self.call(
+            "set_auto_off_config",
+            {"enable": enable, "delay_min": self.data["delay_min"]},
+        )
 
     @property
     def delay(self) -> int:
@@ -30,7 +64,21 @@ class AutoOffModule(SmartModule):
 
     def set_delay(self, delay: int):
         """Set time until auto off."""
-        return self.call("set_auto_off_config", {"delay_min": delay})
+        return self.call(
+            "set_auto_off_config", {"delay_min": delay, "enable": self.data["enable"]}
+        )
 
-    def __cli_output__(self):
-        return f"Auto off enabled: {self.enabled} (delay: {self.delay}min)"
+    @property
+    def is_timer_active(self) -> bool:
+        """Return True is auto-off timer is active."""
+        return self._device.sys_info["auto_off_status"] == "on"
+
+    @property
+    def auto_off_at(self) -> Optional[datetime]:
+        """Return when the device will be turned off automatically."""
+        if not self.is_timer_active:
+            return None
+
+        sysinfo = self._device.sys_info
+
+        return self._device.time + timedelta(seconds=sysinfo["auto_off_remain_time"])

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -17,6 +17,7 @@ from .modules import (  # noqa: F401
     DeviceModule,
     EnergyModule,
     TimeModule,
+    AutoOffModule,
 )
 from .smartmodule import SmartModule
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -13,11 +13,11 @@ from ..exceptions import AuthenticationException, SmartDeviceException, SmartErr
 from ..feature import Feature, FeatureType
 from ..smartprotocol import SmartProtocol
 from .modules import (  # noqa: F401
+    AutoOffModule,
     ChildDeviceModule,
     DeviceModule,
     EnergyModule,
     TimeModule,
-    AutoOffModule,
 )
 from .smartmodule import SmartModule
 

--- a/kasa/tests/fakeprotocol_smart.py
+++ b/kasa/tests/fakeprotocol_smart.py
@@ -46,6 +46,7 @@ class FakeSmartTransport(BaseTransport):
 
     FIXTURE_MISSING_MAP = {
         "get_wireless_scan_info": ("wireless", {"ap_list": [], "wep_supported": False}),
+        "get_auto_off_config": ("auto_off", {'delay_min': 10, 'enable': False}),
     }
 
     async def send(self, request: str):


### PR DESCRIPTION
Adds auto-off implementation. The feature stays enabled after the timer runs out, and it will start the countdown if the device is turned on again without explicitly disabling it.

New features:
* Switch to select if enabled: `Auto off enabled (auto_off_enabled): False`
* Setting to change the delay: `Auto off minutes (auto_off_minutes): 222`
* If timer is active, datetime object when the device gets turned off: `Auto off at (auto_off_at): None`
