### PR TITLE
Add precision_hint to feature

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -79,6 +79,10 @@ class Feature:
     #: Type of the feature
     type: Feature.Type = Type.Sensor
 
+    # Display hints offer a way suggest how the value should be shown to users
+    #: Hint to help rounding the sensor values to given after-comma digits
+    precision_hint: int | None = None
+
     # Number-specific attributes
     #: Minimum value
     minimum_value: int = 0
@@ -151,7 +155,10 @@ class Feature:
         return await getattr(container, self.attribute_setter)(value)
 
     def __repr__(self):
-        s = f"{self.name} ({self.id}): {self.value}"
+        value = self.value
+        if self.precision_hint is not None and value is not None:
+            value = round(self.value, self.precision_hint)
+        s = f"{self.name} ({self.id}): {value}"
         if self.unit is not None:
             s += f" {self.unit}"
 

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -23,6 +23,7 @@ class Emeter(Usage):
                 container=self,
                 unit="W",
                 id="current_power_w",  # for homeassistant backwards compat
+                precision_hint=1,
             )
         )
         self._add_feature(
@@ -33,6 +34,7 @@ class Emeter(Usage):
                 container=self,
                 unit="kWh",
                 id="today_energy_kwh",  # for homeassistant backwards compat
+                precision_hint=2,
             )
         )
         self._add_feature(
@@ -42,6 +44,7 @@ class Emeter(Usage):
                 attribute_getter="emeter_this_month",
                 container=self,
                 unit="kWh",
+                precision_hint=2,
             )
         )
         self._add_feature(
@@ -52,6 +55,7 @@ class Emeter(Usage):
                 container=self,
                 unit="kWh",
                 id="total_energy_kwh",  # for homeassistant backwards compat
+                precision_hint=2,
             )
         )
         self._add_feature(
@@ -62,6 +66,7 @@ class Emeter(Usage):
                 container=self,
                 unit="V",
                 id="voltage",  # for homeassistant backwards compat
+                precision_hint=1,
             )
         )
         self._add_feature(
@@ -72,6 +77,7 @@ class Emeter(Usage):
                 container=self,
                 unit="A",
                 id="current_a",  # for homeassistant backwards compat
+                precision_hint=2,
             )
         )
 

--- a/kasa/smart/modules/energymodule.py
+++ b/kasa/smart/modules/energymodule.py
@@ -26,6 +26,7 @@ class EnergyModule(SmartModule):
                 attribute_getter="current_power",
                 container=self,
                 unit="W",
+                precision_hint=1,
             )
         )
         self._add_feature(
@@ -35,6 +36,7 @@ class EnergyModule(SmartModule):
                 attribute_getter="emeter_today",
                 container=self,
                 unit="Wh",
+                precision_hint=2,
             )
         )
         self._add_feature(
@@ -44,6 +46,7 @@ class EnergyModule(SmartModule):
                 attribute_getter="emeter_this_month",
                 container=self,
                 unit="Wh",
+                precision_hint=2,
             )
         )
 

--- a/kasa/tests/test_feature.py
+++ b/kasa/tests/test_feature.py
@@ -108,3 +108,15 @@ async def test_feature_action(mocker):
     assert feat.value == "<Action>"
     await feat.set_value(1234)
     mock_call_action.assert_called()
+
+
+@pytest.mark.parametrize("precision_hint", [1, 2, 3])
+async def test_precision_hint(dummy_feature, precision_hint):
+    """Test that precision hint works as expected."""
+    dummy_value = 3.141593
+    dummy_feature.type = Feature.Type.Sensor
+    dummy_feature.precision_hint = precision_hint
+
+    dummy_feature.attribute_getter = lambda x: dummy_value
+    assert dummy_feature.value == dummy_value
+    assert f"{round(dummy_value, precision_hint)} dummyunit" in repr(dummy_feature)


### PR DESCRIPTION
This can be used to hint how the sensor value should be rounded when displaying it to users.

The values are adapted from the values used by homeassistant, with the exception that kWh values are using one fewer after-comma digit (2 instead of 3). RFC if two digits is enough for the measurements in kWh?