### PR TITLE
Add child devices from hubs to generated list of supported devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Bulbs**: KL110, KL120, KL125, KL130, KL135, KL50, KL60, LB110
 - **Light Strips**: KL400L5, KL420L5, KL430
 - **Hubs**: KH100<sup>\*</sup>
+- **Sensors**: KE100<sup>\*</sup>
 
 ### Supported Tapo<sup>\*</sup> devices
 
@@ -241,6 +242,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Bulbs**: L510B, L510E, L530E
 - **Light Strips**: L900-10, L900-5, L920-5, L930-5
 - **Hubs**: H100
+- **Sensors**: T300, T310, T315
 
 <!--SUPPORTED_END-->
 <sup>*</sup>&nbsp; Model requires authentication<br>

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Bulbs**: KL110, KL120, KL125, KL130, KL135, KL50, KL60, LB110
 - **Light Strips**: KL400L5, KL420L5, KL430
 - **Hubs**: KH100<sup>\*</sup>
-- **Sensors**: KE100<sup>\*</sup>
+- **Hub-Connected Devices<sup>\*\*\*</sup>**: KE100<sup>\*</sup>
 
 ### Supported Tapo<sup>\*</sup> devices
 
@@ -242,11 +242,12 @@ The following devices have been tested and confirmed as working. If your device 
 - **Bulbs**: L510B, L510E, L530E
 - **Light Strips**: L900-10, L900-5, L920-5, L930-5
 - **Hubs**: H100
-- **Sensors**: T300, T310, T315
+- **Hub-Connected Devices<sup>\*\*\*</sup>**: T300, T310, T315
 
 <!--SUPPORTED_END-->
-<sup>*</sup>&nbsp; Model requires authentication<br>
-<sup>**</sup> Newer versions require authentication
+<sup>\*</sup>&nbsp;&nbsp;&nbsp; Model requires authentication<br>
+<sup>\*\*</sup>&nbsp; Newer versions require authentication<br>
+<sup>\*\*\*</sup> Devices may work across TAPO/KASA branded hubs
 
 See [supported devices in our documentation](SUPPORTED.md) for more detailed information about tested hardware and software versions.
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Hub-Connected Devices<sup>\*\*\*</sup>**: T300, T310, T315
 
 <!--SUPPORTED_END-->
-<sup>\*</sup>&nbsp;&nbsp;&nbsp; Model requires authentication<br>
+<sup>\*</sup>&nbsp;&nbsp; Model requires authentication<br>
 <sup>\*\*</sup>&nbsp; Newer versions require authentication<br>
 <sup>\*\*\*</sup> Devices may work across TAPO/KASA branded hubs
 

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -134,6 +134,12 @@ Some newer Kasa devices require authentication. These are marked with <sup>*</su
 - **KH100**
   - Hardware: 1.0 (UK) / Firmware: 1.5.6<sup>\*</sup>
 
+### Sensors
+
+- **KE100**
+  - Hardware: 1.0 (EU) / Firmware: 2.8.0<sup>\*</sup>
+  - Hardware: 1.0 (UK) / Firmware: 2.8.0<sup>\*</sup>
+
 
 ## Tapo devices
 
@@ -203,6 +209,15 @@ All Tapo devices require authentication.
 - **H100**
   - Hardware: 1.0 (EU) / Firmware: 1.2.3
   - Hardware: 1.0 (EU) / Firmware: 1.5.5
+
+### Sensors
+
+- **T300**
+  - Hardware: 1.0 (EU) / Firmware: 1.7.0
+- **T310**
+  - Hardware: 1.0 (EU) / Firmware: 1.5.0
+- **T315**
+  - Hardware: 1.0 (EU) / Firmware: 1.7.0
 
 
 <!--SUPPORTED_END-->

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -6,7 +6,7 @@ The following devices have been tested and confirmed as working. If your device 
 <!--SUPPORTED_START-->
 ## Kasa devices
 
