### PR TITLE
Cache pipx in CI and add custom setup action

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -1,0 +1,83 @@
+---
+name: Setup Environment
+description: Install requested pipx dependencies, configure the system python, and install poetry and the package dependencies
+
+inputs:
+  poetry-install-options:
+    default: ""
+  poetry-version:
+    default: 1.8.2
+  python-version:
+    required: true
+  cache-pre-commit:
+    default: false
+
+runs:
+  using: composite
+  steps:
+    - uses: "actions/setup-python@v5"
+      id: setup-python
+      with:
+        python-version: "${{ inputs.python-version }}"
+
+    - name: Setup pipx environment Variables
+      id: pipx-env-setup
+      # pipx default home and bin dir are not writable by the cache action
+      # so override them here and add the bin dir to PATH for later steps.
+      # This also ensures the pipx cache only contains poetry
+      run: |
+        SEP="${{ !startsWith(runner.os, 'windows') && '/' || '\\' }}"
+        PIPX_CACHE="${{ github.workspace }}${SEP}pipx_cache"
+        echo "pipx-cache-path=${PIPX_CACHE}" >> $GITHUB_OUTPUT
+        echo "pipx-version=$(pipx --version)" >> $GITHUB_OUTPUT
+        echo "PIPX_HOME=${PIPX_CACHE}${SEP}home" >> $GITHUB_ENV
+        echo "PIPX_BIN_DIR=${PIPX_CACHE}${SEP}bin" >> $GITHUB_ENV
+        echo "PIPX_MAN_DIR=${PIPX_CACHE}${SEP}man" >> $GITHUB_ENV
+        echo "${PIPX_CACHE}${SEP}bin" >> $GITHUB_PATH
+      shell: bash
+
+    - name: Pipx cache
+      id: pipx-cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipx-${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry-${{ inputs.poetry-version }}
+
+    - name: Install poetry
+      if: steps.pipx-cache.outputs.cache-hit != 'true'
+      id: install-poetry
+      shell: bash
+      run: |-
+        pipx install poetry==${{ inputs.poetry-version }} --python "${{ steps.setup-python.outputs.python-path }}"
+
+    - name: Read poetry cache location
+      id: poetry-cache-location
+      shell: bash
+      run: |-
+        echo "poetry-venv-location=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      name: Poetry cache
+      with:
+        path: |
+          ${{ steps.poetry-cache-location.outputs.poetry-venv-location }}
+        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-options-${{ inputs.poetry-install-options }}
+
+    - name: "Poetry install"
+      shell: bash
+      run: |
+        poetry install ${{ inputs.poetry-install-options }}
+
+    - name: Read pre-commit version
+      if: inputs.cache-pre-commit == 'true'
+      id: pre-commit-version
+      shell: bash
+      run: >-
+        echo "pre-commit-version=$(poetry run pre-commit -V | awk '{print $2}')" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@v4
+      if: inputs.cache-pre-commit == 'true'
+      name: Pre-commit cache
+      with:
+        path: ~/.cache/pre-commit/
+        key: ${{ runner.os }}-pre-commit-${{ steps.pre-commit-version.outputs.pre-commit-version }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
     branches: ["master"]
   workflow_dispatch:  # to allow manual re-runs
 
+env:
+  POETRY_VERSION: 1.8.2
 
 jobs:
   linting:
@@ -19,35 +21,13 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
-        id: setup-python
+      - name: Setup environment
+        uses: ./.github/actions/setup
         with:
-          python-version: "${{ matrix.python-version }}"
-      - name: Install poetry
-        run: pipx install poetry --python "${{ steps.setup-python.outputs.python-path }}"
-      - name: Read poetry cache location
-        id: poetry-cache-location
-        shell: bash
-        run: |
-          echo "POETRY_VENV_LOCATION=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Poetry cache
-        with:
-          path: |
-            ${{ steps.poetry-cache-location.outputs.POETRY_VENV_LOCATION }}
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-extras-false
-      - name: "Install dependencies"
-        run: |
-          poetry install
-      - name: Read pre-commit version
-        id: pre-commit-version
-        run: >-
-          echo "PRE_COMMIT_VERSION=$(poetry run pre-commit -V | awk '{print $2}')" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Pre-commit cache
-        with:
-          path: ~/.cache/pre-commit/
-          key: ${{ runner.os }}-pre-commit-${{ steps.pre-commit-version.outputs.PRE_COMMIT_VERSION }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          os: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+          cache-pre-commit: true
+          poetry-version: ${{ env.POETRY_VERSION }}
       - name: "Check supported device md files are up to date"
         run: |
           poetry run pre-commit run generate-supported --all-files
@@ -108,31 +88,13 @@ jobs:
 
     steps:
       - uses: "actions/checkout@v4"
-      - uses: "actions/setup-python@v5"
-        id: setup-python
+      - name: Setup environment
+        uses: ./.github/actions/setup
         with:
-          python-version: "${{ matrix.python-version }}"
-      - name: Install poetry
-        run: pipx install poetry --python "${{ steps.setup-python.outputs.python-path }}"
-      - name: Read poetry cache location
-        id: poetry-cache-location
-        shell: bash
-        run: |
-          echo "POETRY_VENV_LOCATION=$(poetry config virtualenvs.path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Poetry cache
-        with:
-          path: |
-            ${{ steps.poetry-cache-location.outputs.POETRY_VENV_LOCATION }}
-          key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-extras-${{ matrix.extras }}
-      - name: "Install dependencies (no extras)"
-        if: matrix.extras == false
-        run: |
-          poetry install
-      - name: "Install dependencies (with extras)"
-        if: matrix.extras == true
-        run: |
-          poetry install --all-extras
+          os: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+          poetry-version: ${{ env.POETRY_VERSION }}
+          poetry-install-options: ${{ matrix.extras == true && '--all-extras' || '' }}
       - name: "Run tests (no coverage)"
         if: ${{ startsWith(matrix.python-version, 'pypy') }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
-          os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
           cache-pre-commit: true
           poetry-version: ${{ env.POETRY_VERSION }}
@@ -91,7 +90,6 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup
         with:
-          os: ${{ matrix.os }}
           python-version: ${{ matrix.python-version }}
           poetry-version: ${{ env.POETRY_VERSION }}
           poetry-install-options: ${{ matrix.extras == true && '--all-extras' || '' }}


### PR DESCRIPTION
Since fixing the issue with the python version that poetry uses in the CI https://github.com/python-kasa/python-kasa/pull/831 the `pipx install poetry` step has been taking a very long time, especially with pypy.

![image](https://github.com/python-kasa/python-kasa/assets/51370195/8ce2df30-fb54-4684-925d-4592f5edf2e1)

This PR caches the pipx install locations so poetry itself will be restored from the cache. It also moves all the install/setup logic into a custom action so it's not repeated unnecessarily and is easier to read and maintain.

![image](https://github.com/python-kasa/python-kasa/assets/51370195/bf071068-e6af-421b-9eb1-b8831eb25e01)
