### PR TITLE
smartbulb: Limit brightness range to 1-100

### DIFF
--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -233,7 +233,6 @@ class IotBulb(IotDevice, Bulb):
                 )
             )
 
-
     @property  # type: ignore
     @requires_update
     def is_color(self) -> bool:

--- a/kasa/tests/smart/features/test_brightness.py
+++ b/kasa/tests/smart/features/test_brightness.py
@@ -16,7 +16,7 @@ async def test_brightness_component(dev: SmartDevice):
     # Test getting the value
     feature = dev.features["brightness"]
     assert isinstance(feature.value, int)
-    assert feature.value > 0 and feature.value <= 100
+    assert feature.value > 1 and feature.value <= 100
 
     # Test setting the value
     await feature.set_value(10)

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -8,9 +8,10 @@ from pytest_mock import MockerFixture
 
 from kasa import KasaException
 from kasa.exceptions import SmartErrorCode
-from kasa.smart import SmartDevice
+from kasa.smart import SmartBulb, SmartDevice
 
 from .conftest import (
+    bulb_smart,
     device_smart,
 )
 
@@ -103,3 +104,25 @@ async def test_update_module_queries(dev: SmartDevice, mocker: MockerFixture):
         full_query = {**full_query, **mod.query()}
 
     query.assert_called_with(full_query)
+
+
+@bulb_smart
+async def test_smartdevice_brightness(dev: SmartBulb):
+    """Test brightness setter and getter."""
+    assert isinstance(dev, SmartDevice)
+    assert "brightness" in dev._components
+
+    # Test getting the value
+    feature = dev.features["brightness"]
+    assert feature.minimum_value == 1
+    assert feature.maximum_value == 100
+
+    await dev.set_brightness(10)
+    await dev.update()
+    assert dev.brightness == 10
+
+    with pytest.raises(ValueError):
+        await dev.set_brightness(feature.minimum_value - 10)
+
+    with pytest.raises(ValueError):
+        await dev.set_brightness(feature.maximum_value + 10)


### PR DESCRIPTION
The allowed brightness for tested light devices (L530, L900) is [1-100] instead of [0-100] like it was for some kasa devices.

Related to #828.
Needs rebasing after #804 is merged.