### PR TITLE
Add support for pairing devices with hubs

### DIFF
--- a/kasa/cli/hub.py
+++ b/kasa/cli/hub.py
@@ -18,13 +18,13 @@ def pretty_category(cat: str):
 
 @click.group()
 async def hub():
-    """Commands controling child devices."""
+    """Commands controlling hub child device pairing."""
 
 
 @hub.command(name="list")
 @pass_dev
 async def hub_list(dev):
-    """List children."""
+    """List hub paired child devices."""
     for c in dev.children:
         echo(f"{c.device_id}: {c}")
 
@@ -32,7 +32,7 @@ async def hub_list(dev):
 @hub.command(name="supported")
 @pass_dev
 async def hub_supported(dev):
-    """List supported child device categories."""
+    """List supported hub child device categories."""
     if (cs := dev.modules.get(Module.ChildSetup)) is None:
         echo(f"{dev} is not a hub.")
         return
@@ -45,7 +45,10 @@ async def hub_supported(dev):
 @click.option("--timeout", default=10)
 @pass_dev
 async def hub_pair(dev, timeout):
-    """Pair new device."""
+    """Pair all pairable device.
+    
+    This will pair any child devices currently in pairing mode.
+    """
     if (cs := dev.modules.get(Module.ChildSetup)) is None:
         echo(f"{dev} is not a hub.")
         return

--- a/kasa/cli/hub.py
+++ b/kasa/cli/hub.py
@@ -1,0 +1,50 @@
+"""Hub-specific commands."""
+
+import asyncclick as click
+
+from .common import (
+    echo,
+    pass_dev,
+)
+
+
+@click.group()
+async def hub():
+    """Commands controling child devices."""
+
+
+@hub.command(name="list")
+@pass_dev
+async def hub_list(dev):
+    """List children."""
+    for c in dev.children:
+        echo(f"{c.device_id}: {c}")
+
+
+@hub.command(name="pair")
+@click.option("--timeout", default=10)
+@pass_dev
+async def hub_pair(dev, timeout):
+    """Pair new device."""
+    if "ChildSetupModule" not in dev.modules:
+        echo(f"{dev} is not a hub.")
+        return
+
+    echo(f"Finding new devices for {timeout} seconds...")
+    cs = dev.modules["ChildSetupModule"]
+    return await cs.pair(timeout=timeout)
+
+
+@hub.command(name="unpair")
+@click.argument("device_id")
+@pass_dev
+async def hub_unpair(dev, device_id: str):
+    """Unpair given device."""
+    if "ChildSetupModule" not in dev.modules:
+        echo(f"{dev} is not a hub.")
+        return
+
+    cs = dev.modules["ChildSetupModule"]
+    res = await cs.unpair(device_id=device_id)
+    echo(f"Unpaired {device_id} (if it was paired)")
+    return res

--- a/kasa/cli/main.py
+++ b/kasa/cli/main.py
@@ -93,6 +93,7 @@ def _legacy_type_to_class(_type: str) -> Any:
         "hsv": "light",
         "temperature": "light",
         "effect": "light",
+        "hub": "hub",
     },
     result_callback=json_formatter_cb,
 )

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -76,6 +76,7 @@ from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .device import Device
+    from .module import Module
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -142,7 +143,7 @@ class Feature:
     #: Callable coroutine or name of the method that allows changing the value
     attribute_setter: str | Callable[..., Coroutine[Any, Any, Any]] | None = None
     #: Container storing the data, this overrides 'device' for getters
-    container: Any = None
+    container: Device | Module | None = None
     #: Icon suggestion
     icon: str | None = None
     #: Attribute containing the name of the unit getter property.

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -153,6 +153,7 @@ class Module(ABC):
         "ChildProtection"
     )
     TriggerLogs: Final[ModuleName[smart.TriggerLogs]] = ModuleName("TriggerLogs")
+    ChildSetup: Final[ModuleName[smart.ChildSetup]] = ModuleName("ChildSetup")
 
     HomeKit: Final[ModuleName[smart.HomeKit]] = ModuleName("HomeKit")
     Matter: Final[ModuleName[smart.Matter]] = ModuleName("Matter")

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -7,8 +7,8 @@ from .batterysensor import BatterySensor
 from .brightness import Brightness
 from .childdevice import ChildDevice
 from .childprotection import ChildProtection
-from .clean import Clean
 from .childsetup import ChildSetup
