### PR TITLE
Make Light and Brightness a common module

### DIFF
--- a/kasa/interfaces/__init__.py
+++ b/kasa/interfaces/__init__.py
@@ -1,11 +1,13 @@
 """Package for interfaces."""
 
+from .brightness import Brightness
 from .fan import Fan
 from .led import Led
 from .light import Light, LightPreset
 from .lighteffect import LightEffect
 
 __all__ = [
+    "Brightness",
     "Fan",
     "Led",
     "Light",

--- a/kasa/interfaces/brightness.py
+++ b/kasa/interfaces/brightness.py
@@ -1,0 +1,48 @@
+"""Module for base light effect module."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from ..feature import Feature
+from ..module import Module
+
+
+class Brightness(Module, ABC):
+    """Base interface to represent a Brightness module."""
+
+    BRIGHTNESS_MIN = 0
+    BRIGHTNESS_MAX = 100
+
+    def _initialize_features(self):
+        """Initialize features."""
+        device = self._device
+        self._add_feature(
+            Feature(
+                device,
+                id="brightness",
+                name="Brightness",
+                container=self,
+                attribute_getter="brightness",
+                attribute_setter="set_brightness",
+                minimum_value=self.BRIGHTNESS_MIN,
+                maximum_value=self.BRIGHTNESS_MAX,
+                type=Feature.Type.Number,
+                category=Feature.Category.Primary,
+            )
+        )
+
+    @property
+    @abstractmethod
+    def brightness(self) -> int:
+        """Return current brightness in percentage."""
+
+    @abstractmethod
+    async def set_brightness(
+        self, brightness: int, *, transition: int | None = None
+    ) -> None:
+        """Set the brightness in percentage.
+
+        :param int brightness: brightness in percent
+        :param int transition: transition in milliseconds.
+        """

--- a/kasa/interfaces/fan.py
+++ b/kasa/interfaces/fan.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-from ..device import Device
+from ..module import Module
 
 
-class Fan(Device, ABC):
+class Fan(Module, ABC):
     """Interface for a Fan."""
 
     @property

--- a/kasa/interfaces/light.py
+++ b/kasa/interfaces/light.py
@@ -7,7 +7,7 @@ from typing import NamedTuple, Optional
 
 from pydantic.v1 import BaseModel
 
-from ..device import Device
+from ..module import Module
 
 
 class ColorTempRange(NamedTuple):
@@ -42,12 +42,13 @@ class LightPreset(BaseModel):
     mode: Optional[int]  # noqa: UP007
 
 
-class Light(Device, ABC):
+class Light(Module, ABC):
     """Base class for TP-Link Light."""
 
-    def _raise_for_invalid_brightness(self, value):
-        if not isinstance(value, int) or not (0 <= value <= 100):
-            raise ValueError(f"Invalid brightness value: {value} (valid range: 0-100%)")
+    @property
+    @abstractmethod
+    def is_dimmable(self) -> bool:
+        """Whether the light supports brightness changes."""
 
     @property
     @abstractmethod
@@ -98,7 +99,7 @@ class Light(Device, ABC):
         value: int | None = None,
         *,
         transition: int | None = None,
-    ) -> dict:
+    ) -> None:
         """Set new HSV.
 
         Note, transition is not supported and will be ignored.
@@ -112,7 +113,7 @@ class Light(Device, ABC):
     @abstractmethod
     async def set_color_temp(
         self, temp: int, *, brightness=None, transition: int | None = None
-    ) -> dict:
+    ) -> None:
         """Set the color temperature of the device in kelvin.
 
         Note, transition is not supported and will be ignored.
@@ -124,7 +125,7 @@ class Light(Device, ABC):
     @abstractmethod
     async def set_brightness(
         self, brightness: int, *, transition: int | None = None
-    ) -> dict:
+    ) -> None:
         """Set the brightness in percentage.
 
         Note, transition is not supported and will be ignored.
