### PR TITLE
Improve categorization of features

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -103,10 +103,6 @@ class Feature:
 
     def __post_init__(self):
         """Handle late-binding of members."""
-        # Set id, if unset
-        if self.id is None:
-            self.id = self.name.lower().replace(" ", "_")
-
         # Populate minimum & maximum values, if range_getter is given
         container = self.container if self.container is not None else self.device
         if self.range_getter is not None:

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -62,6 +62,8 @@ class Feature:
 
     #: Device instance required for getting and setting values
     device: Device
+    #: Identifier
+    id: str
     #: User-friendly short description
     name: str
     #: Name of the property that allows accessing the value
@@ -98,9 +100,6 @@ class Feature:
     #: Attribute name of the choices getter property.
     #: If set, this property will be used to set *choices*.
     choices_getter: str | None = None
-
-    #: Identifier
-    id: str | None = None
 
     def __post_init__(self):
         """Handle late-binding of members."""

--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -213,6 +213,7 @@ class IotBulb(IotDevice, Bulb):
             self._add_feature(
                 Feature(
                     device=self,
+                    id="brightness",
                     name="Brightness",
                     attribute_getter="brightness",
                     attribute_setter="set_brightness",
@@ -227,6 +228,7 @@ class IotBulb(IotDevice, Bulb):
             self._add_feature(
                 Feature(
                     device=self,
+                    id="color_temperature",
                     name="Color temperature",
                     container=self,
                     attribute_getter="color_temp",

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -334,6 +334,7 @@ class IotDevice(Device):
         self._add_feature(
             Feature(
                 device=self,
+                id="rssi",
                 name="RSSI",
                 attribute_getter="rssi",
                 icon="mdi:signal",
@@ -344,6 +345,7 @@ class IotDevice(Device):
             self._add_feature(
                 Feature(
                     device=self,
+                    id="on_since",
                     name="On since",
                     attribute_getter="on_since",
                     icon="mdi:clock",

--- a/kasa/iot/iotdimmer.py
+++ b/kasa/iot/iotdimmer.py
@@ -96,7 +96,9 @@ class IotDimmer(IotPlug):
                     attribute_setter="set_brightness",
                     minimum_value=1,
                     maximum_value=100,
+                    unit="%",
                     type=Feature.Type.Number,
+                    category=Feature.Category.Primary,
                 )
             )
 

--- a/kasa/iot/iotdimmer.py
+++ b/kasa/iot/iotdimmer.py
@@ -91,6 +91,7 @@ class IotDimmer(IotPlug):
             self._add_feature(
                 Feature(
                     device=self,
+                    id="brightness",
                     name="Brightness",
                     attribute_getter="brightness",
                     attribute_setter="set_brightness",

--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -65,6 +65,7 @@ class IotPlug(IotDevice):
         self._add_feature(
             Feature(
                 device=self,
+                id="led",
                 name="LED",
                 icon="mdi:led-{state}",
                 attribute_getter="led",

--- a/kasa/iot/modules/ambientlight.py
+++ b/kasa/iot/modules/ambientlight.py
@@ -22,6 +22,7 @@ class AmbientLight(IotModule):
             Feature(
                 device=device,
                 container=self,
+                id="ambient_light",
                 name="Ambient Light",
                 icon="mdi:brightness-percent",
                 attribute_getter="ambientlight_brightness",

--- a/kasa/iot/modules/ambientlight.py
+++ b/kasa/iot/modules/ambientlight.py
@@ -26,6 +26,8 @@ class AmbientLight(IotModule):
                 icon="mdi:brightness-percent",
                 attribute_getter="ambientlight_brightness",
                 type=Feature.Type.Sensor,
+                category=Feature.Category.Primary,
+                unit="%",
             )
         )
 

--- a/kasa/iot/modules/cloud.py
+++ b/kasa/iot/modules/cloud.py
@@ -30,6 +30,7 @@ class Cloud(IotModule):
             Feature(
                 device=device,
                 container=self,
+                id="cloud_connection",
                 name="Cloud connection",
                 icon="mdi:cloud",
                 attribute_getter="is_connected",

--- a/kasa/iot/modules/cloud.py
+++ b/kasa/iot/modules/cloud.py
@@ -34,6 +34,7 @@ class Cloud(IotModule):
                 icon="mdi:cloud",
                 attribute_getter="is_connected",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Info,
             )
         )
 

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -24,6 +24,7 @@ class Emeter(Usage):
                 unit="W",
                 id="current_power_w",  # for homeassistant backwards compat
                 precision_hint=1,
+                category=Feature.Category.Primary,
             )
         )
         self._add_feature(
@@ -35,6 +36,7 @@ class Emeter(Usage):
                 unit="kWh",
                 id="today_energy_kwh",  # for homeassistant backwards compat
                 precision_hint=3,
+                category=Feature.Category.Info,
             )
         )
         self._add_feature(
@@ -45,6 +47,7 @@ class Emeter(Usage):
                 container=self,
                 unit="kWh",
                 precision_hint=3,
+                category=Feature.Category.Info,
             )
         )
         self._add_feature(
@@ -56,6 +59,7 @@ class Emeter(Usage):
                 unit="kWh",
                 id="total_energy_kwh",  # for homeassistant backwards compat
                 precision_hint=3,
+                category=Feature.Category.Info,
             )
         )
         self._add_feature(
@@ -67,6 +71,7 @@ class Emeter(Usage):
                 unit="V",
                 id="voltage",  # for homeassistant backwards compat
                 precision_hint=1,
+                category=Feature.Category.Primary,
             )
         )
         self._add_feature(
@@ -78,6 +83,7 @@ class Emeter(Usage):
                 unit="A",
                 id="current_a",  # for homeassistant backwards compat
                 precision_hint=2,
+                category=Feature.Category.Primary,
             )
         )
 

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -42,6 +42,7 @@ class Emeter(Usage):
         self._add_feature(
             Feature(
                 device,
+                id="consumption_this_month",
                 name="This month's consumption",
                 attribute_getter="emeter_this_month",
                 container=self,

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -53,14 +53,10 @@ class Module(ABC):
 
     def _add_feature(self, feature: Feature):
         """Add module feature."""
-
-        def _slugified_name(name):
-            return name.lower().replace(" ", "_").replace("'", "_")
-
-        feat_name = _slugified_name(feature.name)
-        if feat_name in self._module_features:
-            raise KasaException("Duplicate name detected %s" % feat_name)
-        self._module_features[feat_name] = feature
+        id_ = feature.id
+        if id_ in self._module_features:
+            raise KasaException("Duplicate id detected %s" % id_)
+        self._module_features[id_] = feature
 
     def __repr__(self) -> str:
         return (

--- a/kasa/smart/modules/alarmmodule.py
+++ b/kasa/smart/modules/alarmmodule.py
@@ -27,7 +27,8 @@ class AlarmModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Alarm",
+                id="alarm",
+                name="Alarm",
                 container=self,
                 attribute_getter="active",
                 icon="mdi:bell",
@@ -37,7 +38,8 @@ class AlarmModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Alarm source",
+                id="alarm_source",
+                name="Alarm source",
                 container=self,
                 attribute_getter="source",
                 icon="mdi:bell",
@@ -46,7 +48,8 @@ class AlarmModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Alarm sound",
+                id="alarm_sound",
+                name="Alarm sound",
                 container=self,
                 attribute_getter="alarm_sound",
                 attribute_setter="set_alarm_sound",
@@ -58,7 +61,8 @@ class AlarmModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Alarm volume",
+                id="alarm_volume",
+                name="Alarm volume",
                 container=self,
                 attribute_getter="alarm_volume",
                 attribute_setter="set_alarm_volume",
@@ -70,7 +74,8 @@ class AlarmModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Test alarm",
+                id="test_alarm",
+                name="Test alarm",
                 container=self,
                 attribute_setter="play",
                 type=Feature.Type.Action,
@@ -79,7 +84,8 @@ class AlarmModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Stop alarm",
+                id="stop_alarm",
+                name="Stop alarm",
                 container=self,
                 attribute_setter="stop",
                 type=Feature.Type.Action,

--- a/kasa/smart/modules/autooffmodule.py
+++ b/kasa/smart/modules/autooffmodule.py
@@ -42,7 +42,11 @@ class AutoOffModule(SmartModule):
         )
         self._add_feature(
             Feature(
-                device, "Auto off at", container=self, attribute_getter="auto_off_at"
+                device,
+                "Auto off at",
+                container=self,
+                attribute_getter="auto_off_at",
+                category=Feature.Category.Info,
             )
         )
 

--- a/kasa/smart/modules/autooffmodule.py
+++ b/kasa/smart/modules/autooffmodule.py
@@ -23,7 +23,8 @@ class AutoOffModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Auto off enabled",
+                id="auto_off_enabled",
+                name="Auto off enabled",
                 container=self,
                 attribute_getter="enabled",
                 attribute_setter="set_enabled",
@@ -33,7 +34,8 @@ class AutoOffModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Auto off minutes",
+                id="auto_off_minutes",
+                name="Auto off minutes",
                 container=self,
                 attribute_getter="delay",
                 attribute_setter="set_delay",
@@ -43,7 +45,8 @@ class AutoOffModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Auto off at",
+                id="auto_off_at",
+                name="Auto off at",
                 container=self,
                 attribute_getter="auto_off_at",
                 category=Feature.Category.Info,

--- a/kasa/smart/modules/battery.py
+++ b/kasa/smart/modules/battery.py
@@ -22,6 +22,7 @@ class BatterySensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "battery_level",
                 "Battery level",
                 container=self,
                 attribute_getter="battery",
@@ -33,6 +34,7 @@ class BatterySensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "battery_low",
                 "Battery low",
                 container=self,
                 attribute_getter="battery_low",

--- a/kasa/smart/modules/battery.py
+++ b/kasa/smart/modules/battery.py
@@ -26,6 +26,8 @@ class BatterySensor(SmartModule):
                 container=self,
                 attribute_getter="battery",
                 icon="mdi:battery",
+                unit="%",
+                category=Feature.Category.Info,
             )
         )
         self._add_feature(
@@ -36,6 +38,7 @@ class BatterySensor(SmartModule):
                 attribute_getter="battery_low",
                 icon="mdi:alert",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Debug,
             )
         )
 

