### PR TITLE
Add hass_compat to feature

### DIFF
--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -25,7 +25,7 @@ from ..device import Device, WifiNetwork
 from ..deviceconfig import DeviceConfig
 from ..emeterstatus import EmeterStatus
 from ..exceptions import KasaException
-from ..feature import Feature
+from ..feature import Feature, HassCompat
 from ..protocol import BaseProtocol
 from .iotmodule import IotModule
 from .modules import Emeter
@@ -311,6 +311,7 @@ class IotDevice(Device):
                 attribute_getter="rssi",
                 icon="mdi:signal",
                 category=Feature.Category.Debug,
+                hass_compat=HassCompat(entity_registry_enabled_default=False),
             )
         )
         if "on_time" in self._sys_info:
@@ -320,6 +321,9 @@ class IotDevice(Device):
                     name="On since",
                     attribute_getter="on_since",
                     icon="mdi:clock",
+                    # TODO: We could enable this if we implement timezone support
+                    # hass_compat=HassCompat(device_class=
+                    # HassCompat.DeviceClass.Timestamp),
                 )
             )
 

--- a/kasa/iot/iotdimmer.py
+++ b/kasa/iot/iotdimmer.py
@@ -96,6 +96,7 @@ class IotDimmer(IotPlug):
                     attribute_setter="set_brightness",
                     minimum_value=1,
                     maximum_value=100,
+                    category=Feature.Category.Primary,
                     type=Feature.Type.Number,
                 )
             )

--- a/kasa/iot/modules/ambientlight.py
+++ b/kasa/iot/modules/ambientlight.py
@@ -26,6 +26,7 @@ class AmbientLight(IotModule):
                 icon="mdi:brightness-percent",
                 attribute_getter="ambientlight_brightness",
                 type=Feature.Type.Sensor,
+                unit="%",
             )
         )
 

--- a/kasa/iot/modules/cloud.py
+++ b/kasa/iot/modules/cloud.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from pydantic import BaseModel
 
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..iotmodule import IotModule
 
 
@@ -37,6 +37,8 @@ class Cloud(IotModule):
                 icon="mdi:cloud",
                 attribute_getter="is_connected",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Debug,
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Connected),
             )
         )
 

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 from ... import Device
 from ...emeterstatus import EmeterStatus
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from .usage import Usage
 
 
@@ -23,6 +23,10 @@ class Emeter(Usage):
                 container=self,
                 unit="W",
                 id="current_power_w",  # for homeassistant backwards compat
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Power,
+                    state_class=HassCompat.StateClass.Measurement,
+                ),
             )
         )
         self._add_feature(
@@ -33,6 +37,11 @@ class Emeter(Usage):
                 container=self,
                 unit="kWh",
                 id="today_energy_kwh",  # for homeassistant backwards compat
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Energy,
+                    state_class=HassCompat.StateClass.TotalIncreasing,
+                    entity_registry_visible_default=False,
+                ),
             )
         )
         self._add_feature(
@@ -42,6 +51,11 @@ class Emeter(Usage):
                 attribute_getter="emeter_this_month",
                 container=self,
                 unit="kWh",
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Energy,
+                    state_class=HassCompat.StateClass.TotalIncreasing,
+                    entity_registry_visible_default=False,
+                ),
             )
         )
         self._add_feature(
@@ -52,6 +66,11 @@ class Emeter(Usage):
                 container=self,
                 unit="kWh",
                 id="total_energy_kwh",  # for homeassistant backwards compat
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Energy,
+                    state_class=HassCompat.StateClass.TotalIncreasing,
+                    entity_registry_visible_default=False,
+                ),
             )
         )
         self._add_feature(
@@ -62,6 +81,10 @@ class Emeter(Usage):
                 container=self,
                 unit="V",
                 id="voltage",  # for homeassistant backwards compat
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Voltage,
+                    state_class=HassCompat.StateClass.Measurement,
+                ),
             )
         )
         self._add_feature(
@@ -72,6 +95,10 @@ class Emeter(Usage):
                 container=self,
                 unit="A",
                 id="current_a",  # for homeassistant backwards compat
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Current,
+                    state_class=HassCompat.StateClass.Measurement,
+                ),
             )
         )
 

