### PR TITLE
Add colortemp feature for iot devices

### DIFF
--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -221,6 +221,19 @@ class IotBulb(IotDevice, Bulb):
                 )
             )
 
+        if self.is_variable_color_temp:
+            self._add_feature(
+                Feature(
+                    device=self,
+                    name="Color temperature",
+                    container=self,
+                    attribute_getter="color_temp",
+                    attribute_setter="set_color_temp",
+                    range_getter="valid_temperature_range",
+                )
+            )
+
+
     @property  # type: ignore
     @requires_update
     def is_color(self) -> bool:

--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -133,11 +133,6 @@ async def test_variable_temp_state_information(dev: Bulb):
     assert "Color temperature" in dev.state_information
     assert dev.state_information["Color temperature"] == dev.color_temp
 
-    assert "Valid temperature range" in dev.state_information
-    assert (
-        dev.state_information["Valid temperature range"] == dev.valid_temperature_range
-    )
-
 
 @variable_temp
 @turn_on


### PR DESCRIPTION
Make color temperature feature available for iot bulbs.


Should get merged after #804 is done.