--- a/kasa/smart/modules/brightness.py
+++ b/kasa/smart/modules/brightness.py
@@ -25,7 +25,8 @@ class Brightness(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Brightness",
+                id="brightness",
+                name="Brightness",
                 container=self,
                 attribute_getter="brightness",
                 attribute_setter="set_brightness",

--- a/kasa/smart/modules/cloudmodule.py
+++ b/kasa/smart/modules/cloudmodule.py
@@ -24,7 +24,8 @@ class CloudModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Cloud connection",
+                id="cloud_connection",
+                name="Cloud connection",
                 container=self,
                 attribute_getter="is_connected",
                 icon="mdi:cloud",

--- a/kasa/smart/modules/cloudmodule.py
+++ b/kasa/smart/modules/cloudmodule.py
@@ -29,6 +29,7 @@ class CloudModule(SmartModule):
                 attribute_getter="is_connected",
                 icon="mdi:cloud",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Info,
             )
         )
 

--- a/kasa/smart/modules/colormodule.py
+++ b/kasa/smart/modules/colormodule.py
@@ -22,6 +22,7 @@ class ColorModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "hsv",
                 "HSV",
                 container=self,
                 attribute_getter="hsv",

--- a/kasa/smart/modules/colortemp.py
+++ b/kasa/smart/modules/colortemp.py
@@ -28,6 +28,7 @@ class ColorTemperatureModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "color_temperature",
                 "Color temperature",
                 container=self,
                 attribute_getter="color_temp",

