### PR TITLE
Update interfaces so they all inherit from Device

### DIFF
--- a/kasa/bulb.py
+++ b/kasa/bulb.py
@@ -7,6 +7,8 @@ from typing import NamedTuple, Optional
 
 from pydantic.v1 import BaseModel
 
+from .device import Device
+
 
 class ColorTempRange(NamedTuple):
     """Color temperature range."""
@@ -40,7 +42,7 @@ class BulbPreset(BaseModel):
     mode: Optional[int]  # noqa: UP007
 
 
-class Bulb(ABC):
+class Bulb(Device, ABC):
     """Base class for TP-Link Bulb."""
 
     def _raise_for_invalid_brightness(self, value):

--- a/kasa/device.py
+++ b/kasa/device.py
@@ -246,6 +246,11 @@ class Device(ABC):
         return False
 
     @property
+    def is_fan(self) -> bool:
+        """Return True if the device is a fan."""
+        return self.device_type == DeviceType.Fan
+
+    @property
     def is_variable_color_temp(self) -> bool:
         """Return True if the device supports color temperature."""
         return False

--- a/kasa/fan.py
+++ b/kasa/fan.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
+from .device import Device
 
-class Fan(ABC):
+
+class Fan(Device, ABC):
     """Interface for a Fan."""
-
-    @property
-    @abstractmethod
-    def is_fan(self) -> bool:
-        """Return True if the device is a fan."""
 
     @property
     @abstractmethod

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -46,7 +46,9 @@ AVAILABLE_BULB_EFFECTS = {
 }
 
 
-class SmartDevice(Device, Bulb, Fan):
+# Device must go last as the other interfaces also inherit Device
+# and python needs a consistent method resolution order.
+class SmartDevice(Bulb, Fan, Device):
     """Base class to represent a SMART protocol based device."""
 
     def __init__(


### PR DESCRIPTION
This is to bring consistency to the api across `Smart` and `Iot` so the interfaces can be used for their specialist methods as well as the device methods (e.g. turn_on/off) , i.e. a consumer can do:

```py
device = await Discover.discover_single(127.0.0.1)
if device.is_bulb:
	bulb = cast(Bulb, device)
	await bulb.turn_on()
	await bulb.set_brightness(50)
if device.is_fan:
	fan = cast(Fan, device)
	await fan.turn_on()
	await fan.set_fan_speed_level(3)
```

Once this is in we can start moving the documentation to the interfaces.