### PR TITLE
Fix smartprotocol response list handler to handle null reponses

### DIFF
--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -206,7 +206,8 @@ class SmartProtocol(BaseProtocol):
         self, response_result: dict[str, Any], method, retry_count
     ):
         if (
-            isinstance(response_result, SmartErrorCode)
+            response_result is None
+            or isinstance(response_result, SmartErrorCode)
             or "start_index" not in response_result
             or (list_sum := response_result.get("sum")) is None
         ):


### PR DESCRIPTION
Fixes issue currently only affecting `dump_devinfo` https://github.com/python-kasa/python-kasa/issues/875 but could also impact other device queries in the future.