+from .clean import Clean
 from .cloud import Cloud
 from .color import Color
 from .colortemperature import ColorTemperature

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -9,6 +9,7 @@ from .childdevice import ChildDevice
 from .childprotection import ChildProtection
 from .clean import Clean
 from .cloud import Cloud
+from .childsetup import ChildSetupModule
 from .color import Color
 from .colortemperature import ColorTemperature
 from .contactsensor import ContactSensor
@@ -45,6 +46,7 @@ __all__ = [
     "Energy",
     "DeviceModule",
     "ChildDevice",
+    "ChildSetupModule",
     "BatterySensor",
     "HumiditySensor",
     "TemperatureSensor",

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -8,8 +8,8 @@ from .brightness import Brightness
 from .childdevice import ChildDevice
 from .childprotection import ChildProtection
 from .clean import Clean
+from .childsetup import ChildSetup
 from .cloud import Cloud
-from .childsetup import ChildSetupModule
 from .color import Color
 from .colortemperature import ColorTemperature
 from .contactsensor import ContactSensor
@@ -46,7 +46,7 @@ __all__ = [
     "Energy",
     "DeviceModule",
     "ChildDevice",
-    "ChildSetupModule",
+    "ChildSetup",
     "BatterySensor",
     "HumiditySensor",
     "TemperatureSensor",

--- a/kasa/smart/modules/childsetup.py
+++ b/kasa/smart/modules/childsetup.py
@@ -1,0 +1,71 @@
+"""Implementation for child device setup.
+
+This module allows pairing and disconnecting child devices.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+# hen support for cpython older than 3.11 is dropped
+# async_timeout can be replaced with asyncio.timeout
+from async_timeout import timeout as asyncio_timeout
+
+from ..smartmodule import SmartModule
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ChildSetupModule(SmartModule):
+    """Implementation for child device setup."""
+
+    REQUIRED_COMPONENT = "child_quick_setup"
+    QUERY_GETTER_NAME = "get_support_child_device_category"
+
+    @property
+    def supported_device_categories(self) -> list[str]:
+        """Return supported device categories."""
+        return self.data["device_category_list"]
+
+    async def pair(self, *, timeout=5):
+        """Scan for new devices and pair after discovering first new device."""
+        await self.call("begin_scanning_child_device")
+
+        discovered: dict = {}
+        try:
+            async with asyncio_timeout(timeout):
+                while True:
+                    await asyncio.sleep(0.5)
+                    res = await self.get_detected_devices()
+                    if res["child_device_list"]:
+                        discovered = res
+                        break
+
+        except TimeoutError:
+            pass
+
+        _LOGGER.info(
+            "Discovery done, found %s devices", len(discovered["child_device_list"])
+        )
+        if discovered:
+            _LOGGER.info("Adding %s", discovered)
+            await self.add_devices(discovered)
+        else:
+            _LOGGER.warning("No devices found.")
+
+    async def unpair(self, device_id: str):
+        """Remove device from the hub."""
+        payload = {"child_device_list": [{"device_id": device_id}]}
+        return await self._device._query_helper("remove_child_device_list", payload)
+
+    async def add_devices(self, devices: dict):
+        """Add devices."""
+        return await self._device._query_helper("add_child_device_list", devices)
+
+    async def get_detected_devices(self) -> dict:
+        """Return list of devices detected during scanning."""
+        param = {"scan_list": self.supported_device_categories}
+        res = await self.call("get_scan_child_device_list", param)
+        _LOGGER.debug("Scan status: %s", res)
+        return res["get_scan_child_device_list"]

--- a/kasa/smart/modules/childsetup.py
+++ b/kasa/smart/modules/childsetup.py
@@ -19,7 +19,7 @@ from ..smartmodule import SmartModule
 _LOGGER = logging.getLogger(__name__)
 
 
-class ChildSetupModule(SmartModule):
+class ChildSetup(SmartModule):
     """Implementation for child device setup."""
 
     REQUIRED_COMPONENT = "child_quick_setup"
@@ -30,6 +30,7 @@ class ChildSetupModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                id="pair",
                 name="Pair",
                 container=self,
                 attribute_setter="pair",

--- a/kasa/smart/modules/childsetup.py
+++ b/kasa/smart/modules/childsetup.py
@@ -34,7 +34,7 @@ class ChildSetup(SmartModule):
             )
         )
 
-    async def get_supported_device_categories(self) -> list[str]:
+    async def get_supported_device_categories(self) -> list[dict]:
         """Get supported device categories."""
         categories = await self.call("get_support_child_device_category")
         return categories["get_support_child_device_category"]["device_category_list"]

--- a/kasa/smart/modules/childsetup.py
+++ b/kasa/smart/modules/childsetup.py
@@ -63,6 +63,8 @@ class ChildSetup(SmartModule):
 
     async def unpair(self, device_id: str) -> dict:
         """Remove device from the hub."""
+        _LOGGER.debug("Going to unpair %s from %s", device_id, self)
+
         payload = {"child_device_list": [{"device_id": device_id}]}
         return await self.call("remove_child_device_list", payload)
 

--- a/kasa/smart/modules/childsetup.py
+++ b/kasa/smart/modules/childsetup.py
@@ -7,13 +7,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-
-# hen support for cpython older than 3.11 is dropped
-# async_timeout can be replaced with asyncio.timeout
-from async_timeout import timeout as asyncio_timeout
+from asyncio import timeout as asyncio_timeout
 
 from ...feature import Feature
-from ..smartdevice import SmartDevice
 from ..smartmodule import SmartModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -25,11 +21,11 @@ class ChildSetup(SmartModule):
     REQUIRED_COMPONENT = "child_quick_setup"
     QUERY_GETTER_NAME = "get_support_child_device_category"
 
-    def __init__(self, device: SmartDevice, module: str):
-        super().__init__(device, module)
+    def _initialize_features(self) -> None:
+        """Initialize features."""
         self._add_feature(
             Feature(
-                device,
+                self._device,
                 id="pair",
                 name="Pair",
                 container=self,
@@ -44,7 +40,7 @@ class ChildSetup(SmartModule):
         """Return supported device categories."""
         return self.data["device_category_list"]
 
-    async def pair(self, *, timeout=10):
+    async def pair(self, *, timeout: int = 10) -> dict:
         """Scan for new devices and pair after discovering first new device."""
         await self.call("begin_scanning_child_device")
 
@@ -63,7 +59,7 @@ class ChildSetup(SmartModule):
 
         if not discovered:
             _LOGGER.warning("No devices found.")
-            return
+            return {}
 
         _LOGGER.info(
             "Discovery done, found %s devices", len(discovered["child_device_list"])
@@ -71,14 +67,14 @@ class ChildSetup(SmartModule):
 
         return await self.add_devices(discovered)
 
-    async def unpair(self, device_id: str):
+    async def unpair(self, device_id: str) -> dict:
         """Remove device from the hub."""
         payload = {"child_device_list": [{"device_id": device_id}]}
-        return await self._device._query_helper("remove_child_device_list", payload)
+        return await self.call("remove_child_device_list", payload)
 
-    async def add_devices(self, devices: dict):
+    async def add_devices(self, devices: dict) -> dict:
         """Add devices."""
-        return await self._device._query_helper("add_child_device_list", devices)
+        return await self.call("add_child_device_list", devices)
 
     async def get_detected_devices(self) -> dict:
         """Return list of devices detected during scanning."""

--- a/kasa/smart/modules/childsetup.py
+++ b/kasa/smart/modules/childsetup.py
@@ -43,15 +43,15 @@ class ChildSetup(SmartModule):
         """Scan for new devices and pair after discovering first new device."""
         await self.call("begin_scanning_child_device")
 
-        _LOGGER.debug("Waiting %s seconds for discovering new devices", timeout)
+        _LOGGER.info("Waiting %s seconds for discovering new devices", timeout)
         await asyncio.sleep(timeout)
         detected = await self._get_detected_devices()
 
         if not detected["child_device_list"]:
-            _LOGGER.debug("No devices found.")
+            _LOGGER.info("No devices found.")
             return []
 
-        _LOGGER.debug(
+        _LOGGER.info(
             "Discovery done, found %s devices: %s",
             len(detected["child_device_list"]),
             detected,

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -537,13 +537,16 @@ class SmartDevice(Device):
             )
         )
 
-        if self.parent is not None and Module.ChildSetup in self.parent.modules:
+        if self.parent is not None and (
+            cs := self.parent.modules.get(Module.ChildSetup)
+        ):
             self._add_feature(
                 Feature(
                     device=self,
                     id="unpair",
                     name="Unpair device",
-                    attribute_setter="unpair",
+                    container=cs,
+                    attribute_setter=lambda: cs.unpair(self.device_id),
                     category=Feature.Category.Debug,
                     type=Feature.Type.Action,
                 )
@@ -827,21 +830,6 @@ class SmartDevice(Device):
         Note, this does not downgrade the firmware.
         """
         await self.protocol.query("device_reset")
-
-    async def unpair(self) -> dict:
-        """Unpair the device from the hub."""
-        if self.parent is None:
-            raise KasaException("Device has no parent")
-
-        if (cs := self.parent.modules.get(Module.ChildSetup)) is None:
-            raise KasaException(
-                "Device is not hub-paired device or "
-                "the parent does not support child setup"
-            )
-
-        _LOGGER.debug("Going to unpair %s", self)
-
-        return await cs.unpair(self.device_id)
 
     @property
     def device_type(self) -> DeviceType:

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -65,6 +65,7 @@ class SmartDevice(Device):
         self.protocol: SmartProtocol
         self._components_raw: ComponentsRaw | None = None
         self._components: dict[str, int] = {}
+        self._state_information: dict[str, Any] = {}
         self._modules: dict[str | ModuleName[Module], SmartModule] = {}
         self._parent: SmartDevice | None = None
         self._children: dict[str, SmartDevice] = {}
@@ -226,21 +227,6 @@ class SmartDevice(Device):
 
         if "child_device" in self._components and not self.children:
             await self._initialize_children()
-
-    def request_renegotiation(self) -> None:
-        """Request renegotiation on the next update.
-
-        This is used by childsetup to inform about new or removed children.
-        """
-        self._modules.clear()
-        self._features.clear()
-        self._last_update.clear()
-        self._components.clear()
-        if self._components_raw is not None:
-            self._components_raw.clear()
-            self._components_raw = None
-        # we cannot use clear here, as mapping doesn't have it...
-        self._children = {}
 
     async def _update_children_info(self) -> bool:
         """Update the internal child device info from the parent info.

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -65,7 +65,6 @@ class SmartDevice(Device):
         self.protocol: SmartProtocol
         self._components_raw: ComponentsRaw | None = None
         self._components: dict[str, int] = {}
-        self._state_information: dict[str, Any] = {}
         self._modules: dict[str | ModuleName[Module], SmartModule] = {}
         self._parent: SmartDevice | None = None
         self._children: dict[str, SmartDevice] = {}
@@ -227,6 +226,21 @@ class SmartDevice(Device):
 
         if "child_device" in self._components and not self.children:
             await self._initialize_children()
+
+    def request_renegotiation(self) -> None:
+        """Request renegotiation on the next update.
+
+        This is used by childsetup to inform about new or removed children.
+        """
+        self._modules.clear()
+        self._features.clear()
+        self._last_update.clear()
+        self._components.clear()
+        if self._components_raw is not None:
+            self._components_raw.clear()
+            self._components_raw = None
+        # we cannot use clear here, as mapping doesn't have it...
+        self._children = {}
 
     async def _update_children_info(self) -> bool:
         """Update the internal child device info from the parent info.

--- a/tests/cli/test_hub.py
+++ b/tests/cli/test_hub.py
@@ -1,0 +1,53 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from kasa import DeviceType, Module
+from kasa.cli.hub import hub
+
+from ..device_fixtures import HUBS_SMART, hubs_smart, parametrize, plug_iot
+
+
+@hubs_smart
+async def test_hub_pair(dev, mocker: MockerFixture, runner, caplog):
+    """Test that pair calls the expected methods."""
+    cs = dev.modules.get(Module.ChildSetup)
+    # Patch if the device supports the module
+    if cs is not None:
+        mock_pair = mocker.patch.object(cs, "pair")
+
+    res = await runner.invoke(hub, ["pair"], obj=dev, catch_exceptions=False)
+    if cs is None:
+        assert "is not a hub" in res.output
+        return
+
+    mock_pair.assert_awaited()
+    assert "Finding new devices for 10 seconds" in res.output
+    assert res.exit_code == 0
+
+
+@parametrize("hubs smart", model_filter=HUBS_SMART, protocol_filter={"SMART"})
+async def test_hub_unpair(dev, mocker: MockerFixture, runner):
+    """Test that unpair calls the expected method."""
+    if not dev.children:
+        pytest.skip("Cannot test without child devices")
+
+    id_ = next(iter(dev.children)).device_id
+
+    cs = dev.modules.get(Module.ChildSetup)
+    mock_unpair = mocker.spy(cs, "unpair")
+
+    res = await runner.invoke(hub, ["unpair", id_], obj=dev, catch_exceptions=False)
+
+    mock_unpair.assert_awaited()
+    assert f"Unpaired {id_}" in res.output
+    assert res.exit_code == 0
+
+
+@plug_iot
+async def test_non_hub(dev, mocker: MockerFixture, runner):
+    """Test that hub commands return an error if executed on a non-hub."""
+    assert dev.device_type is not DeviceType.Hub
+    res = await runner.invoke(
+        hub, ["unpair", "dummy_id"], obj=dev, catch_exceptions=False
+    )
+    assert "is not a hub" in res.output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# TODO: this and runner fixture could be moved to tests/cli/conftest.py
+from asyncclick.testing import CliRunner
 
 from kasa import (
     DeviceConfig,
@@ -149,3 +153,12 @@ def mock_datagram_endpoint(request):  # noqa: PT004
             side_effect=_create_datagram_endpoint,
         ):
             yield
+
+
+@pytest.fixture
+def runner():
+    """Runner fixture that unsets the KASA_ environment variables for tests."""
+    KASA_VARS = {k: None for k, v in os.environ.items() if k.startswith("KASA_")}
+    runner = CliRunner(env=KASA_VARS)
+
+    return runner

--- a/tests/fakeprotocol_smart.py
+++ b/tests/fakeprotocol_smart.py
@@ -668,12 +668,13 @@ class FakeSmartTransport(BaseTransport):
             return self._set_on_off_gradually_info(info, params)
         elif method == "set_child_protection":
             return self._update_sysinfo_key(info, "child_protection", params["enable"])
-        # Hub pairing
+        # actions
         elif method in [
-            "begin_scanning_child_device",
-            "add_child_device_list",
-            "remove_child_device_list",
-        ] or method in ["playSelectAudio"]:
+            "begin_scanning_child_device",  #hub pairing
+            "add_child_device_list",  #hub pairing
+            "remove_child_device_list",  #hub pairing
+            "playSelectAudio",  #vacuum special actions
+        ]:
             return {"error_code": 0}
         elif method[:3] == "set":
             target_method = f"get{method[3:]}"

--- a/tests/fakeprotocol_smart.py
+++ b/tests/fakeprotocol_smart.py
@@ -670,10 +670,10 @@ class FakeSmartTransport(BaseTransport):
             return self._update_sysinfo_key(info, "child_protection", params["enable"])
         # actions
         elif method in [
-            "begin_scanning_child_device",  #hub pairing
-            "add_child_device_list",  #hub pairing
-            "remove_child_device_list",  #hub pairing
-            "playSelectAudio",  #vacuum special actions
+            "begin_scanning_child_device",  # hub pairing
+            "add_child_device_list",  # hub pairing
+            "remove_child_device_list",  # hub pairing
+            "playSelectAudio",  # vacuum special actions
         ]:
             return {"error_code": 0}
         elif method[:3] == "set":

--- a/tests/fakeprotocol_smart.py
+++ b/tests/fakeprotocol_smart.py
@@ -561,7 +561,6 @@ class FakeSmartTransport(BaseTransport):
     def _hub_remove_device(self, info, params):
         """Remove hub device."""
         items_to_remove = [dev["device_id"] for dev in params["child_device_list"]]
-        print(items_to_remove)
         children = info["get_child_device_list"]["child_device_list"]
         new_children = [
             dev for dev in children if dev["device_id"] not in items_to_remove

--- a/tests/fakeprotocol_smart.py
+++ b/tests/fakeprotocol_smart.py
@@ -171,6 +171,16 @@ class FakeSmartTransport(BaseTransport):
                 "setup_payload": "00:0000000-0000.00.000",
             },
         ),
