### PR TITLE
Fix non python 3.8 compliant test

### DIFF
--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -99,6 +99,6 @@ async def test_update_module_queries(dev: SmartDevice, mocker: MockerFixture):
     await dev.update()
     full_query: Dict[str, Any] = {}
     for mod in dev.modules.values():
-        full_query |= mod.query()
+        full_query = {**full_query, **mod.query()}
 
     query.assert_called_with(full_query)


### PR DESCRIPTION
Issue slipped through due a problem with the CI https://github.com/python-kasa/python-kasa/pull/831