--- a/kasa/smart/modules/energymodule.py
+++ b/kasa/smart/modules/energymodule.py
@@ -22,6 +22,7 @@ class EnergyModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "consumption_current",
                 name="Current consumption",
                 attribute_getter="current_power",
                 container=self,
@@ -33,6 +34,7 @@ class EnergyModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "consumption_today",
                 name="Today's consumption",
                 attribute_getter="emeter_today",
                 container=self,
@@ -44,6 +46,7 @@ class EnergyModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "consumption_this_month",
                 name="This month's consumption",
                 attribute_getter="emeter_this_month",
                 container=self,

--- a/kasa/smart/modules/energymodule.py
+++ b/kasa/smart/modules/energymodule.py
@@ -27,6 +27,7 @@ class EnergyModule(SmartModule):
                 container=self,
                 unit="W",
                 precision_hint=1,
+                category=Feature.Category.Primary,
             )
         )
         self._add_feature(
@@ -37,6 +38,7 @@ class EnergyModule(SmartModule):
                 container=self,
                 unit="Wh",
                 precision_hint=2,
+                category=Feature.Category.Info,
             )
         )
         self._add_feature(
@@ -47,6 +49,7 @@ class EnergyModule(SmartModule):
                 container=self,
                 unit="Wh",
                 precision_hint=2,
+                category=Feature.Category.Info,
             )
         )
 