@@ -132,8 +133,3 @@ class Light(Device, ABC):
         :param int brightness: brightness in percent
         :param int transition: transition in milliseconds.
         """
-
-    @property
-    @abstractmethod
-    def presets(self) -> list[LightPreset]:
-        """Return a list of available bulb setting presets."""

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -307,12 +307,18 @@ class IotDevice(Device):
             self._last_update = response
             self._set_sys_info(response["system"]["get_sysinfo"])
 
+        if not self._modules:
+            await self._initialize_modules()
+
         await self._modular_update(req)
 
         if not self._features:
             await self._initialize_features()
 
         self._set_sys_info(self._last_update["system"]["get_sysinfo"])
+
+    async def _initialize_modules(self):
+        """Initialize modules not added in init."""
 
     async def _initialize_features(self):
         self._add_feature(

--- a/kasa/iot/iotlightstrip.py
+++ b/kasa/iot/iotlightstrip.py
@@ -56,6 +56,10 @@ class IotLightStrip(IotBulb):
     ) -> None:
         super().__init__(host=host, config=config, protocol=protocol)
         self._device_type = DeviceType.LightStrip
+
+    async def _initialize_modules(self):
+        """Initialize modules not added in init."""
+        await super()._initialize_modules()
         self.add_module(
             Module.LightEffect,
             LightEffect(self, "smartlife.iot.lighting_effect"),

--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -53,6 +53,10 @@ class IotPlug(IotDevice):
     ) -> None:
         super().__init__(host=host, config=config, protocol=protocol)
         self._device_type = DeviceType.Plug
+
+    async def _initialize_modules(self):
+        """Initialize modules."""
+        await super()._initialize_modules()
         self.add_module(Module.IotSchedule, Schedule(self, "schedule"))
         self.add_module(Module.IotUsage, Usage(self, "schedule"))
         self.add_module(Module.IotAntitheft, Antitheft(self, "anti_theft"))

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -255,6 +255,10 @@ class IotStripPlug(IotPlug):
         self._set_sys_info(parent.sys_info)
         self._device_type = DeviceType.StripSocket
         self.protocol = parent.protocol  # Must use the same connection as the parent
+
+    async def _initialize_modules(self):
+        """Initialize modules not added in init."""
+        await super()._initialize_modules()
         self.add_module("time", Time(self, "time"))
 
     async def update(self, update_children: bool = True):

--- a/kasa/iot/modules/__init__.py
+++ b/kasa/iot/modules/__init__.py
@@ -2,10 +2,12 @@
 
 from .ambientlight import AmbientLight
 from .antitheft import Antitheft
+from .brightness import Brightness
 from .cloud import Cloud
 from .countdown import Countdown
 from .emeter import Emeter
 from .led import Led
+from .light import Light
 from .lighteffect import LightEffect
 from .motion import Motion
 from .rulemodule import Rule, RuleModule
@@ -16,10 +18,12 @@ from .usage import Usage
 __all__ = [
     "AmbientLight",
     "Antitheft",
+    "Brightness",
     "Cloud",
     "Countdown",
     "Emeter",
     "Led",
+    "Light",
     "LightEffect",
     "Motion",
     "Rule",

--- a/kasa/iot/modules/brightness.py
+++ b/kasa/iot/modules/brightness.py
@@ -1,0 +1,42 @@
+"""Implementation of brightness module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ...interfaces import Brightness as BrightnessInterface
+from ..iotmodule import IotModule
+
+if TYPE_CHECKING:
+    from ..iotbulb import IotBulb
+    from ..iotdimmer import IotDimmer
+
+
+BRIGHTNESS_MIN = 0
+BRIGHTNESS_MAX = 100
+
+
+class Brightness(IotModule, BrightnessInterface):
+    """Implementation of brightness module."""
+
+    _device: IotBulb | IotDimmer
+
+    def query(self) -> dict:
+        """Query to execute during the update cycle."""
+        # Brightness is contained in the main device info response.
+        return {}
+
+    @property  # type: ignore
+    def brightness(self) -> int:
+        """Return the current brightness in percentage."""
+        return self._device.brightness
+
+    async def set_brightness(
+        self, brightness: int, *, transition: int | None = None
+    ) -> None:
+        """Set the brightness in percentage.
+
+        :param int brightness: brightness in percent
+        :param int transition: transition in milliseconds.
+        """
+        await self._device.set_brightness(brightness, transition=transition)

