### PR TITLE
Do not fail fast on pypy CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
     name: Python ${{ matrix.python-version}} on ${{ matrix.os }}${{ fromJSON('[" (extras)", ""]')[matrix.extras == ''] }}
     needs: linting
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ startsWith(matrix.python-version, 'pypy') }}
 
     strategy:
       matrix:


### PR DESCRIPTION
The pypy jobs are quite error prone, particularly the windows ones.