--- a/kasa/smart/modules/autooffmodule.py
+++ b/kasa/smart/modules/autooffmodule.py
@@ -42,7 +42,11 @@ class AutoOffModule(SmartModule):
         )
         self._add_feature(
             Feature(
-                device, "Auto off at", container=self, attribute_getter="auto_off_at"
+                device,
+                "Auto off at",
+                container=self,
+                attribute_getter="auto_off_at",
+                category=Feature.Category.Debug,
             )
         )
 

--- a/kasa/smart/modules/battery.py
+++ b/kasa/smart/modules/battery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -26,6 +26,9 @@ class BatterySensor(SmartModule):
                 container=self,
                 attribute_getter="battery",
                 icon="mdi:battery",
+                unit="%",
+                category=Feature.Category.Debug,
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Battery),
             )
         )
         self._add_feature(
@@ -36,6 +39,8 @@ class BatterySensor(SmartModule):
                 attribute_getter="battery_low",
                 icon="mdi:alert",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Debug,
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.LowBattery),
             )
         )
 

--- a/kasa/smart/modules/cloudmodule.py
+++ b/kasa/smart/modules/cloudmodule.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...exceptions import SmartErrorCode
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -29,6 +29,8 @@ class CloudModule(SmartModule):
                 attribute_getter="is_connected",
                 icon="mdi:cloud",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Debug,
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Connected),
             )
         )
 

--- a/kasa/smart/modules/energymodule.py
+++ b/kasa/smart/modules/energymodule.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...emeterstatus import EmeterStatus
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -26,6 +26,10 @@ class EnergyModule(SmartModule):
                 attribute_getter="current_power",
                 container=self,
                 unit="W",
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Power,
+                    state_class=HassCompat.StateClass.Measurement,
+                ),
             )
         )
         self._add_feature(
@@ -35,6 +39,10 @@ class EnergyModule(SmartModule):
                 attribute_getter="emeter_today",
                 container=self,
                 unit="Wh",
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Energy,
+                    state_class=HassCompat.StateClass.TotalIncreasing,
+                ),
             )
         )
         self._add_feature(
@@ -44,6 +52,10 @@ class EnergyModule(SmartModule):
                 attribute_getter="emeter_this_month",
                 container=self,
                 unit="Wh",
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Energy,
+                    state_class=HassCompat.StateClass.TotalIncreasing,
+                ),
             )
         )
 

--- a/kasa/smart/modules/firmware.py
+++ b/kasa/smart/modules/firmware.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Optional
 
 from ...exceptions import SmartErrorCode
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 try:
@@ -69,6 +69,10 @@ class Firmware(SmartModule):
                 container=self,
                 attribute_getter="update_available",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Debug,
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.UpdateAvailable
+                ),
             )
         )
 

--- a/kasa/smart/modules/humidity.py
+++ b/kasa/smart/modules/humidity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -27,6 +27,7 @@ class HumiditySensor(SmartModule):
                 attribute_getter="humidity",
                 icon="mdi:water-percent",
                 unit="%",
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Humidity),
             )
         )
         self._add_feature(
@@ -37,6 +38,8 @@ class HumiditySensor(SmartModule):
                 attribute_getter="humidity_warning",
                 type=Feature.Type.BinarySensor,
                 icon="mdi:alert",
+                category=Feature.Category.Debug,
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Problem),
             )
         )
 

--- a/kasa/smart/modules/reportmodule.py
+++ b/kasa/smart/modules/reportmodule.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -26,6 +26,7 @@ class ReportModule(SmartModule):
                 container=self,
                 attribute_getter="report_interval",
                 category=Feature.Category.Debug,
+                hass_compat=HassCompat(entity_registry_enabled_default=False),
             )
         )
 

--- a/kasa/smart/modules/temperature.py
+++ b/kasa/smart/modules/temperature.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal
 
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -27,6 +27,7 @@ class TemperatureSensor(SmartModule):
                 attribute_getter="temperature",
                 icon="mdi:thermometer",
                 category=Feature.Category.Primary,
+                hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Temperature),
             )
         )
         if "current_temp_exception" in device.sys_info:
@@ -38,6 +39,8 @@ class TemperatureSensor(SmartModule):
                     attribute_getter="temperature_warning",
                     type=Feature.Type.BinarySensor,
                     icon="mdi:alert",