--- a/kasa/smart/modules/fanmodule.py
+++ b/kasa/smart/modules/fanmodule.py
@@ -22,7 +22,8 @@ class FanModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Fan speed level",
+                id="fan_speed_level",
+                name="Fan speed level",
                 container=self,
                 attribute_getter="fan_speed_level",
                 attribute_setter="set_fan_speed_level",
@@ -36,7 +37,8 @@ class FanModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Fan sleep mode",
+                id="fan_sleep_mode",
+                name="Fan sleep mode",
                 container=self,
                 attribute_getter="sleep_mode",
                 attribute_setter="set_sleep_mode",

--- a/kasa/smart/modules/firmware.py
+++ b/kasa/smart/modules/firmware.py
@@ -52,7 +52,8 @@ class Firmware(SmartModule):
             self._add_feature(
                 Feature(
                     device,
-                    "Auto update enabled",
+                    id="auto_update_enabled",
+                    name="Auto update enabled",
                     container=self,
                     attribute_getter="auto_update_enabled",
                     attribute_setter="set_auto_update_enabled",
@@ -62,7 +63,8 @@ class Firmware(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Update available",
+                id="update_available",
+                name="Update available",
                 container=self,
                 attribute_getter="update_available",
                 type=Feature.Type.BinarySensor,

--- a/kasa/smart/modules/firmware.py
+++ b/kasa/smart/modules/firmware.py
@@ -66,6 +66,7 @@ class Firmware(SmartModule):
                 container=self,
                 attribute_getter="update_available",
                 type=Feature.Type.BinarySensor,
+                category=Feature.Category.Info,
             )
         )
 

--- a/kasa/smart/modules/frostprotection.py
+++ b/kasa/smart/modules/frostprotection.py
@@ -27,6 +27,7 @@ class FrostProtectionModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
+                "frost_protection_enabled",
                 name="Frost protection enabled",
                 container=self,
                 attribute_getter="enabled",

--- a/kasa/smart/modules/humidity.py
+++ b/kasa/smart/modules/humidity.py
@@ -27,6 +27,7 @@ class HumiditySensor(SmartModule):
                 attribute_getter="humidity",
                 icon="mdi:water-percent",
                 unit="%",
+                category=Feature.Category.Primary,
             )
         )
         self._add_feature(
@@ -37,6 +38,7 @@ class HumiditySensor(SmartModule):
                 attribute_getter="humidity_warning",
                 type=Feature.Type.BinarySensor,
                 icon="mdi:alert",
+                category=Feature.Category.Debug,
             )
         )
 

--- a/kasa/smart/modules/humidity.py
+++ b/kasa/smart/modules/humidity.py
@@ -22,7 +22,8 @@ class HumiditySensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Humidity",
+                id="humidity",
+                name="Humidity",
                 container=self,
                 attribute_getter="humidity",
                 icon="mdi:water-percent",
@@ -33,7 +34,8 @@ class HumiditySensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Humidity warning",
+                id="humidity_warning",
+                name="Humidity warning",
                 container=self,
                 attribute_getter="humidity_warning",
                 type=Feature.Type.BinarySensor,

