### PR TITLE
Add runner.arch to cache-key in CI

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -41,7 +41,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.pipx-env-setup.outputs.pipx-cache-path }}
-        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-pipx-${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry-${{ inputs.poetry-version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-python-${{ steps.setup-python.outputs.python-version }}-pipx-${{ steps.pipx-env-setup.outputs.pipx-version }}-poetry-${{ inputs.poetry-version }}
 
     - name: Install poetry
       if: steps.pipx-cache.outputs.cache-hit != 'true'
@@ -61,7 +61,7 @@ runs:
       with:
         path: |
           ${{ steps.poetry-cache-location.outputs.poetry-venv-location }}
-        key: ${{ runner.os }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-options-${{ inputs.poetry-install-options }}
+        key: ${{ runner.os }}-${{ runner.arch }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}-options-${{ inputs.poetry-install-options }}
 
     - name: "Poetry install"
       shell: bash
@@ -80,4 +80,4 @@ runs:
       name: Pre-commit cache
       with:
         path: ~/.cache/pre-commit/
-        key: ${{ runner.os }}-pre-commit-${{ steps.pre-commit-version.outputs.pre-commit-version }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-pre-commit-${{ steps.pre-commit-version.outputs.pre-commit-version }}-python-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}


### PR DESCRIPTION
The recent update to the `macos-latest` github runner changed the os architecture from x86_64 to arm64 which caused the application cache to have incompatible binaries.  This PR adds the `runner.arch` context variable to the cache keys to prevent this happening again. The manual workaround in this instance was to delete all the macos caches.

Action run for reference:
https://github.com/python-kasa/python-kasa/actions/runs/8828284579/job/24236995440
```
ImportError: dlopen(/Users/runner/work/python-kasa/python-kasa/pipx_cache/home/venvs/poetry/lib/python3.11/site-packages/charset_normalizer/md.cpython-311-darwin.so, 0x0002): 
tried: '/Users/runner/work/python-kasa/python-kasa/pipx_cache/home/venvs/poetry/lib/python3.11/site-packages/charset_normalizer/md.cpython-311-darwin.so' 
(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), 
'/System/Volumes/Preboot/Cryptexes/OS/Users/runner/work/python-kasa/python-kasa/pipx_cache/home/venvs/poetry/lib/python3.11/site-packages/charset_normalizer/md.cpython-311-darwin.so' 
(no such file), '/Users/runner/work/python-kasa/python-kasa/pipx_cache/home/venvs/poetry/lib/python3.11/site-packages/charset_normalizer/md.cpython-311-darwin.so' 
(mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
```