--- a/kasa/iot/modules/light.py
+++ b/kasa/iot/modules/light.py
@@ -1,0 +1,137 @@
+"""Implementation of brightness module."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from ...exceptions import KasaException
+from ...interfaces.light import HSV, ColorTempRange
+from ...interfaces.light import Light as LightInterface
+from ..iotmodule import IotModule
+
+if TYPE_CHECKING:
+    from ..iotbulb import IotBulb
+    from ..iotdimmer import IotDimmer
+
+
+BRIGHTNESS_MIN = 0
+BRIGHTNESS_MAX = 100
+
+
+class Light(IotModule, LightInterface):
+    """Implementation of brightness module."""
+
+    _device: IotBulb | IotDimmer
+
+    def query(self) -> dict:
+        """Query to execute during the update cycle."""
+        # Brightness is contained in the main device info response.
+        return {}
+
+    def _get_bulb_device(self) -> IotBulb | None:
+        if self._device.is_bulb or self._device.is_light_strip:
+            return cast("IotBulb", self._device)
+        return None
+
+    @property  # type: ignore
+    def is_dimmable(self) -> int:
+        """Whether the bulb supports brightness changes."""
+        return self._device.is_dimmable
+
+    @property  # type: ignore
+    def brightness(self) -> int:
+        """Return the current brightness in percentage."""
+        return self._device.brightness
+
+    async def set_brightness(
+        self, brightness: int, *, transition: int | None = None
+    ) -> None:
+        """Set the brightness in percentage.
+
+        :param int brightness: brightness in percent
+        :param int transition: transition in milliseconds.
+        """
+        return await self._device.set_brightness(brightness, transition=transition)
+
+    @property
+    def is_color(self) -> bool:
+        """Whether the light supports color changes."""
+        if (bulb := self._get_bulb_device()) is None:
+            return False
+        return bulb.is_color
+
+    @property
+    def is_variable_color_temp(self) -> bool:
+        """Whether the bulb supports color temperature changes."""
+        if (bulb := self._get_bulb_device()) is None:
+            return False
+        return bulb.is_variable_color_temp
+
+    @property
+    def has_effects(self) -> bool:
+        """Return True if the device supports effects."""
+        if (bulb := self._get_bulb_device()) is None:
+            return False
+        return bulb.has_effects
+
+    @property
+    def hsv(self) -> HSV:
+        """Return the current HSV state of the bulb.
+
+        :return: hue, saturation and value (degrees, %, %)
+        """
+        if (bulb := self._get_bulb_device()) is None or not bulb.is_color:
+            raise KasaException("Light does not support color.")
+        return bulb.hsv
+
+    async def set_hsv(
+        self,
+        hue: int,
+        saturation: int,
+        value: int | None = None,
+        *,
+        transition: int | None = None,
+    ) -> None:
+        """Set new HSV.
+
+        Note, transition is not supported and will be ignored.
+
+        :param int hue: hue in degrees
+        :param int saturation: saturation in percentage [0,100]
+        :param int value: value in percentage [0, 100]
+        :param int transition: transition in milliseconds.
+        """
+        if (bulb := self._get_bulb_device()) is None or not bulb.is_color:
+            raise KasaException("Light does not support color.")
+        await bulb.set_hsv(hue, saturation, value, transition=transition)
+
+    @property
+    def valid_temperature_range(self) -> ColorTempRange:
+        """Return the device-specific white temperature range (in Kelvin).
+
+        :return: White temperature range in Kelvin (minimum, maximum)
+        """
+        if (bulb := self._get_bulb_device()) is None or not bulb.is_variable_color_temp:
+            raise KasaException("Light does not support colortemp.")
+        return bulb.valid_temperature_range
+
+    @property
+    def color_temp(self) -> int:
+        """Whether the bulb supports color temperature changes."""
+        if (bulb := self._get_bulb_device()) is None or not bulb.is_variable_color_temp:
+            raise KasaException("Light does not support colortemp.")
+        return bulb.color_temp
+
+    async def set_color_temp(
+        self, temp: int, *, brightness=None, transition: int | None = None
+    ) -> None:
+        """Set the color temperature of the device in kelvin.
+
+        Note, transition is not supported and will be ignored.
+
+        :param int temp: The new color temperature, in Kelvin
+        :param int transition: transition in milliseconds.
+        """
+        if (bulb := self._get_bulb_device()) is None or not bulb.is_variable_color_temp:
+            raise KasaException("Light does not support colortemp.")
+        await bulb.set_color_temp(temp, brightness=brightness, transition=transition)

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -15,9 +15,8 @@ from .feature import Feature
 from .modulemapping import ModuleName
 
 if TYPE_CHECKING:
+    from . import interfaces
     from .device import Device
-    from .interfaces.led import Led
-    from .interfaces.lighteffect import LightEffect
     from .iot import modules as iot
     from .smart import modules as smart
 
@@ -34,8 +33,10 @@ class Module(ABC):
     """
 
     # Common Modules
