### PR TITLE
Add --child option to feature command

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -1156,18 +1156,34 @@ async def shell(dev: Device):
 @cli.command(name="feature")
 @click.argument("name", required=False)
 @click.argument("value", required=False)
+@click.option("--child", required=False)
 @pass_dev
-async def feature(dev, name: str, value):
+async def feature(dev, child, name: str, value):
     """Access and modify features.
 
     If no *name* is given, lists available features and their values.
     If only *name* is given, the value of named feature is returned.
     If both *name* and *value* are set, the described setting is changed.
     """
+    if child is not None:
+        echo(f"Targeting child device {child}")
+        dev = dev.children[child]
     if not name:
+
+        def _print_features(dev):
+            for name, feat in dev.features.items():
+                try:
+                    echo(f"\t{feat.name} ({name}): {feat.value}")
+                except Exception as ex:
+                    echo(f"\t{feat.name} ({name}): [red]{ex}[/red]")
+
         echo("[bold]== Features ==[/bold]")
-        for name, feat in dev.features.items():
-            echo(f"{feat.name} ({name}): {feat.value}")
+        _print_features(dev)
+
+        if dev.children:
+            for child in dev.children:
+                echo(f"[bold]== Child {child.alias} ==")
+                _print_features(child)
         return
 
     if name not in dev.features:

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -1158,7 +1158,7 @@ async def shell(dev: Device):
 @click.argument("value", required=False)
 @click.option("--child", required=False)
 @pass_dev
-async def feature(dev, child, name: str, value):
+async def feature(dev: Device, child: str, name: str, value):
     """Access and modify features.
 
     If no *name* is given, lists available features and their values.
@@ -1167,7 +1167,7 @@ async def feature(dev, child, name: str, value):
     """
     if child is not None:
         echo(f"Targeting child device {child}")
-        dev = dev.children[child]
+        dev = dev.get_child_device(child)
     if not name:
 
         def _print_features(dev):
@@ -1181,12 +1181,14 @@ async def feature(dev, child, name: str, value):
         _print_features(dev)
 
         if dev.children:
-            for child in dev.children:
-                echo(f"[bold]== Child {child.alias} ==")
-                _print_features(child)
+            for child_dev in dev.children:
+                echo(f"[bold]== Child {child_dev.alias} ==")
+                _print_features(child_dev)
+
         return
 
     if name not in dev.features:
+        raise
         echo(f"No feature by name {name}")
         return
 

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -1188,8 +1188,7 @@ async def feature(dev: Device, child: str, name: str, value):
         return
 
     if name not in dev.features:
-        raise
-        echo(f"No feature by name {name}")
+        echo(f"No feature by name '{name}'")
         return
 
     feat = dev.features[name]

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -573,7 +573,7 @@ def unsupported_device_info(request, mocker):
     yield discovery_data
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def dummy_protocol():
     """Return a smart protocol instance with a mocking-ready dummy transport."""
 

--- a/kasa/tests/conftest.py
+++ b/kasa/tests/conftest.py
@@ -573,7 +573,7 @@ def unsupported_device_info(request, mocker):
     yield discovery_data
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def dummy_protocol():
     """Return a smart protocol instance with a mocking-ready dummy transport."""
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -32,7 +32,14 @@ from kasa.cli import (
 from kasa.discover import Discover, DiscoveryResult
 from kasa.iot import IotDevice
 
-from .conftest import device_iot, device_smart, handle_turn_on, new_discovery, turn_on
+from .conftest import (
+    device_iot,
+    device_smart,
+    get_device_for_file,
+    handle_turn_on,
+    new_discovery,
+    turn_on,
+)
 
 
 async def test_update_called_by_cli(dev, mocker):
@@ -684,3 +691,71 @@ async def test_errors(mocker):
     )
     assert res.exit_code == 2
     assert "Raised error:" not in res.output
