### PR TITLE
Put child fixtures in subfolder

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -39,6 +39,7 @@ SmartCall = namedtuple("SmartCall", "module request should_succeed child_device_
 FixtureResult = namedtuple("FixtureResult", "filename, folder, data")
 
 SMART_FOLDER = "kasa/tests/fixtures/smart/"
+SMART_CHILD_FOLDER = "kasa/tests/fixtures/smart/child/"
 IOT_FOLDER = "kasa/tests/fixtures/"
 
 _LOGGER = logging.getLogger(__name__)
@@ -531,7 +532,9 @@ def get_smart_child_fixture(response):
         model += f"({region})"
 
     save_filename = f"{model}_{hw_version}_{sw_version}.json"
-    return FixtureResult(filename=save_filename, folder=SMART_FOLDER, data=response)
+    return FixtureResult(
+        filename=save_filename, folder=SMART_CHILD_FOLDER, data=response
+    )
 
 
 async def get_smart_fixtures(device: SmartDevice, batch_size: int):

--- a/kasa/tests/device_fixtures.py
+++ b/kasa/tests/device_fixtures.py
@@ -277,7 +277,7 @@ check_categories()
 
 
 def device_for_fixture_name(model, protocol):
-    if protocol == "SMART":
+    if "SMART" in protocol:
         for d in PLUGS_SMART:
             if d in model:
                 return SmartDevice
@@ -345,22 +345,21 @@ async def get_device_for_fixture(fixture_data: FixtureInfo):
     d = device_for_fixture_name(fixture_data.name, fixture_data.protocol)(
         host="127.0.0.123"
     )
-    if fixture_data.protocol == "SMART":
+    if "SMART" in fixture_data.protocol:
         d.protocol = FakeSmartProtocol(fixture_data.data, fixture_data.name)
     else:
         d.protocol = FakeIotProtocol(fixture_data.data)
 
-    # smart child devices do not have their own discovery data
-    if fixture_data.protocol == "SMART.CHILD":
-        return d
-
+    discovery_data = None
     if "discovery_result" in fixture_data.data:
         discovery_data = {"result": fixture_data.data["discovery_result"]}
-    else:
+    elif "system" in fixture_data.data:
         discovery_data = {
             "system": {"get_sysinfo": fixture_data.data["system"]["get_sysinfo"]}
         }
-    d.update_from_discover_info(discovery_data)
+    if discovery_data:  # Child devices do not have discovery info
+        d.update_from_discover_info(discovery_data)
+
     await _update_and_close(d)
     return d
 

--- a/kasa/tests/device_fixtures.py
+++ b/kasa/tests/device_fixtures.py
@@ -349,6 +349,11 @@ async def get_device_for_fixture(fixture_data: FixtureInfo):
         d.protocol = FakeSmartProtocol(fixture_data.data, fixture_data.name)
     else:
         d.protocol = FakeIotProtocol(fixture_data.data)
+
+    # smart child devices do not have their own discovery data
+    if fixture_data.protocol == "SMART.CHILD":
+        return d
+
     if "discovery_result" in fixture_data.data:
         discovery_data = {"result": fixture_data.data["discovery_result"]}
     else:

--- a/kasa/tests/discovery_fixtures.py
+++ b/kasa/tests/discovery_fixtures.py
@@ -135,7 +135,7 @@ def discovery_mock(request, mocker):
         side_effect=lambda *_, **__: [(None, None, None, None, (dm.ip, 0))],
     )
 
-    if fixture_info.protocol == "SMART":
+    if "SMART" in fixture_info.protocol:
         proto = FakeSmartProtocol(fixture_data, fixture_info.name)
     else:
         proto = FakeIotProtocol(fixture_data)

--- a/kasa/tests/fixtureinfo.py
+++ b/kasa/tests/fixtureinfo.py
@@ -29,8 +29,17 @@ SUPPORTED_SMART_DEVICES = [
     )
 ]
 
+SUPPORTED_SMART_CHILD_DEVICES = [
+    (device, "SMART.CHILD")
+    for device in glob.glob(
+        os.path.dirname(os.path.abspath(__file__)) + "/fixtures/smart/child/*.json"
+    )
+]
 
-SUPPORTED_DEVICES = SUPPORTED_IOT_DEVICES + SUPPORTED_SMART_DEVICES
+
+SUPPORTED_DEVICES = (
+    SUPPORTED_IOT_DEVICES + SUPPORTED_SMART_DEVICES + SUPPORTED_SMART_CHILD_DEVICES
+)
 
 
 def idgenerator(paramtuple: FixtureInfo):
@@ -50,6 +59,8 @@ def get_fixture_info() -> List[FixtureInfo]:
         folder = Path(__file__).parent / "fixtures"
         if protocol == "SMART":
             folder = folder / "smart"
+        if protocol == "SMART.CHILD":
+            folder = folder / "smart/child"
         p = folder / file
 
         with open(p) as f:

--- a/kasa/tests/fixtures/smart/child/.gitkeep
+++ b/kasa/tests/fixtures/smart/child/.gitkeep
@@ -1,0 +1,1 @@
+Can be deleted when first fixture is added


### PR DESCRIPTION
This should prevent child fixtures from hubs breaking tests due to missing discovery info.  To get these devices in `filter_fixtures` include protocol string of `SMART.CHILD`.