### PR TITLE
Do not show a zero error code when cli exits from showing help

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -111,6 +111,10 @@ def CatchAllExceptions(cls):
     def _handle_exception(debug, exc):
         if isinstance(exc, click.ClickException):
             raise
+        # Handle exit request from click.
+        if isinstance(exc, click.exceptions.Exit):
+            sys.exit(exc.exit_code)
+
         echo(f"Raised error: {exc}")
         if debug:
             raise


### PR DESCRIPTION
Running `--help` causes otherwise `Raised error: 0` when click wants to exit after showing the help.