### PR TITLE
Update dump_devinfo to print original exception stack on errors.

### DIFF
--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -206,7 +206,8 @@ class SmartProtocol(BaseProtocol):
         self, response_result: dict[str, Any], method, retry_count
     ):
         if (
-            isinstance(response_result, SmartErrorCode)
+            response_result is None
+            or isinstance(response_result, SmartErrorCode)
             or "start_index" not in response_result
             or (list_sum := response_result.get("sum")) is None
         ):


### PR DESCRIPTION
While investigating dump_devinfo issue https://github.com/python-kasa/python-kasa/issues/875 the stack trace from the `print_stack` was unhelpful.  This PR prints the stack trace from the exception as if the exception was not caught.