+        # child setup
+        "get_support_child_device_category": (
+            "child_quick_setup",
+            {"device_category_list": [{"category": "subg.trv"}]},
+        ),
+        # no devices found
+        "get_scan_child_device_list": (
+            "child_quick_setup",
+            {"child_device_list": [{"dummy": "response"}], "scan_status": "idle"},
+        ),
     }
 
     def _missing_result(self, method):
@@ -658,8 +668,12 @@ class FakeSmartTransport(BaseTransport):
             return self._set_on_off_gradually_info(info, params)
         elif method == "set_child_protection":
             return self._update_sysinfo_key(info, "child_protection", params["enable"])
-        # Vacuum special actions
-        elif method in ["playSelectAudio"]:
+        # Hub pairing
+        elif method in [
+            "begin_scanning_child_device",
+            "add_child_device_list",
+            "remove_child_device_list",
+        ] or method in ["playSelectAudio"]:
             return {"error_code": 0}
         elif method[:3] == "set":
             target_method = f"get{method[3:]}"

--- a/tests/fakeprotocol_smart.py
+++ b/tests/fakeprotocol_smart.py
@@ -558,6 +558,18 @@ class FakeSmartTransport(BaseTransport):
 
         return {"error_code": 0}
 
+    def _hub_remove_device(self, info, params):
+        """Remove hub device."""
+        items_to_remove = [dev["device_id"] for dev in params["child_device_list"]]
+        print(items_to_remove)
+        children = info["get_child_device_list"]["child_device_list"]
+        new_children = [
+            dev for dev in children if dev["device_id"] not in items_to_remove
+        ]
+        info["get_child_device_list"]["child_device_list"] = new_children
+
+        return {"error_code": 0}
+
     def get_child_device_queries(self, method, params):
         return self._get_method_from_info(method, params)
 
