### PR TITLE
Be more lax on unknown SMART devices

### DIFF
--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -171,7 +171,13 @@ def get_device_class_from_family(device_type: str) -> type[Device] | None:
         "IOT.SMARTPLUGSWITCH": IotPlug,
         "IOT.SMARTBULB": IotBulb,
     }
-    return supported_device_types.get(device_type)
+    if (
+        cls := supported_device_types.get(device_type)
+    ) is None and device_type.startswith("SMART."):
+        _LOGGER.warning("Unknown SMART device with %s, using SmartDevice", device_type)
+        cls = SmartDevice
+
+    return cls
 
 
 def get_protocol(

--- a/kasa/tests/test_device_factory.py
+++ b/kasa/tests/test_device_factory.py
@@ -13,6 +13,7 @@ from kasa import (
 from kasa.device_factory import (
     _get_device_type_from_sys_info,
     connect,
+    get_device_class_from_family,
     get_protocol,
 )
 from kasa.deviceconfig import (
@@ -164,3 +165,11 @@ async def test_device_types(dev: Device):
         res = _get_device_type_from_sys_info(dev._last_update)
 
     assert dev.device_type == res
+
+
+async def test_device_class_from_unknown_family(caplog):
+    """Verify that unknown SMART devices yield a warning and fallback to SmartDevice."""
+    dummy_name = "SMART.foo"
+    with caplog.at_level(logging.WARNING):
+        assert get_device_class_from_family(dummy_name) == SmartDevice
+    assert f"Unknown SMART device with {dummy_name}" in caplog.text


### PR DESCRIPTION
Changes the device factory logic to allow constructing any devices from the SMART family, just logging a warning that it's an unknown device.

Fixes #768