### PR TITLE
Fix wifi scan re-querying error

### DIFF
--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -512,22 +512,18 @@ class SmartDevice(Device, Bulb, Fan):
                 bssid=res["bssid"],
             )
 
-        async def _query_networks(networks=None, start_index=0):
-            _LOGGER.debug("Querying networks using start_index=%s", start_index)
+        async def _query_networks(networks=None):
+            _LOGGER.debug("Querying networks")
             if networks is None:
                 networks = []
 
             resp = await self.protocol.query(
-                {"get_wireless_scan_info": {"start_index": start_index}}
+                {"get_wireless_scan_info": {"start_index": 0}}
             )
-            network_list = [
+            networks = [
                 _net_for_scan_info(net)
                 for net in resp["get_wireless_scan_info"]["ap_list"]
             ]
-            networks.extend(network_list)
-
-            if resp["get_wireless_scan_info"].get("sum", 0) > start_index + 10:
-                return await _query_networks(networks, start_index=start_index + 10)
 
             return networks
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -512,22 +512,13 @@ class SmartDevice(Device, Bulb, Fan):
                 bssid=res["bssid"],
             )
 
-        async def _query_networks(networks=None):
-            _LOGGER.debug("Querying networks")
-            if networks is None:
-                networks = []
+        _LOGGER.debug("Querying networks")
 
-            resp = await self.protocol.query(
-                {"get_wireless_scan_info": {"start_index": 0}}
-            )
-            networks = [
-                _net_for_scan_info(net)
-                for net in resp["get_wireless_scan_info"]["ap_list"]
-            ]
-
-            return networks
-
-        return await _query_networks()
+        resp = await self.protocol.query({"get_wireless_scan_info": {"start_index": 0}})
+        networks = [
+            _net_for_scan_info(net) for net in resp["get_wireless_scan_info"]["ap_list"]
+        ]
+        return networks
 
     async def wifi_join(self, ssid: str, password: str, keytype: str = "wpa2_psk"):
         """Join the given wifi network.


### PR DESCRIPTION
https://github.com/python-kasa/python-kasa/pull/862 updated the `SmartProtocol` to automatically get the remainder of lists with partial responses.  As a result the wifi_scan logic ends up querying twice and doubling the number of networks, as it doesn't check the returned count before trying another query.  The re-query logic can be removed entirely.