### PR TITLE
Implement choice feature type

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -92,6 +92,13 @@ class Feature:
     #: If set, this property will be used to set *minimum_value* and *maximum_value*.
     range_getter: str | None = None
 
+    # Choice-specific attributes
+    #: List of choices as enum
+    choices: list[str] | None = None
+    #: Attribute name of the choices getter property.
+    #: If set, this property will be used to set *choices*.
+    choices_getter: str | None = None
+
     #: Identifier
     id: str | None = None
 
@@ -107,6 +114,10 @@ class Feature:
             self.minimum_value, self.maximum_value = getattr(
                 container, self.range_getter
             )
+
+        # Populate choices, if choices_getter is given
+        if self.choices_getter is not None:
+            self.choices = getattr(container, self.choices_getter)
 
         # Set the category, if unset
         if self.category is Feature.Category.Unset:

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -158,6 +158,12 @@ class Feature:
                     f"Value {value} out of range "
                     f"[{self.minimum_value}, {self.maximum_value}]"
                 )
+        elif self.type == Feature.Type.Choice:  # noqa: SIM102
+            if value not in self.choices:
+                raise ValueError(
+                    f"Unexpected value for {self.name}: {value}"
+                    f" - allowed: {self.choices}"
+                )
 
         container = self.container if self.container is not None else self.device
         if self.type == Feature.Type.Action:

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -40,6 +40,12 @@ class Module(ABC):
     def data(self):
         """Return the module specific raw data from the last update."""
 
+    def _initialize_features(self):
+        """Initialize features after the initial update.
+
+        This can be implemented if features depend on module query responses.
+        """
+
     def _add_feature(self, feature: Feature):
         """Add module feature."""
 

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -40,7 +40,7 @@ class Module(ABC):
     def data(self):
         """Return the module specific raw data from the last update."""
 
-    def _initialize_features(self):
+    def _initialize_features(self):  # noqa: B027
         """Initialize features after the initial update.
 
         This can be implemented if features depend on module query responses.

--- a/kasa/smart/modules/alarmmodule.py
+++ b/kasa/smart/modules/alarmmodule.py
@@ -8,7 +8,7 @@ from ...feature import Feature
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
-    from ..smartdevice import SmartDevice
+    pass
 
 
 class AlarmModule(SmartModule):
@@ -23,8 +23,12 @@ class AlarmModule(SmartModule):
             "get_support_alarm_type_list": None,  # This should be needed only once
         }
 
-    def __init__(self, device: SmartDevice, module: str):
-        super().__init__(device, module)
+    def _initialize_features(self):
+        """Initialize features.
+
+        This is implemented as some features depend on device responses.
+        """
+        device = self._device
         self._add_feature(
             Feature(
                 device,
@@ -46,12 +50,26 @@ class AlarmModule(SmartModule):
         )
         self._add_feature(
             Feature(
-                device, "Alarm sound", container=self, attribute_getter="alarm_sound"
+                device,
+                "Alarm sound",
+                container=self,
+                attribute_getter="alarm_sound",
+                attribute_setter="set_alarm_sound",
+                category=Feature.Category.Config,
+                type=Feature.Type.Choice,
+                choices_getter="alarm_sounds",
             )
         )
         self._add_feature(
             Feature(
-                device, "Alarm volume", container=self, attribute_getter="alarm_volume"
+                device,
+                "Alarm volume",
+                container=self,
+                attribute_getter="alarm_volume",
+                attribute_setter="set_alarm_volume",
+                category=Feature.Category.Config,
+                type=Feature.Type.Choice,
+                choices=["low", "high"],
             )
         )
         self._add_feature(
@@ -78,6 +96,15 @@ class AlarmModule(SmartModule):
         """Return current alarm sound."""
         return self.data["get_alarm_configure"]["type"]
 
+    async def set_alarm_sound(self, sound: str):
+        """Set alarm sound.
+
+        See *alarm_sounds* for list of available sounds.
+        """
+        payload = self.data["get_alarm_configure"].copy()
+        payload["type"] = sound
+        return await self.call("set_alarm_configure", payload)
+
     @property
     def alarm_sounds(self) -> list[str]:
         """Return list of available alarm sounds."""
@@ -87,6 +114,12 @@ class AlarmModule(SmartModule):
     def alarm_volume(self):
         """Return alarm volume."""
         return self.data["get_alarm_configure"]["volume"]
+
+    async def set_alarm_volume(self, volume: str):
+        """Set alarm volume."""
+        payload = self.data["get_alarm_configure"].copy()
+        payload["volume"] = volume
+        return await self.call("set_alarm_configure", payload)
 
     @property
     def active(self) -> bool:

--- a/kasa/smart/modules/alarmmodule.py
+++ b/kasa/smart/modules/alarmmodule.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from ...feature import Feature
 from ..smartmodule import SmartModule
-
-if TYPE_CHECKING:
-    pass
 
 
 class AlarmModule(SmartModule):

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -305,6 +305,7 @@ class SmartDevice(Device, Bulb):
             )
 
         for module in self._modules.values():
+            module._initialize_features()
             for feat in module._module_features.values():
                 self._add_feature(feat)
 

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -354,9 +354,6 @@ async def test_credentials(discovery_mock, mocker, runner):
 
     mocker.patch("kasa.cli.state", new=_state)
 
-    mocker.patch("kasa.IotProtocol.query", return_value=discovery_mock.query_data)
-    mocker.patch("kasa.SmartProtocol.query", return_value=discovery_mock.query_data)
-
     dr = DiscoveryResult(**discovery_mock.discovery_data["result"])
     res = await runner.invoke(
         cli,

--- a/kasa/tests/test_feature.py
+++ b/kasa/tests/test_feature.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_mock import MockFixture
 
 from kasa import Feature
 
@@ -108,6 +109,23 @@ async def test_feature_action(mocker):
     assert feat.value == "<Action>"
     await feat.set_value(1234)
     mock_call_action.assert_called()
+
+
+async def test_feature_choice_list(dummy_feature, caplog, mocker: MockFixture):
+    """Test the choice feature type."""
+    dummy_feature.type = Feature.Type.Choice
+    dummy_feature.choices = ["first", "second"]
+
+    mock_setter = mocker.patch.object(dummy_feature.device, "dummysetter", create=True)
+    await dummy_feature.set_value("first")
+    mock_setter.assert_called_with("first")
+    mock_setter.reset_mock()
+
+    with pytest.raises(ValueError):
+        await dummy_feature.set_value("invalid")
+        assert "Unexpected value" in caplog.text
+
+    mock_setter.assert_not_called()
 
 
 @pytest.mark.parametrize("precision_hint", [1, 2, 3])


### PR DESCRIPTION
This implements the choice feature type allowing to provide a list of choices that can be set.
This changes the initialization a bit, as some choices, like the alarm tune, require that the device's module queries have been executed.

![image](https://github.com/python-kasa/python-kasa/assets/3705853/18486f99-d934-4f0b-bf9d-3d90036962e3)

The implementation is done by adding a new `_initialize_features` to the module interface, which however fails to pass ruff as the interface is currently abstract. Thus I will mark this PR as draft for now, as I'm unsure what's the best approach here.

This could be also used for enum sensor types later on, to give hints to homeassistant about possible values a sensor can have.