### PR TITLE
Fix dump_devinfo scrubbing for ks240

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -52,6 +52,8 @@ def scrub(res):
         "longitude_i",
         "latitude",
         "longitude",
+        "la",  # lat on ks240
+        "lo",  # lon on ks240
         "owner",
         "device_id",
         "ip",


### PR DESCRIPTION
"la" and "lo" are used in the child dev statuses for geoloc.