### PR TITLE
Fix passing custom port for dump_devinfo

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -207,7 +207,7 @@ async def handle_device(basedir, autosave, device: Device, batch_size: int):
         + " Do not use this flag unless you are sure you know what it means."
     ),
 )
-@click.option("--port", help="Port override")
+@click.option("--port", help="Port override", type=int)
 async def cli(
     host,
     target,


### PR DESCRIPTION
Seen in https://github.com/python-kasa/python-kasa/issues/937#issuecomment-2132207151