### PR TITLE
Fix CI issue with python version used by pipx to install poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,23 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v4"
-      - name: Install poetry
-        run: pipx install poetry
       - uses: "actions/setup-python@v5"
         id: setup-python
         with:
           python-version: "${{ matrix.python-version }}"
-          cache: 'poetry'
+      - name: Install poetry
+        run: pipx install poetry --python "${{ steps.setup-python.outputs.python-path }}"
+      - name: Read poetry cache location
+        id: poetry-cache-location
+        shell: bash
+        run: |
+          echo "POETRY_VENV_LOCATION=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        name: Poetry cache
+        with:
+          path: |
+            ${{ steps.poetry-cache-location.outputs.POETRY_VENV_LOCATION }}
+          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-extras-false
       - name: "Install dependencies"
         run: |
           poetry install
@@ -34,6 +44,7 @@ jobs:
         run: >-
           echo "PRE_COMMIT_VERSION=$(poetry run pre-commit -V | awk '{print $2}')" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
+        name: Pre-commit cache
         with:
           path: ~/.cache/pre-commit/
           key: ${{ runner.os }}-pre-commit-${{ steps.pre-commit-version.outputs.PRE_COMMIT_VERSION }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -97,18 +108,19 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v4"
-      - name: Install poetry
-        run: pipx install poetry
       - uses: "actions/setup-python@v5"
         id: setup-python
         with:
           python-version: "${{ matrix.python-version }}"
+      - name: Install poetry
+        run: pipx install poetry --python "${{ steps.setup-python.outputs.python-path }}"
       - name: Read poetry cache location
         id: poetry-cache-location
         shell: bash
         run: |
           echo "POETRY_VENV_LOCATION=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
+        name: Poetry cache
         with:
           path: |
             ${{ steps.poetry-cache-location.outputs.POETRY_VENV_LOCATION }}


### PR DESCRIPTION
The [instructions](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md) for using the poetry cache in `actions/setup-python` appear to be erroneous.  pipx is installed before `actions/setup-python` is run so that the cache location is created, however this causes poetry to use the default python version rather than the version from `actions/setup-python`.  This PR drops the use of the `setup-python` cache altogether and just uses the `actions/cache` and ensures that pipx uses the python version from `actiona/setup-python`.