### PR TITLE
Do not run coverage on pypy and cache poetry envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,15 @@ jobs:
         python-version: ["3.12"]
 
     steps:
-      - uses: "actions/checkout@v2"
-      - uses: "actions/setup-python@v2"
+      - uses: "actions/checkout@v4"
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: 'poetry'
       - name: "Install dependencies"
         run: |
-          python -m pip install --upgrade pip poetry
           poetry install
       - name: "Check supported device md files are up to date"
         run: |
@@ -85,21 +87,27 @@ jobs:
             extras: true
 
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/checkout@v4"
+      - name: Install poetry
+        run: pipx install poetry
+      - uses: "actions/setup-python@v5"
         with:
           python-version: "${{ matrix.python-version }}"
+          cache: 'poetry'
       - name: "Install dependencies (no extras)"
         if: matrix.extras == false
         run: |
-          python -m pip install --upgrade pip poetry
           poetry install
       - name: "Install dependencies (with extras)"
         if: matrix.extras == true
         run: |
-          python -m pip install --upgrade pip poetry
           poetry install --all-extras
-      - name: "Run tests"
+      - name: "Run tests (no coverage)"
+        if: ${{ startsWith(matrix.python-version, 'pypy') }}
+        run: |
+          poetry run pytest
+      - name: "Run tests (with coverage)"
+        if: ${{ !startsWith(matrix.python-version, 'pypy') }}
         run: |
           poetry run pytest --cov kasa --cov-report xml
       - name: "Upload coverage to Codecov"


### PR DESCRIPTION
Currently the CI is very slow for pypy vs cpython, one job is 24m vs 3m on cpython.  This PR enables poetry environment caching and bypasses coverage checking for pypy.

N.B. The poetry cache is keyed on a hash of the `poetry.lock` file.

*Before:*
![image](https://github.com/python-kasa/python-kasa/assets/51370195/3f831868-16f6-4d44-a25e-103b330a2d70)

*After:*
![image](https://github.com/python-kasa/python-kasa/assets/51370195/502973fa-4508-4bd7-950b-521ff34c1e96)
