### PR TITLE
Do not automatically add emeter to iot strip

### DIFF
--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -18,7 +18,7 @@ from .iotdevice import (
     requires_update,
 )
 from .iotplug import IotPlug
-from .modules import Antitheft, Countdown, Emeter, Schedule, Time, Usage
+from .modules import Antitheft, Countdown, Schedule, Time, Usage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -99,7 +99,6 @@ class IotStrip(IotDevice):
         self.add_module("usage", Usage(self, "schedule"))
         self.add_module("time", Time(self, "time"))
         self.add_module("countdown", Countdown(self, "countdown"))
-        self.add_module("emeter", Emeter(self, "emeter"))
 
     @property  # type: ignore
     @requires_update


### PR DESCRIPTION
This fixes the current broken tests in https://github.com/python-kasa/python-kasa/pull/844 caused by the fixtures for `HS107(US)_1.0_1.0.8.json` and `KP400(US)_1.0_1.0.10.json` having the `emeter` value in the fixture but no `get_realtime` value.  Other strips do not fail because they do not have the `emeter` value in the fixture and the `FakeIotProtocol` creates one for them.

It seems that https://github.com/python-kasa/python-kasa/pull/299 introduced the adding of Emeter in the smart strip constructor (in commit https://github.com/python-kasa/python-kasa/commit/c8ad99abcbc6bbef8cd2360d8821e1774d26f1de) and this was added after https://github.com/python-kasa/python-kasa/pull/243 which adds the Emeter in the IoDevice `update()` method so perhaps there is an implication to this change that I'm missing, although it seems `_create_emeter_request` is no longer called anywhere so maybe that was a historical reason.

N.B. The tests all pass with this PR.