@@ -668,6 +680,8 @@ class FakeSmartTransport(BaseTransport):
             return self._set_on_off_gradually_info(info, params)
         elif method == "set_child_protection":
             return self._update_sysinfo_key(info, "child_protection", params["enable"])
+        elif method == "remove_child_device_list":
+            return self._hub_remove_device(info, params)
         # actions
         elif method in [
             "begin_scanning_child_device",  # hub pairing

--- a/tests/fixtures/smart/H100(EU)_1.0_1.5.10.json
+++ b/tests/fixtures/smart/H100(EU)_1.0_1.5.10.json
@@ -472,6 +472,24 @@
         "setup_code": "00000000000",
         "setup_payload": "00:0000000000000000000"
     },
+    "get_scan_child_device_list": {
+        "child_device_list": [
+            {
+                "category": "subg.trigger.temp-hmdt-sensor",
+                "device_id": "REDACTED_1",
+                "device_model": "T315",
+                "name": "REDACTED_1"
+            },
+            {
+                "category": "subg.trigger.contact-sensor",
+                "device_id": "REDACTED_2",
+                "device_model": "T110",
+                "name": "REDACTED_2"
+            }
+        ],
+        "scan_status": "scanning",
+        "scan_wait_time": 28
+    },
     "get_support_alarm_type_list": {
         "alarm_type_list": [
             "Doorbell Ring 1",

--- a/tests/smart/modules/test_childsetup.py
+++ b/tests/smart/modules/test_childsetup.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pytest_mock import MockerFixture
+
+from kasa import Feature, Module
+from kasa.smart import SmartDevice
+from kasa.tests.device_fixtures import parametrize
+
+childsetup = parametrize(
+    "supports pairing", component_filter="child_quick_setup", protocol_filter={"SMART"}
+)
+
+
+@childsetup
+async def test_childsetup_features(dev: SmartDevice):
+    """Test the exposed features."""
+    cs = dev.modules.get(Module.ChildSetup)
+    assert cs
+
+    assert "pair" in cs._module_features
+    pair = cs._module_features["pair"]
+    assert pair.type == Feature.Type.Action
+
+
+@childsetup
+async def test_childsetup_pair(
+    dev: SmartDevice, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+):
+    """Test device pairing."""
+    caplog.set_level(logging.INFO)
+    mock_query_helper = mocker.spy(dev, "_query_helper")
+    mocker.patch("asyncio.sleep")
+
+    cs = dev.modules.get(Module.ChildSetup)
+    assert cs
+
+    await cs.pair()
+
+    mock_query_helper.assert_has_awaits(
+        [
+            mocker.call("begin_scanning_child_device", None),
+            mocker.call("get_scan_child_device_list", params=mocker.ANY),
+            mocker.call("add_child_device_list", params=mocker.ANY),
+        ]
+    )
+    assert "Discovery done" in caplog.text
+
+
+@childsetup
+async def test_childsetup_unpair(
+    dev: SmartDevice, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+):
+    """Test unpair."""
+    mock_query_helper = mocker.spy(dev, "_query_helper")
+    DUMMY_ID = "dummy_id"
+
+    cs = dev.modules.get(Module.ChildSetup)
+    assert cs
+
+    await cs.unpair(DUMMY_ID)
+
+    mock_query_helper.assert_awaited_with(
+        "remove_child_device_list",
+        params={"child_device_list": [{"device_id": DUMMY_ID}]},
+    )

--- a/tests/smart/modules/test_childsetup.py
+++ b/tests/smart/modules/test_childsetup.py
@@ -5,9 +5,9 @@ import logging
 import pytest
 from pytest_mock import MockerFixture
 
-from kasa import Feature, Module
-from kasa.smart import SmartDevice
-from kasa.tests.device_fixtures import parametrize
+from kasa import Feature, Module, SmartDevice
+
+from ...device_fixtures import parametrize
 
 childsetup = parametrize(
     "supports pairing", component_filter="child_quick_setup", protocol_filter={"SMART"}

--- a/tests/smart/modules/test_childsetup.py
+++ b/tests/smart/modules/test_childsetup.py
@@ -42,6 +42,7 @@ async def test_childsetup_pair(
     mock_query_helper.assert_has_awaits(
         [
             mocker.call("begin_scanning_child_device", None),
+            mocker.call("get_support_child_device_category", None),
             mocker.call("get_scan_child_device_list", params=mocker.ANY),
             mocker.call("add_child_device_list", params=mocker.ANY),
         ]

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -1004,6 +1004,8 @@ async def test_unpair(dev: SmartDevice, mocker: MockerFixture):
 
     unpair_call = mocker.spy(cs, "unpair")
 
-    await child.unpair()
+    unpair_feat = child.features.get("unpair")
+    assert unpair_feat
+    await unpair_feat.set_value(None)
 
     unpair_call.assert_called_with(child.device_id)

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -988,3 +988,22 @@ async def test_dynamic_devices(dev: Device, caplog: pytest.LogCaptureFixture):
         await dev.update()
 
     assert "Could not find child id for device" not in caplog.text
+
+
+@hubs_smart
+async def test_unpair(dev: SmartDevice, mocker: MockerFixture):
+    """Verify that unpair calls childsetup module."""
+    if not dev.children:
+        pytest.skip("device has no children")
+
+    child = dev.children[0]
+
+    assert child.parent is not None
+    assert Module.ChildSetup in dev.modules
+    cs = dev.modules[Module.ChildSetup]
+
+    unpair_call = mocker.spy(cs, "unpair")
+
+    await child.unpair()
+
+    unpair_call.assert_called_with(child.device_id)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -409,7 +409,7 @@ async def test_wifi_join_exception(dev, mocker, runner):
     assert isinstance(res.exception, KasaException)
 
 
-@device_smart
+@hubs_smart
 async def test_child_pair(dev, mocker: MockerFixture, runner, caplog):
     """Test that pair calls the expected methods."""
     cs = dev.modules.get(Module.ChildSetup)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -428,7 +428,7 @@ async def test_hub_pair(dev, mocker: MockerFixture, runner, caplog):
     assert res.exit_code == 0
 
 
-@device_smart
+@hubs_smart
 async def test_hub_unpair(dev, mocker: MockerFixture, runner):
     """Test that unpair calls the expected method."""
     DUMMY_ID = "dummy_id"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -419,7 +419,7 @@ async def test_child_pair(dev, mocker: MockerFixture, runner, caplog):
 
     res = await runner.invoke(hub, ["pair"], obj=dev, catch_exceptions=False)
     if cs is None:
-        assert "does not support pairing" in res.output.replace("\n", "")
+        assert "is not a hub" in res.output
         return
 
     mock_pair.assert_awaited()
@@ -441,7 +441,7 @@ async def test_child_unpair(dev, mocker: MockerFixture, runner):
     )
 
     if cs is None:
-        assert "does not support pairing" in res.output.replace("\n", "")
+        assert "is not a hub" in res.output
         return
 
     mock_unpair.assert_awaited()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,7 @@ from .conftest import (
     device_smart,
     get_device_for_fixture_protocol,
     handle_turn_on,
+    hubs_smart,
     new_discovery,
     turn_on,
 )
@@ -410,7 +411,7 @@ async def test_wifi_join_exception(dev, mocker, runner):
 
 
 @hubs_smart
-async def test_child_pair(dev, mocker: MockerFixture, runner, caplog):
+async def test_hub_pair(dev, mocker: MockerFixture, runner, caplog):
     """Test that pair calls the expected methods."""
     cs = dev.modules.get(Module.ChildSetup)
     # Patch if the device supports the module
@@ -428,7 +429,7 @@ async def test_child_pair(dev, mocker: MockerFixture, runner, caplog):
 
 
 @device_smart
-async def test_child_unpair(dev, mocker: MockerFixture, runner):
+async def test_hub_unpair(dev, mocker: MockerFixture, runner):
     """Test that unpair calls the expected method."""
     DUMMY_ID = "dummy_id"
     cs = dev.modules.get(Module.ChildSetup)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,6 @@ from kasa import (
 from kasa.cli.device import (
     alias,
     factory_reset,
-    child,
     led,
     reboot,
     state,
@@ -32,6 +31,7 @@ from kasa.cli.device import (
     toggle,
     update_credentials,
 )
+from kasa.cli.hub import hub
 from kasa.cli.light import (
     brightness,
     effect,
@@ -417,7 +417,7 @@ async def test_child_pair(dev, mocker: MockerFixture, runner, caplog):
     if cs is not None:
         mock_pair = mocker.patch.object(cs, "pair")
 
-    res = await runner.invoke(child, ["pair"], obj=dev, catch_exceptions=False)
+    res = await runner.invoke(hub, ["pair"], obj=dev, catch_exceptions=False)
     if cs is None:
         assert "does not support pairing" in res.output.replace("\n", "")
         return
@@ -437,7 +437,7 @@ async def test_child_unpair(dev, mocker: MockerFixture, runner):
         mock_unpair = mocker.patch.object(cs, "unpair")
 
     res = await runner.invoke(
-        child, ["unpair", DUMMY_ID], obj=dev, catch_exceptions=False
+        hub, ["unpair", DUMMY_ID], obj=dev, catch_exceptions=False
     )
 
     if cs is None:

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -189,7 +189,8 @@ async def test_feature_setters(dev: Device, mocker: MockerFixture):
 
     async def _test_features(dev):
         exceptions = []
-        for feat in dev.features.values():
+        feats = dev.features.copy()
+        for feat in feats.values():
             try:
                 with patch.object(feat.device.protocol, "query") as query:
                     await _test_feature(feat, query)
@@ -201,6 +202,9 @@ async def test_feature_setters(dev: Device, mocker: MockerFixture):
                 exceptions.append(ex)
 
         return exceptions
+
+    # We mock the device state reset
+    mocker.patch.object(dev, "request_renegotiation")
 
     exceptions = await _test_features(dev)
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -189,8 +189,7 @@ async def test_feature_setters(dev: Device, mocker: MockerFixture):
 
     async def _test_features(dev):
         exceptions = []
-        feats = dev.features.copy()
-        for feat in feats.values():
+        for feat in dev.features.values():
             try:
                 with patch.object(feat.device.protocol, "query") as query:
                     await _test_feature(feat, query)
@@ -202,9 +201,6 @@ async def test_feature_setters(dev: Device, mocker: MockerFixture):
                 exceptions.append(ex)
 
         return exceptions
-
-    # We mock the device state reset
-    mocker.patch.object(dev, "request_renegotiation")
 
     exceptions = await _test_features(dev)
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -74,7 +74,7 @@ def test_feature_value_container(mocker, dummy_feature: Feature):
         def test_prop(self):
             return "dummy"
 
-    dummy_feature.container = DummyContainer()
+    dummy_feature.container = DummyContainer()  # type: ignore[assignment]
     dummy_feature.attribute_getter = "test_prop"
 
     mock_dev_prop = mocker.patch.object(
@@ -191,7 +191,12 @@ async def test_feature_setters(dev: Device, mocker: MockerFixture):
         exceptions = []
         for feat in dev.features.values():
             try:
-                with patch.object(feat.device.protocol, "query", name=feat.id) as query:
+                prot = (
+                    feat.container._device.protocol
+                    if feat.container
+                    else feat.device.protocol
+                )
+                with patch.object(prot, "query", name=feat.id) as query:
                     await _test_feature(feat, query)
             # we allow our own exceptions to avoid mocking valid responses
             except KasaException:

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -191,7 +191,7 @@ async def test_feature_setters(dev: Device, mocker: MockerFixture):
         exceptions = []
         for feat in dev.features.values():
             try:
-                with patch.object(feat.device.protocol, "query") as query:
+                with patch.object(feat.device.protocol, "query", name=feat.id) as query:
                     await _test_feature(feat, query)
             # we allow our own exceptions to avoid mocking valid responses
             except KasaException:


### PR DESCRIPTION
This implements "child_quick_setup" that allows pairing and unpairing devices with a hub.
Three new cli commands are added to make the process smooth:
* `kasa hub list` lists current children and their device ids
* `kasa hub pair` searches for unpaired devices and performs pairing after something is discovered. The search ends immediately after finding the first device that can be paired.
* `kasa hub unpair <device_id>`  allows unpairing an existing device.
* `kasa hub supported` to list supported device categories.