-    LightEffect: Final[ModuleName[LightEffect]] = ModuleName("LightEffect")
-    Led: Final[ModuleName[Led]] = ModuleName("Led")
+    LightEffect: Final[ModuleName[interfaces.LightEffect]] = ModuleName("LightEffect")
+    Led: Final[ModuleName[interfaces.Led]] = ModuleName("Led")
+    Light: Final[ModuleName[interfaces.Light]] = ModuleName("Light")
+    Brightness: Final[ModuleName[interfaces.Brightness]] = ModuleName("Brightness")
 
     # IOT only Modules
     IotAmbientLight: Final[ModuleName[iot.AmbientLight]] = ModuleName("ambient")
@@ -52,7 +53,6 @@ class Module(ABC):
     Alarm: Final[ModuleName[smart.Alarm]] = ModuleName("Alarm")
     AutoOff: Final[ModuleName[smart.AutoOff]] = ModuleName("AutoOff")
     BatterySensor: Final[ModuleName[smart.BatterySensor]] = ModuleName("BatterySensor")
-    Brightness: Final[ModuleName[smart.Brightness]] = ModuleName("Brightness")
     ChildDevice: Final[ModuleName[smart.ChildDevice]] = ModuleName("ChildDevice")
     Cloud: Final[ModuleName[smart.Cloud]] = ModuleName("Cloud")
     Color: Final[ModuleName[smart.Color]] = ModuleName("Color")

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -16,6 +16,7 @@ from .firmware import Firmware
 from .frostprotection import FrostProtection
 from .humiditysensor import HumiditySensor
 from .led import Led
+from .light import Light
 from .lighteffect import LightEffect
 from .lighttransition import LightTransition
 from .reportmode import ReportMode
