### PR TITLE
Simplify device __repr__

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -366,8 +366,4 @@ class Device(ABC):
     def __repr__(self):
         if self._last_update is None:
             return f"<{self.device_type} at {self.host} - update() needed>"
-        return (
-            f"<{self.device_type} model {self.model} at {self.host}"
-            f" ({self.alias}), is_on: {self.is_on}"
-            f" - dev specific: {self.state_information}>"
-        )
+        return f"<{self.device_type} at {self.host} - {self.alias} ({self.model})>"

--- a/kasa/smart/smartchilddevice.py
+++ b/kasa/smart/smartchilddevice.py
@@ -56,4 +56,4 @@ class SmartChildDevice(SmartDevice):
         return dev_type
 
     def __repr__(self):
-        return f"<ChildDevice {self.alias} of {self._parent}>"
+        return f"<{self.device_type} {self.alias} ({self.model}) of {self._parent}>"

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -198,7 +198,7 @@ async def test_mac(dev):
 async def test_representation(dev):
     import re
 
-    pattern = re.compile("<.* model .* at .* (.*), is_on: .* - dev specific: .*>")
+    pattern = re.compile("<DeviceType\..+ at .+? - .*? \(.+?\)>")
     assert pattern.match(str(dev))
 
 


### PR DESCRIPTION
Simplify `__repr__` for `Device`.

Previously:
```
>>> dev
<DeviceType.Hub model H100 at 192.168.xx.xx (Smart Hub), is_on: False - dev specific: {'overheated': False, 'signal_level': 2, 'SSID': 'xx'}>
>>> dev.children[0]
<ChildDevice Temperature Humidity Sensor of <DeviceType.Hub model H100 at 192.168.xx.xx (Smart Hub), is_on: False - dev specific: {'overheated': False, 'signal_level': 2, 'SSID': 'xx'}>>
```

Now:
```
>>> dev
Device: <DeviceType.Hub at 192.168.xx.xx - Smart Hub (H100)>
>>> dev.children[0]
<DeviceType.Sensor Temperature Humidity Sensor (T315) of <DeviceType.Hub at 192.168.xx.xx - Smart Hub (H100)>>
```
