### PR TITLE
Re-query missing responses after multi request errors

### DIFF
--- a/kasa/tests/fakeprotocol_smart.py
+++ b/kasa/tests/fakeprotocol_smart.py
@@ -113,6 +113,9 @@ class FakeSmartTransport(BaseTransport):
             responses = []
             for request in params["requests"]:
                 response = self._send_request(request)  # type: ignore[arg-type]
+                # Devices do not continue after error
+                if response["error_code"] != 0:
+                    break
                 response["method"] = request["method"]  # type: ignore[index]
                 responses.append(response)
             return {"result": {"responses": responses}, "error_code": 0}

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -36,6 +36,11 @@ async def test_smart_device_errors(dummy_protocol, mocker, error_code):
 async def test_smart_device_errors_in_multiple_request(
     dummy_protocol, mocker, error_code
 ):
+    mock_request = {
+        "foobar1": {"foo": "bar", "bar": "foo"},
+        "foobar2": {"foo": "bar", "bar": "foo"},
+        "foobar3": {"foo": "bar", "bar": "foo"},
+    }
     mock_response = {
         "result": {
             "responses": [
@@ -55,9 +60,10 @@ async def test_smart_device_errors_in_multiple_request(
         dummy_protocol._transport, "send", return_value=mock_response
     )
 
-    resp_dict = await dummy_protocol.query(DUMMY_MULTIPLE_QUERY, retry_count=2)
+    resp_dict = await dummy_protocol.query(mock_request, retry_count=2)
     assert resp_dict["foobar2"] == error_code
     assert send_mock.call_count == 1
+    assert len(resp_dict) == len(mock_request)
 
 
 @pytest.mark.parametrize("request_size", [1, 3, 5, 10])


### PR DESCRIPTION
When smart devices encounter an error during a multipleRequest they return the previous successes and the current error and stop processing subsequent requests.  This PR checks the responses returned and re-queries individually for any missing responses so that individual errors do not break other components.