@@ -41,6 +42,7 @@ __all__ = [
     "Fan",
     "Firmware",
     "Cloud",
+    "Light",
     "LightEffect",
     "LightTransition",
     "ColorTemperature",

--- a/kasa/smart/modules/brightness.py
+++ b/kasa/smart/modules/brightness.py
@@ -4,38 +4,17 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ...feature import Feature
+from ...interfaces.brightness import Brightness as BrightnessInterface
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
-    from ..smartdevice import SmartDevice
+    pass
 
 
-BRIGHTNESS_MIN = 1
-BRIGHTNESS_MAX = 100
-
-
-class Brightness(SmartModule):
+class Brightness(SmartModule, BrightnessInterface):
     """Implementation of brightness module."""
 
     REQUIRED_COMPONENT = "brightness"
-
-    def __init__(self, device: SmartDevice, module: str):
-        super().__init__(device, module)
-        self._add_feature(
-            Feature(
-                device,
-                id="brightness",
-                name="Brightness",
-                container=self,
-                attribute_getter="brightness",
-                attribute_setter="set_brightness",
-                minimum_value=BRIGHTNESS_MIN,
-                maximum_value=BRIGHTNESS_MAX,
-                type=Feature.Type.Number,
-                category=Feature.Category.Primary,
-            )
-        )
 
     def query(self) -> dict:
         """Query to execute during the update cycle."""
@@ -47,16 +26,21 @@ class Brightness(SmartModule):
         """Return current brightness."""
         return self.data["brightness"]
 
-    async def set_brightness(self, brightness: int):
-        """Set the brightness."""
+    async def set_brightness(self, brightness: int, *, transition: int | None = None):
+        """Set the brightness. A brightness value of 0 will turn off the light.
+
+        Note, transition is not supported and will be ignored.
+        """
         if not isinstance(brightness, int) or not (
-            BRIGHTNESS_MIN <= brightness <= BRIGHTNESS_MAX
+            self.BRIGHTNESS_MIN <= brightness <= self.BRIGHTNESS_MAX
         ):
             raise ValueError(
                 f"Invalid brightness value: {brightness} "
-                f"(valid range: {BRIGHTNESS_MIN}-{BRIGHTNESS_MAX}%)"
+                f"(valid range: {self.BRIGHTNESS_MIN}-{self.BRIGHTNESS_MAX}%)"
             )
 
+        if brightness == 0:
+            return await self._device.turn_off()
         return await self.call("set_device_info", {"brightness": brightness})
 
     async def _check_supported(self):

--- a/kasa/smart/modules/light.py
+++ b/kasa/smart/modules/light.py
@@ -1,0 +1,126 @@
+"""Module for led controls."""
+
+from __future__ import annotations
+
+from ...exceptions import KasaException
+from ...interfaces.light import HSV, ColorTempRange
+from ...interfaces.light import Light as LightInterface
+from ...module import Module
+from ..smartmodule import SmartModule
+
+
+class Light(SmartModule, LightInterface):
+    """Implementation of a light."""
+
+    def query(self) -> dict:
+        """Query to execute during the update cycle."""
+        return {}
+
+    @property
+    def is_color(self) -> bool:
+        """Whether the bulb supports color changes."""
+        return Module.Color in self._device.modules
+
+    @property
+    def is_dimmable(self) -> bool:
+        """Whether the bulb supports brightness changes."""
+        return Module.Brightness in self._device.modules
+
+    @property
+    def is_variable_color_temp(self) -> bool:
+        """Whether the bulb supports color temperature changes."""
+        return Module.ColorTemperature in self._device.modules
+
+    @property
+    def valid_temperature_range(self) -> ColorTempRange:
+        """Return the device-specific white temperature range (in Kelvin).
+
+        :return: White temperature range in Kelvin (minimum, maximum)
+        """
+        if not self.is_variable_color_temp:
+            raise KasaException("Color temperature not supported")
+
+        return self._device.modules[Module.ColorTemperature].valid_temperature_range
+
+    @property
+    def hsv(self) -> HSV:
+        """Return the current HSV state of the bulb.
+
+        :return: hue, saturation and value (degrees, %, %)
+        """
+        if not self.is_color:
+            raise KasaException("Bulb does not support color.")
+
+        return self._device.modules[Module.Color].hsv
+
+    @property
+    def color_temp(self) -> int:
+        """Whether the bulb supports color temperature changes."""
+        if not self.is_variable_color_temp:
+            raise KasaException("Bulb does not support colortemp.")
+
+        return self._device.modules[Module.ColorTemperature].color_temp
+
+    @property
+    def brightness(self) -> int:
+        """Return the current brightness in percentage."""
+        if not self.is_dimmable:  # pragma: no cover
+            raise KasaException("Bulb is not dimmable.")
+
+        return self._device.modules[Module.Brightness].brightness
+
+    async def set_hsv(
+        self,
+        hue: int,
+        saturation: int,
+        value: int | None = None,
+        *,
+        transition: int | None = None,
+    ) -> None:
+        """Set new HSV.
+
+        Note, transition is not supported and will be ignored.
+
+        :param int hue: hue in degrees
+        :param int saturation: saturation in percentage [0,100]
+        :param int value: value between 1 and 100
+        :param int transition: transition in milliseconds.
+        """
+        if not self.is_color:
+            raise KasaException("Bulb does not support color.")
+
+        await self._device.modules[Module.Color].set_hsv(hue, saturation, value)
+
+    async def set_color_temp(
+        self, temp: int, *, brightness=None, transition: int | None = None
+    ) -> None:
+        """Set the color temperature of the device in kelvin.
+
+        Note, transition is not supported and will be ignored.
+
+        :param int temp: The new color temperature, in Kelvin
+        :param int transition: transition in milliseconds.
+        """
+        if not self.is_variable_color_temp:
+            raise KasaException("Bulb does not support colortemp.")
+        await self._device.modules[Module.ColorTemperature].set_color_temp(temp)
+
+    async def set_brightness(
+        self, brightness: int, *, transition: int | None = None
+    ) -> None:
+        """Set the brightness in percentage.
+
+        Note, transition is not supported and will be ignored.
+
+        :param int brightness: brightness in percent
+        :param int transition: transition in milliseconds.
+        """
+        if not self.is_dimmable:  # pragma: no cover
+            raise KasaException("Bulb is not dimmable.")
+
+        await self._device.modules[Module.Brightness].set_brightness(brightness)
+
+    @property
+    def has_effects(self) -> bool:
+        """Return True if the device supports effects."""
+        return Module.LightEffect in self._device.modules

--- a/kasa/tests/device_fixtures.py
+++ b/kasa/tests/device_fixtures.py
@@ -203,14 +203,14 @@ wallswitch_iot = parametrize(
     "wall switches iot", model_filter=SWITCHES, protocol_filter={"IOT"}
 )
 strip = parametrize("strips", model_filter=STRIPS, protocol_filter={"SMART", "IOT"})
-dimmer = parametrize("dimmers", model_filter=DIMMERS, protocol_filter={"IOT"})
-lightstrip = parametrize(
+dimmer_iot = parametrize("dimmers", model_filter=DIMMERS, protocol_filter={"IOT"})
+lightstrip_iot = parametrize(
     "lightstrips", model_filter=LIGHT_STRIPS, protocol_filter={"IOT"}
 )
 
 # bulb types
-dimmable = parametrize("dimmable", model_filter=DIMMABLE, protocol_filter={"IOT"})
-non_dimmable = parametrize(
+dimmable_iot = parametrize("dimmable", model_filter=DIMMABLE, protocol_filter={"IOT"})
+non_dimmable_iot = parametrize(
     "non-dimmable", model_filter=BULBS - DIMMABLE, protocol_filter={"IOT"}
 )
 variable_temp = parametrize(
@@ -292,12 +292,12 @@ device_iot = parametrize(
 def check_categories():
     """Check that every fixture file is categorized."""
     categorized_fixtures = set(
-        dimmer.args[1]
+        dimmer_iot.args[1]
         + strip.args[1]
         + plug.args[1]
         + bulb.args[1]
         + wallswitch.args[1]
-        + lightstrip.args[1]
+        + lightstrip_iot.args[1]
         + bulb_smart.args[1]
         + dimmers_smart.args[1]
         + hubs_smart.args[1]

--- a/kasa/tests/smart/features/test_brightness.py
+++ b/kasa/tests/smart/features/test_brightness.py
@@ -2,7 +2,7 @@ import pytest
 
 from kasa.iot import IotDevice
 from kasa.smart import SmartDevice
-from kasa.tests.conftest import dimmable, parametrize
+from kasa.tests.conftest import dimmable_iot, parametrize
 
 brightness = parametrize("brightness smart", component_filter="brightness")
 
@@ -32,7 +32,7 @@ async def test_brightness_component(dev: SmartDevice):
         await feature.set_value(feature.maximum_value + 10)
 
 
-@dimmable
+@dimmable_iot
 async def test_brightness_dimmable(dev: IotDevice):
     """Test brightness feature."""
     assert isinstance(dev, IotDevice)

--- a/kasa/tests/smart/modules/test_fan.py
+++ b/kasa/tests/smart/modules/test_fan.py
@@ -52,7 +52,7 @@ async def test_sleep_mode(dev: SmartDevice, mocker: MockerFixture):
 
 
 @fan
-async def test_fan_interface(dev: SmartDevice, mocker: MockerFixture):
+async def test_fan_module(dev: SmartDevice, mocker: MockerFixture):
     """Test fan speed on device interface."""
     assert isinstance(dev, SmartDevice)
     fan = dev.modules.get(Module.Fan)
@@ -60,21 +60,21 @@ async def test_fan_interface(dev: SmartDevice, mocker: MockerFixture):
     device = fan._device
     assert device.is_fan
 
-    await device.set_fan_speed_level(1)
+    await fan.set_fan_speed_level(1)
     await dev.update()
-    assert device.fan_speed_level == 1
+    assert fan.fan_speed_level == 1
     assert device.is_on
 
-    await device.set_fan_speed_level(4)
+    await fan.set_fan_speed_level(4)
     await dev.update()
-    assert device.fan_speed_level == 4
+    assert fan.fan_speed_level == 4
 
-    await device.set_fan_speed_level(0)
+    await fan.set_fan_speed_level(0)
     await dev.update()
     assert not device.is_on
 
     with pytest.raises(ValueError):
-        await device.set_fan_speed_level(-1)
+        await fan.set_fan_speed_level(-1)
 
     with pytest.raises(ValueError):
-        await device.set_fan_speed_level(5)
+        await fan.set_fan_speed_level(5)

--- a/kasa/tests/test_dimmer.py
+++ b/kasa/tests/test_dimmer.py
@@ -3,10 +3,10 @@ import pytest
 from kasa import DeviceType
 from kasa.iot import IotDimmer
 
-from .conftest import dimmer, handle_turn_on, turn_on
+from .conftest import dimmer_iot, handle_turn_on, turn_on
 
 
-@dimmer
+@dimmer_iot
 @turn_on
 async def test_set_brightness(dev, turn_on):
     await handle_turn_on(dev, turn_on)
@@ -22,7 +22,7 @@ async def test_set_brightness(dev, turn_on):
     assert dev.is_on == turn_on
 
 
-@dimmer
+@dimmer_iot
 @turn_on
 async def test_set_brightness_transition(dev, turn_on, mocker):
     await handle_turn_on(dev, turn_on)
@@ -44,7 +44,7 @@ async def test_set_brightness_transition(dev, turn_on, mocker):
     assert dev.brightness == 1
 
 
-@dimmer
+@dimmer_iot
 async def test_set_brightness_invalid(dev):
     for invalid_brightness in [-1, 101, 0.5]:
         with pytest.raises(ValueError):
@@ -55,7 +55,7 @@ async def test_set_brightness_invalid(dev):
             await dev.set_brightness(1, transition=invalid_transition)
 
 
-@dimmer
+@dimmer_iot
 async def test_turn_on_transition(dev, mocker):
     query_helper = mocker.spy(IotDimmer, "_query_helper")
     original_brightness = dev.brightness
@@ -72,7 +72,7 @@ async def test_turn_on_transition(dev, mocker):
     assert dev.brightness == original_brightness
 
 
-@dimmer
+@dimmer_iot
 async def test_turn_off_transition(dev, mocker):
     await handle_turn_on(dev, True)
     query_helper = mocker.spy(IotDimmer, "_query_helper")
@@ -90,7 +90,7 @@ async def test_turn_off_transition(dev, mocker):
     )
 
 
-@dimmer
+@dimmer_iot
 @turn_on
 async def test_set_dimmer_transition(dev, turn_on, mocker):
     await handle_turn_on(dev, turn_on)
@@ -108,7 +108,7 @@ async def test_set_dimmer_transition(dev, turn_on, mocker):
     assert dev.brightness == 99
 
 
-@dimmer
+@dimmer_iot
 @turn_on
 async def test_set_dimmer_transition_to_off(dev, turn_on, mocker):
     await handle_turn_on(dev, turn_on)
@@ -127,7 +127,7 @@ async def test_set_dimmer_transition_to_off(dev, turn_on, mocker):
     )
 
 
-@dimmer
+@dimmer_iot
 async def test_set_dimmer_transition_invalid(dev):
     for invalid_brightness in [-1, 101, 0.5]:
         with pytest.raises(ValueError):
@@ -138,6 +138,6 @@ async def test_set_dimmer_transition_invalid(dev):
             await dev.set_dimmer_transition(1, invalid_transition)
 
 
-@dimmer
+@dimmer_iot
 def test_device_type_dimmer(dev):
     assert dev.device_type == DeviceType.Dimmer

--- a/kasa/tests/test_discovery.py
+++ b/kasa/tests/test_discovery.py
@@ -26,8 +26,8 @@ from kasa.xortransport import XorEncryption
 
 from .conftest import (
     bulb_iot,
-    dimmer,
-    lightstrip,
+    dimmer_iot,
+    lightstrip_iot,
     new_discovery,
     plug_iot,
     strip_iot,
@@ -86,14 +86,14 @@ async def test_type_detection_strip(dev: Device):
     assert d.device_type == DeviceType.Strip
 
 
-@dimmer
+@dimmer_iot
 async def test_type_detection_dimmer(dev: Device):
     d = Discover._get_device_class(dev._last_update)("localhost")
     assert d.is_dimmer
     assert d.device_type == DeviceType.Dimmer
 
 
-@lightstrip
+@lightstrip_iot
 async def test_type_detection_lightstrip(dev: Device):
     d = Discover._get_device_class(dev._last_update)("localhost")
     assert d.is_light_strip

--- a/kasa/tests/test_lightstrip.py
+++ b/kasa/tests/test_lightstrip.py
@@ -3,24 +3,24 @@ import pytest
 from kasa import DeviceType
 from kasa.iot import IotLightStrip
 
-from .conftest import lightstrip
+from .conftest import lightstrip_iot
 
 
-@lightstrip
+@lightstrip_iot
 async def test_lightstrip_length(dev: IotLightStrip):
     assert dev.is_light_strip
     assert dev.device_type == DeviceType.LightStrip
     assert dev.length == dev.sys_info["length"]
 
 
-@lightstrip
+@lightstrip_iot
 async def test_lightstrip_effect(dev: IotLightStrip):
     assert isinstance(dev.effect, dict)
     for k in ["brightness", "custom", "enable", "id", "name"]:
         assert k in dev.effect
 
 
-@lightstrip
+@lightstrip_iot
 async def test_effects_lightstrip_set_effect(dev: IotLightStrip):
     with pytest.raises(ValueError):
         await dev.set_effect("Not real")
@@ -30,7 +30,7 @@ async def test_effects_lightstrip_set_effect(dev: IotLightStrip):
     assert dev.effect["name"] == "Candy Cane"
 
 
-@lightstrip
+@lightstrip_iot
 @pytest.mark.parametrize("brightness", [100, 50])
 async def test_effects_lightstrip_set_effect_brightness(
     dev: IotLightStrip, brightness, mocker
@@ -48,7 +48,7 @@ async def test_effects_lightstrip_set_effect_brightness(
     assert payload["brightness"] == brightness
 
 
-@lightstrip
+@lightstrip_iot
 @pytest.mark.parametrize("transition", [500, 1000])
 async def test_effects_lightstrip_set_effect_transition(
     dev: IotLightStrip, transition, mocker
@@ -66,12 +66,12 @@ async def test_effects_lightstrip_set_effect_transition(
     assert payload["transition"] == transition
 
 
-@lightstrip
+@lightstrip_iot
 async def test_effects_lightstrip_has_effects(dev: IotLightStrip):
     assert dev.has_effects is True
     assert dev.effect_list
 
 
-@lightstrip
+@lightstrip_iot
 def test_device_type_lightstrip(dev):
     assert dev.device_type == DeviceType.LightStrip

--- a/kasa/tests/test_smartdevice.py
+++ b/kasa/tests/test_smartdevice.py
@@ -14,7 +14,6 @@ from kasa.exceptions import SmartErrorCode
 from kasa.smart import SmartDevice
 
 from .conftest import (
-    bulb_smart,
     device_smart,
     get_device_for_fixture_protocol,
 )
@@ -157,28 +156,6 @@ async def test_get_modules():
 
     module = dummy_device.modules.get(Module.IotAmbientLight)
     assert module is None
-
-
-@bulb_smart
-async def test_smartdevice_brightness(dev: SmartDevice):
-    """Test brightness setter and getter."""
-    assert isinstance(dev, SmartDevice)
-    assert "brightness" in dev._components
-
-    # Test getting the value
-    feature = dev.features["brightness"]
-    assert feature.minimum_value == 1
-    assert feature.maximum_value == 100
-
-    await dev.set_brightness(10)
-    await dev.update()
-    assert dev.brightness == 10
-
-    with pytest.raises(ValueError):
-        await dev.set_brightness(feature.minimum_value - 10)
-
-    with pytest.raises(ValueError):
-        await dev.set_brightness(feature.maximum_value + 10)
 
 
 @device_smart


### PR DESCRIPTION
Moves `iot` module initialization into an `_initialize_modules` method so it can check sysinfo to conditionally add the `Brightness` and `Light` modules.

To align the brightness settings across devices setting brightness to 0 on `smart` devices will call `turn_off`. I think that's ok but still need to test with a real device.

Also makes Fan just a module rather than a device interface.