### PR TITLE
Expose IOT emeter info as features

### DIFF
--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -18,7 +18,7 @@ from .iotdevice import (
     requires_update,
 )
 from .iotplug import IotPlug
-from .modules import Antitheft, Countdown, Emeter, Schedule, Time, Usage
+from .modules import Antitheft, Countdown, Schedule, Time, Usage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,7 +100,6 @@ class IotStrip(IotDevice):
         self.add_module("usage", Usage(self, "schedule"))
         self.add_module("time", Time(self, "time"))
         self.add_module("countdown", Countdown(self, "countdown"))
-        self.add_module("emeter", Emeter(self, "emeter"))
 
     @property  # type: ignore
     @requires_update

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -216,13 +216,13 @@ class IotStrip(IotDevice):
     @requires_update
     def emeter_this_month(self) -> float | None:
         """Return this month's energy consumption in kWh."""
-        return sum(plug.emeter_this_month for plug in self.children)
+        return sum(v if (v := plug.emeter_this_month) else 0 for plug in self.children)
 
     @property  # type: ignore
     @requires_update
     def emeter_today(self) -> float | None:
         """Return this month's energy consumption in kWh."""
-        return sum(plug.emeter_today for plug in self.children)
+        return sum(v if (v := plug.emeter_today) else 0 for plug in self.children)
 
     @property  # type: ignore
     @requires_update

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -4,12 +4,62 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from ... import Device
 from ...emeterstatus import EmeterStatus
+from ...feature import Feature
 from .usage import Usage
 
 
 class Emeter(Usage):
     """Emeter module."""
+
+    def __init__(self, device: Device, module: str):
+        super().__init__(device, module)
+        self._add_feature(
+            Feature(
+                device,
+                name="Current consumption",
+                attribute_getter="current_consumption",
+                container=self,
+                unit="W",
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                name="Today's consumption",
+                attribute_getter="emeter_today",
+                container=self,
+                unit="kWh",
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                name="This month's consumption",
+                attribute_getter="emeter_this_month",
+                container=self,
+                unit="kWh",
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                name="Voltage",
+                attribute_getter="voltage",
+                container=self,
+                unit="V",
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                name="Current",
+                attribute_getter="current",
+                container=self,
+                unit="A",
+            )
+        )
 
     @property  # type: ignore
     def realtime(self) -> EmeterStatus:
@@ -31,6 +81,22 @@ class Emeter(Usage):
         current_month = datetime.now().month
         data = self._convert_stat_data(raw_data, entry_key="month", key=current_month)
         return data.get(current_month)
+
+    @property
+    def current_consumption(self) -> float:
+        """Get the current power consumption in Watt."""
+        response = self.realtime
+        return float(response["power"])
+
+    @property
+    def current(self) -> float | None:
+        """Return the current in A."""
+        return self.realtime.current
+
+    @property
+    def voltage(self) -> float | None:
+        """Get the current voltage in V."""
+        return self.realtime.voltage
 
     async def erase_stats(self):
         """Erase all stats.

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -97,10 +97,14 @@ class Emeter(Usage):
         return data.get(current_month)
 
     @property
-    def current_consumption(self) -> float:
+    def current_consumption(self) -> float | None:
         """Get the current power consumption in Watt."""
-        response = self.realtime
-        return float(response["power"])
+        return self.realtime.power
+
+    @property
+    def emeter_total(self) -> float | None:
+        """Return total consumption since last reboot in kWh."""
+        return self.realtime.total
 
     @property
     def current(self) -> float | None:

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -22,6 +22,7 @@ class Emeter(Usage):
                 attribute_getter="current_consumption",
                 container=self,
                 unit="W",
+                id="current_power_w",  # for homeassistant backwards compat
             )
         )
         self._add_feature(
@@ -31,6 +32,7 @@ class Emeter(Usage):
                 attribute_getter="emeter_today",
                 container=self,
                 unit="kWh",
+                id="today_energy_kwh",  # for homeassistant backwards compat
             )
         )
         self._add_feature(
@@ -45,10 +47,21 @@ class Emeter(Usage):
         self._add_feature(
             Feature(
                 device,
+                name="Total consumption since reboot",
+                attribute_getter="emeter_total",
+                container=self,
+                unit="kWh",
+                id="total_energy_kwh",  # for homeassistant backwards compat
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
                 name="Voltage",
                 attribute_getter="voltage",
                 container=self,
                 unit="V",
+                id="voltage",  # for homeassistant backwards compat
             )
         )
         self._add_feature(
@@ -58,6 +71,7 @@ class Emeter(Usage):
                 attribute_getter="current",
                 container=self,
                 unit="A",
+                id="current_a",  # for homeassistant backwards compat
             )
         )
 


### PR DESCRIPTION
Exposes IOT emeter information using features, bases on #843 to allow defining the units.

Note, this doesn't currently pass mypy checks due to typing on some `emeter_*` properties which are currently defined to return an optional value.

Closes #772