+
+
+async def test_feature(mocker):
+    """Test feature command."""
+    dummy_device = await get_device_for_file("P300(EU)_1.0_1.0.13.json", "SMART")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+    runner = CliRunner()
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature"],
+        catch_exceptions=False,
+    )
+    assert "LED" in res.output
+    assert "== Child " in res.output  # child listing
+
+    assert res.exit_code == 0
+
+
+async def test_feature_set(mocker):
+    """Test feature command's set value."""
+    dummy_device = await get_device_for_file("P300(EU)_1.0_1.0.13.json", "SMART")
+    led_setter = mocker.patch("kasa.smart.modules.ledmodule.LedModule.set_led")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+
+    runner = CliRunner()
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature", "led", "True"],
+        catch_exceptions=False,
+    )
+
+    led_setter.assert_called_with(True)
+    assert "Setting led to True" in res.output
+    assert res.exit_code == 0
+
+
+async def test_feature_set_child(mocker):
+    """Test feature command's set value."""
+    dummy_device = await get_device_for_file("P300(EU)_1.0_1.0.13.json", "SMART")
+    setter = mocker.patch("kasa.smart.smartdevice.SmartDevice.set_state")
+
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+    get_child_device = mocker.spy(dummy_device, "get_child_device")
+
+    child_id = "000000000000000000000000000000000000000001"
+
+    runner = CliRunner()
+    res = await runner.invoke(
+        cli,
+        [
+            "--host",
+            "127.0.0.123",
+            "--debug",
+            "feature",
+            "--child",
+            child_id,
+            "state",
+            "False",
+        ],
+        catch_exceptions=False,
+    )
+
+    get_child_device.assert_called()
+    setter.assert_called_with(False)
+
+    assert f"Targeting child device {child_id}"
+    assert "Setting state to False" in res.output
+    assert res.exit_code == 0

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -709,6 +709,34 @@ async def test_feature(mocker):
     assert res.exit_code == 0
 
 
+async def test_feature_single(mocker):
+    """Test feature command returning single value."""
+    dummy_device = await get_device_for_file("P300(EU)_1.0_1.0.13.json", "SMART")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+    runner = CliRunner()
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature", "led"],
+        catch_exceptions=False,
+    )
+    assert "LED" in res.output
+    assert "== Features ==" not in res.output
+    assert res.exit_code == 0
+
+async def test_feature_missing(mocker):
+    """Test feature command returning single value."""
+    dummy_device = await get_device_for_file("P300(EU)_1.0_1.0.13.json", "SMART")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+    runner = CliRunner()
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature", "missing"],
+        catch_exceptions=False,
+    )
+    assert "No feature by name 'missing'" in res.output
+    assert "== Features ==" not in res.output
+    assert res.exit_code == 0
+
 async def test_feature_set(mocker):
     """Test feature command's set value."""
     dummy_device = await get_device_for_file("P300(EU)_1.0_1.0.13.json", "SMART")


### PR DESCRIPTION
This allows displaying and changing child device features that were previously not accessible using the cli tool:
```
kasa --host 192.168.xx  feature                                                              
No --type or --device-family and --encrypt-type defined, discovering for 5 seconds..
== Features ==
        Device ID (device_id): xx
        Signal Level (signal_level): 2
        RSSI (rssi): -57
        SSID (ssid): xx
        Overheated (overheated): False
        Alarm (alarm): False
        Alarm source (alarm_source): None
        Alarm sound (alarm_sound): Doorbell Ring 2
        Alarm volume (alarm_volume): low
        Cloud connection (cloud_connection): False
        Auto update enabled (auto_update_enabled): False
        Update available (update_available): False
        LED (led): False
        Time (time): 2024-02-22 23:23:51+01:00
== Child Temperature Humidity Sensor ==
        Device ID (device_id): xx
        Signal Level (signal_level): 3
        RSSI (rssi): -54
        Battery level (battery_level): 100
        Battery low (battery_low): False
        Cloud connection (cloud_connection): False
        Auto update enabled (auto_update_enabled): False
        Update available (update_available): False
        Humidity (humidity): 63
        Humidity warning (humidity_warning): True
        Report interval (report_interval): 16
        Temperature (temperature): 21.1
        Temperature warning (temperature_warning): False
        Time (time): 2024-02-22 23:23:51+01:00
```