### PR TITLE
Fix set_state for common light modules

### DIFF
--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -35,7 +35,7 @@ from kasa.exceptions import (
     UnsupportedDeviceError,
 )
 from kasa.feature import Feature
-from kasa.interfaces.light import Light, LightState
+from kasa.interfaces.light import HSV, ColorTempRange, Light, LightState
 from kasa.iotprotocol import (
     IotProtocol,
     _deprecated_TPLinkSmartHomeProtocol,  # noqa: F401
@@ -60,6 +60,8 @@ __all__ = [
     "EmeterStatus",
     "Device",
     "Light",
+    "ColorTempRange",
+    "HSV",
     "Plug",
     "Module",
     "KasaException",

--- a/kasa/interfaces/light.py
+++ b/kasa/interfaces/light.py
@@ -18,7 +18,7 @@ class LightState:
     hue: int | None = None
     saturation: int | None = None
     color_temp: int | None = None
-    transition: bool | None = None
+    transition: int | None = None
 
 
 class ColorTempRange(NamedTuple):
@@ -127,6 +127,11 @@ class Light(Module, ABC):
         :param int brightness: brightness in percent
         :param int transition: transition in milliseconds.
         """
+
+    @property
+    @abstractmethod
+    def state(self) -> LightState:
+        """Return the current light state."""
 
     @abstractmethod
     async def set_state(self, state: LightState) -> dict:

--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -329,6 +329,9 @@ class IotBulb(IotDevice):
         if transition is not None:
             state["transition_period"] = transition
 
+        if "brightness" in state:
+            self._raise_for_invalid_brightness(state["brightness"])
+
         # if no on/off is defined, turn on the light
         if "on_off" not in state:
             state["on_off"] = 1

--- a/kasa/iot/iotdimmer.py
+++ b/kasa/iot/iotdimmer.py
@@ -168,6 +168,9 @@ class IotDimmer(IotPlug):
         if not 0 <= brightness <= 100:
             raise ValueError("Brightness value %s is not valid." % brightness)
 
+        # If zero set to 1 millisecond
+        if transition == 0:
+            transition = 1
         if not isinstance(transition, int):
             raise ValueError(
                 "Transition must be integer, " "not of %s.", type(transition)

--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -241,7 +241,7 @@ async def test_dimmable_brightness_transition(dev: IotBulb, mocker):
     set_light_state = mocker.patch("kasa.iot.IotBulb._set_light_state")
     await dev.set_brightness(10, transition=1000)
 
-    set_light_state.assert_called_with({"brightness": 10}, transition=1000)
+    set_light_state.assert_called_with({"brightness": 10, "on_off": 1}, transition=1000)
 
 
 @dimmable_iot

--- a/kasa/tests/test_dimmer.py
+++ b/kasa/tests/test_dimmer.py
@@ -7,19 +7,19 @@ from .conftest import dimmer_iot, handle_turn_on, turn_on
 
 
 @dimmer_iot
-@turn_on
-async def test_set_brightness(dev, turn_on):
-    await handle_turn_on(dev, turn_on)
+async def test_set_brightness(dev):
+    await handle_turn_on(dev, False)
+    assert dev.is_on is False
 
     await dev.set_brightness(99)
     await dev.update()
     assert dev.brightness == 99
-    assert dev.is_on == turn_on
+    assert dev.is_on is True
 
     await dev.set_brightness(0)
     await dev.update()
-    assert dev.brightness == 1
-    assert dev.is_on == turn_on
+    assert dev.brightness == 99
+    assert dev.is_on is False
 
 
 @dimmer_iot
@@ -41,7 +41,7 @@ async def test_set_brightness_transition(dev, turn_on, mocker):
 
     await dev.set_brightness(0, transition=1000)
     await dev.update()
-    assert dev.brightness == 1
+    assert dev.is_on is False
 
 
 @dimmer_iot
@@ -50,7 +50,7 @@ async def test_set_brightness_invalid(dev):
         with pytest.raises(ValueError):
             await dev.set_brightness(invalid_brightness)
 
-    for invalid_transition in [-1, 0, 0.5]:
+    for invalid_transition in [-1, 0.5]:
         with pytest.raises(ValueError):
             await dev.set_brightness(1, transition=invalid_transition)
 
@@ -133,7 +133,7 @@ async def test_set_dimmer_transition_invalid(dev):
         with pytest.raises(ValueError):
             await dev.set_dimmer_transition(invalid_brightness, 1000)
 
-    for invalid_transition in [-1, 0, 0.5]:
+    for invalid_transition in [-1, 0.5]:
         with pytest.raises(ValueError):
             await dev.set_dimmer_transition(1, invalid_transition)
 


### PR DESCRIPTION
PR contains a number of fixes from testing with HA devices:

- Fixes a bug with turning the light on and off via `set_state`
- Aligns `set_brightness` behaviour across `smart` and `iot` devices such that a value of 0 is off.
- Aligns `set_brightness` behaviour for `IotDimmer` such that setting the brightness turns on the device with a transition of 1ms. ([HA comment](https://github.com/home-assistant/core/pull/117839#discussion_r1608720006))
- Fixes a typing issue in `LightState`.
- Adds `ColorTempRange` and `HSV` to `__init__.py`
- Adds a `state` property to the interface returning `LightState` for validating `set_state` changes.
- Adds tests for `set_state`