### PR TITLE
Add missing firmware module import

### DIFF
--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -4,6 +4,7 @@ from .childdevicemodule import ChildDeviceModule
 from .cloudmodule import CloudModule
 from .devicemodule import DeviceModule
 from .energymodule import EnergyModule
+from .firmware import Firmware
 from .ledmodule import LedModule
 from .lighttransitionmodule import LightTransitionModule
 from .timemodule import TimeModule

--- a/kasa/tests/fakeprotocol_smart.py
+++ b/kasa/tests/fakeprotocol_smart.py
@@ -46,7 +46,7 @@ class FakeSmartTransport(BaseTransport):
 
     FIXTURE_MISSING_MAP = {
         "get_wireless_scan_info": ("wireless", {"ap_list": [], "wep_supported": False}),
-        "get_auto_off_config": ("auto_off", {'delay_min': 10, 'enable': False}),
+        "get_auto_off_config": ("auto_off", {"delay_min": 10, "enable": False}),
         "get_led_info": (
             "led",
             {
@@ -63,6 +63,23 @@ class FakeSmartTransport(BaseTransport):
         ),
         "get_connect_cloud_state": ("cloud_connect", {"status": 1}),
         "get_on_off_gradually_info": ("on_off_gradually", {"enable": True}),
+        "get_latest_fw": (
+            "firmware",
+            {
+                "fw_size": 0,
+                "fw_ver": "1.0.5 Build 230801 Rel.095702",
+                "hw_id": "",
+                "need_to_upgrade": False,
+                "oem_id": "",
+                "release_date": "",
+                "release_note": "",
+                "type": 0,
+            },
+        ),
+        "get_auto_update_info": (
+            "firmware",
+            {"enable": True, "random_range": 120, "time": 180},
+        ),
     }
 
     async def send(self, request: str):


### PR DESCRIPTION
#766 was merged too hastily to fail the tests as the module was never imported, this fixes that and adds the missing fixture data to the dummy fixture mapping.