+                    category=Feature.Category.Debug,
+                    hass_compat=HassCompat(device_class=HassCompat.DeviceClass.Problem),
                 )
             )
         self._add_feature(
@@ -65,6 +68,7 @@ class TemperatureSensor(SmartModule):
     @property
     def temperature_unit(self):
         """Return current temperature unit."""
+        # TODO: use directly homeassistant compatible units, ⁰C and ⁰F?
         return self._device.sys_info["temp_unit"]
 
     async def set_temperature_unit(self, unit: Literal["celsius", "fahrenheit"]):

--- a/kasa/smart/modules/timemodule.py
+++ b/kasa/smart/modules/timemodule.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 from time import mktime
 from typing import TYPE_CHECKING, cast
 
-from ...feature import Feature
+from ...feature import Feature, HassCompat
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
@@ -29,6 +29,10 @@ class TimeModule(SmartModule):
                 attribute_getter="time",
                 container=self,
                 category=Feature.Category.Debug,
+                hass_compat=HassCompat(
+                    device_class=HassCompat.DeviceClass.Timestamp,
+                    entity_registry_enabled_default=False,
+                ),
             )
         )
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -13,7 +13,7 @@ from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
 from ..emeterstatus import EmeterStatus
 from ..exceptions import AuthenticationError, DeviceError, KasaException, SmartErrorCode
-from ..feature import Feature
+from ..feature import Feature, HassCompat
 from ..smartprotocol import SmartProtocol
 from .modules import *  # noqa: F403
 
@@ -206,6 +206,7 @@ class SmartDevice(Device):
                 "Device ID",
                 attribute_getter="device_id",
                 category=Feature.Category.Debug,
+                hass_compat=HassCompat(entity_registry_enabled_default=False),
             )
         )
         if "device_on" in self._info:
@@ -227,7 +228,7 @@ class SmartDevice(Device):
                     "Signal Level",
                     attribute_getter=lambda x: x._info["signal_level"],
                     icon="mdi:signal",
-                    category=Feature.Category.Info,
+                    category=Feature.Category.Debug,
                 )
             )
 
@@ -239,6 +240,7 @@ class SmartDevice(Device):
                     attribute_getter=lambda x: x._info["rssi"],
                     icon="mdi:signal",
                     category=Feature.Category.Debug,
+                    hass_compat=HassCompat(entity_registry_enabled_default=False),
                 )
             )
 
@@ -250,6 +252,7 @@ class SmartDevice(Device):
                     attribute_getter="ssid",
                     icon="mdi:wifi",
                     category=Feature.Category.Debug,
+                    hass_compat=HassCompat(entity_registry_enabled_default=False),
                 )
             )
 
@@ -262,6 +265,9 @@ class SmartDevice(Device):
                     icon="mdi:heat-wave",
                     type=Feature.Type.BinarySensor,
                     category=Feature.Category.Debug,
+                    hass_compat=HassCompat(
+                        device_class=HassCompat.DeviceClass.Overheated
+                    ),
                 )
             )
 
@@ -274,7 +280,10 @@ class SmartDevice(Device):
                     name="On since",
                     attribute_getter="on_since",
                     icon="mdi:clock",
-                    category=Feature.Category.Debug,
+                    category=Feature.Category.Info,
+                    hass_compat=HassCompat(
+                        device_class=HassCompat.DeviceClass.Timestamp
+                    ),
                 )
             )
 


### PR DESCRIPTION
This adds `hass_compat` (name suggestions welcome!) that allows defining extra attributes to homeassistant's *entitydescriptions for better and cleaner UX. At the moment this is just converted to dict and passed directly to *entitydescriptions.

* Disable some diagnostic features per default
* Hide some sensor information (like historical consumption) from the dashboard, while still keeping them active

![image](https://github.com/python-kasa/python-kasa/assets/3705853/b5b114db-835a-4d6e-a8df-8189e7d01f3e)
![image](https://github.com/python-kasa/python-kasa/assets/3705853/f051fbdc-9533-498a-998e-f8d0e37aab69)
![image](https://github.com/python-kasa/python-kasa/assets/3705853/fa844dbb-7708-4352-a3c3-e36fae63e71b)
![image](https://github.com/python-kasa/python-kasa/assets/3705853/aae9322e-cb15-4960-a270-af2effc7c6bf)
