### PR TITLE
Use Path.save for saving the fixtures

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -164,7 +164,7 @@ async def handle_device(basedir, autosave, device: Device, batch_size: int):
         if save == "y":
             click.echo(f"Saving info to {save_filename}")
 
-            with open(save_filename, "w") as f:
+            with save_filename.open("w") as f:
                 json.dump(fixture_result.data, f, sort_keys=True, indent=4)
                 f.write("\n")
         else:


### PR DESCRIPTION
This might fix saving of fixture files on Windows, but it's a good practice to use pathlib where possible.