-Some newer Kasa devices require authentication. These are marked with <sup>*</sup> in the list below.
+Some newer Kasa devices require authentication. These are marked with <sup>*</sup> in the list below.<br>Hub-Connected Devices may work across TAPO/KASA branded hubs even if they don't work across the native apps.
 
 ### Plugs
 
@@ -134,7 +134,7 @@ Some newer Kasa devices require authentication. These are marked with <sup>*</su
 - **KH100**
   - Hardware: 1.0 (UK) / Firmware: 1.5.6<sup>\*</sup>
 
-### Sensors
+### Hub-Connected Devices
 
 - **KE100**
   - Hardware: 1.0 (EU) / Firmware: 2.8.0<sup>\*</sup>
@@ -143,7 +143,7 @@ Some newer Kasa devices require authentication. These are marked with <sup>*</su
 
 ## Tapo devices
 
-All Tapo devices require authentication.
+All Tapo devices require authentication.<br>Hub-Connected Devices may work across TAPO/KASA branded hubs even if they don't work across the native apps.
 
 ### Plugs
 
@@ -210,7 +210,7 @@ All Tapo devices require authentication.
   - Hardware: 1.0 (EU) / Firmware: 1.2.3
   - Hardware: 1.0 (EU) / Firmware: 1.5.5
 
-### Sensors
+### Hub-Connected Devices
 
 - **T300**
   - Hardware: 1.0 (EU) / Firmware: 1.7.0

--- a/devtools/generate_supported.py
+++ b/devtools/generate_supported.py
@@ -33,8 +33,8 @@ DEVICE_TYPE_TO_PRODUCT_GROUP = {
     DeviceType.Bulb: "Bulbs",
     DeviceType.LightStrip: "Light Strips",
     DeviceType.Hub: "Hubs",
-    DeviceType.Sensor: "Sensors",
-    DeviceType.Thermostat: "Sensors",
+    DeviceType.Sensor: "Hub-Connected Devices",
+    DeviceType.Thermostat: "Hub-Connected Devices",
 }
 
 
@@ -108,7 +108,7 @@ def _supported_summary(supported):
     return _supported_text(
         supported,
         "### Supported $brand$auth devices\n\n$types\n",
-        "- **$type_**: $models\n",
+        "- **$type_$type_asterix**: $models\n",
     )
 
 
@@ -137,6 +137,10 @@ def _supported_text(
             + "These are marked with <sup>*</sup> in the list below."
             if brand == "kasa"
             else "All Tapo devices require authentication."
+        )
+        preamble_text += (
+            "<br>Hub-Connected Devices may work across TAPO/KASA branded "
+            + "hubs even if they don't work across the native apps."
         )
         brand_text = brand.capitalize()
         brand_auth = r"<sup>\*</sup>" if brand == "tapo" else ""
@@ -179,7 +183,14 @@ def _supported_text(
                 else:
                     models_list.append(f"{model}{auth_flag}")
             models_text = models_text if models_text else ", ".join(models_list)
-            types_text += typest.substitute(type_=supported_type, models=models_text)
+            type_asterix = (
+                r"<sup>\*\*\*</sup>"
+                if supported_type == "Hub-Connected Devices"
+                else ""
+            )
+            types_text += typest.substitute(
+                type_=supported_type, type_asterix=type_asterix, models=models_text
+            )
         brands += brandt.substitute(
             brand=brand_text, types=types_text, auth=brand_auth, preamble=preamble_text
         )

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -639,6 +639,10 @@ class SmartDevice(Bulb, Fan, Device):
             return DeviceType.Bulb
         if "SWITCH" in device_type:
             return DeviceType.WallSwitch
+        if "SENSOR" in device_type:
+            return DeviceType.Sensor
+        if "ENERGY" in device_type:
+            return DeviceType.Thermostat
         _LOGGER.warning("Unknown device type, falling back to plug")
         return DeviceType.Plug
 


### PR DESCRIPTION
Updates `generate_supported` hook to include child devices of hubs in the list of supported devices.