--- a/kasa/smart/modules/ledmodule.py
+++ b/kasa/smart/modules/ledmodule.py
@@ -23,6 +23,7 @@ class LedModule(SmartModule):
             Feature(
                 device=device,
                 container=self,
+                id="led",
                 name="LED",
                 icon="mdi:led-{state}",
                 attribute_getter="led",

--- a/kasa/smart/modules/lighteffectmodule.py
+++ b/kasa/smart/modules/lighteffectmodule.py
@@ -34,7 +34,8 @@ class LightEffectModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Light effect",
+                id="light_effect",
+                name="Light effect",
                 container=self,
                 attribute_getter="effect",
                 attribute_setter="set_effect",

--- a/kasa/smart/modules/lighttransitionmodule.py
+++ b/kasa/smart/modules/lighttransitionmodule.py
@@ -31,6 +31,7 @@ class LightTransitionModule(SmartModule):
                 Feature(
                     device=self._device,
                     container=self,
+                    id="smooth_transitions",
                     name="Smooth transitions",
                     icon=icon,
                     attribute_getter="enabled_v1",
@@ -46,7 +47,8 @@ class LightTransitionModule(SmartModule):
             self._add_feature(
                 Feature(
                     self._device,
-                    "Smooth transition on",
+                    id="smooth_transition_on",
+                    name="Smooth transition on",
                     container=self,
                     attribute_getter="turn_on_transition",
                     attribute_setter="set_turn_on_transition",
@@ -58,7 +60,8 @@ class LightTransitionModule(SmartModule):
             self._add_feature(
                 Feature(
                     self._device,
-                    "Smooth transition off",
+                    id="smooth_transition_off",
+                    name="Smooth transition off",
                     container=self,
                     attribute_getter="turn_off_transition",
                     attribute_setter="set_turn_off_transition",

--- a/kasa/smart/modules/reportmodule.py
+++ b/kasa/smart/modules/reportmodule.py
@@ -22,7 +22,8 @@ class ReportModule(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Report interval",
+                id="report_interval",
+                name="Report interval",
                 container=self,
                 attribute_getter="report_interval",
                 category=Feature.Category.Debug,

--- a/kasa/smart/modules/temperature.py
+++ b/kasa/smart/modules/temperature.py
@@ -22,7 +22,8 @@ class TemperatureSensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Temperature",
+                id="temperature",
+                name="Temperature",
                 container=self,
                 attribute_getter="temperature",
                 icon="mdi:thermometer",
@@ -33,7 +34,8 @@ class TemperatureSensor(SmartModule):
             self._add_feature(
                 Feature(
                     device,
-                    "Temperature warning",
+                    id="temperature_warning",
+                    name="Temperature warning",
                     container=self,
                     attribute_getter="temperature_warning",
                     type=Feature.Type.BinarySensor,
@@ -44,7 +46,8 @@ class TemperatureSensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Temperature unit",
+                id="temperature_unit",
+                name="Temperature unit",
                 container=self,
                 attribute_getter="temperature_unit",
                 attribute_setter="set_temperature_unit",

--- a/kasa/smart/modules/temperature.py
+++ b/kasa/smart/modules/temperature.py
@@ -38,6 +38,7 @@ class TemperatureSensor(SmartModule):
                     attribute_getter="temperature_warning",
                     type=Feature.Type.BinarySensor,
                     icon="mdi:alert",
+                    category=Feature.Category.Debug,
                 )
             )
         self._add_feature(

--- a/kasa/smart/modules/temperaturecontrol.py
+++ b/kasa/smart/modules/temperaturecontrol.py
@@ -36,7 +36,8 @@ class TemperatureControl(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Target temperature",
+                id="target_temperature",
+                name="Target temperature",
                 container=self,
                 attribute_getter="target_temperature",
                 attribute_setter="set_target_temperature",
@@ -50,7 +51,8 @@ class TemperatureControl(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Temperature offset",
+                id="temperature_offset",
+                name="Temperature offset",
                 container=self,
                 attribute_getter="temperature_offset",
                 attribute_setter="set_temperature_offset",
@@ -64,7 +66,8 @@ class TemperatureControl(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "State",
+                id="state",
+                name="State",
                 container=self,
                 attribute_getter="state",
                 attribute_setter="set_state",
@@ -76,7 +79,8 @@ class TemperatureControl(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Mode",
+                id="mode",
+                name="Mode",
                 container=self,
                 attribute_getter="mode",
                 category=Feature.Category.Primary,

--- a/kasa/smart/modules/timemodule.py
+++ b/kasa/smart/modules/timemodule.py
@@ -25,6 +25,7 @@ class TimeModule(SmartModule):
         self._add_feature(
             Feature(
                 device=device,
+                id="time",
                 name="Time",
                 attribute_getter="time",
                 container=self,

--- a/kasa/smart/modules/waterleak.py
+++ b/kasa/smart/modules/waterleak.py
@@ -30,7 +30,8 @@ class WaterleakSensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Water leak",
+                id="water_leak",
+                name="Water leak",
                 container=self,
                 attribute_getter="status",
                 icon="mdi:water",
@@ -39,7 +40,8 @@ class WaterleakSensor(SmartModule):
         self._add_feature(
             Feature(
                 device,
-                "Water alert",
+                id="water_alert",
+                name="Water alert",
                 container=self,
                 attribute_getter="alert",
                 icon="mdi:water-alert",

--- a/kasa/smart/modules/waterleak.py
+++ b/kasa/smart/modules/waterleak.py
@@ -35,6 +35,7 @@ class WaterleakSensor(SmartModule):
                 container=self,
                 attribute_getter="status",
                 icon="mdi:water",
+                category=Feature.Category.Debug,
             )
         )
         self._add_feature(
@@ -45,6 +46,7 @@ class WaterleakSensor(SmartModule):
                 container=self,
                 attribute_getter="alert",
                 icon="mdi:water-alert",
+                category=Feature.Category.Primary,
             )
         )
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -283,7 +283,7 @@ class SmartDevice(Bulb, Fan, Device):
                     attribute_getter=lambda x: x._info["overheated"],
                     icon="mdi:heat-wave",
                     type=Feature.Type.BinarySensor,
-                    category=Feature.Category.Debug,
+                    category=Feature.Category.Info,
                 )
             )
 
@@ -296,7 +296,7 @@ class SmartDevice(Bulb, Fan, Device):
                     name="On since",
                     attribute_getter="on_since",
                     icon="mdi:clock",
-                    category=Feature.Category.Debug,
+                    category=Feature.Category.Info,
                 )
             )
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -225,7 +225,8 @@ class SmartDevice(Bulb, Fan, Device):
         self._add_feature(
             Feature(
                 self,
-                "Device ID",
+                id="device_id",
+                name="Device ID",
                 attribute_getter="device_id",
                 category=Feature.Category.Debug,
             )
@@ -234,7 +235,8 @@ class SmartDevice(Bulb, Fan, Device):
             self._add_feature(
                 Feature(
                     self,
-                    "State",
+                    id="state",
+                    name="State",
                     attribute_getter="is_on",
                     attribute_setter="set_state",
                     type=Feature.Type.Switch,
@@ -246,7 +248,8 @@ class SmartDevice(Bulb, Fan, Device):
             self._add_feature(
                 Feature(
                     self,
-                    "Signal Level",
+                    id="signal_level",
+                    name="Signal Level",
                     attribute_getter=lambda x: x._info["signal_level"],
                     icon="mdi:signal",
                     category=Feature.Category.Info,
@@ -257,7 +260,8 @@ class SmartDevice(Bulb, Fan, Device):
             self._add_feature(
                 Feature(
                     self,
-                    "RSSI",
+                    id="rssi",
+                    name="RSSI",
                     attribute_getter=lambda x: x._info["rssi"],
                     icon="mdi:signal",
                     category=Feature.Category.Debug,
@@ -268,6 +272,7 @@ class SmartDevice(Bulb, Fan, Device):
             self._add_feature(
                 Feature(
                     device=self,
+                    id="ssid",
                     name="SSID",
                     attribute_getter="ssid",
                     icon="mdi:wifi",
@@ -279,7 +284,8 @@ class SmartDevice(Bulb, Fan, Device):
             self._add_feature(
                 Feature(
                     self,
-                    "Overheated",
+                    id="overheated",
+                    name="Overheated",
                     attribute_getter=lambda x: x._info["overheated"],
                     icon="mdi:heat-wave",
                     type=Feature.Type.BinarySensor,
@@ -293,6 +299,7 @@ class SmartDevice(Bulb, Fan, Device):
             self._add_feature(
                 Feature(
                     device=self,
+                    id="on_since",
                     name="On since",
                     attribute_getter="on_since",
                     icon="mdi:clock",

--- a/kasa/tests/test_feature.py
+++ b/kasa/tests/test_feature.py
@@ -19,6 +19,7 @@ def dummy_feature() -> Feature:
 
     feat = Feature(
         device=DummyDevice(),  # type: ignore[arg-type]
+        id="dummy_feature",
         name="dummy_feature",
         attribute_getter="dummygetter",
         attribute_setter="dummysetter",
@@ -47,6 +48,7 @@ def test_feature_missing_type():
     with pytest.raises(ValueError):
         Feature(
             device=DummyDevice(),  # type: ignore[arg-type]
+            id="dummy_error",
             name="dummy error",
             attribute_getter="dummygetter",
             attribute_setter="dummysetter",
@@ -104,6 +106,7 @@ async def test_feature_action(mocker):
     """Test that setting value on button calls the setter."""
     feat = Feature(
         device=DummyDevice(),  # type: ignore[arg-type]
+        id="dummy_feature",
         name="dummy_feature",
         attribute_setter="call_action",
         container=None,


### PR DESCRIPTION
This will update the categorization of features as discussed in the now-obsolete #879:
* Primary: primary controls (state, brightness, etc.) & sensors (like temperature, emeter)
* Config: secondary controls, entity_category=Config
* Info: diagnostic information that is enabled per default in homeassistant
* Debug: diagnostic information that is disabled per default

The `id` is also made mandatory for features, which will allow using it as a translation key without fear of breaking the "API" inadvertently.