### PR TITLE
Do not raise on multi-request errors on child devices

### DIFF
--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -402,7 +402,9 @@ class _ChildProtocolWrapper(SmartProtocol):
                 ret_val = {}
                 for multi_response in multi_responses:
                     method = multi_response["method"]
-                    self._handle_response_error_code(multi_response, method)
+                    self._handle_response_error_code(
+                        multi_response, method, raise_on_error=False
+                    )
                     ret_val[method] = multi_response.get("result")
                 return ret_val
 

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -181,8 +181,9 @@ async def test_childdevicewrapper_multiplerequest_error(dummy_protocol, mocker):
     }
     wrapped_protocol = _ChildProtocolWrapper("dummyid", dummy_protocol)
     mocker.patch.object(wrapped_protocol._transport, "send", return_value=mock_response)
-    with pytest.raises(KasaException):
-        await wrapped_protocol.query(DUMMY_QUERY)
+    res = await wrapped_protocol.query(DUMMY_QUERY)
+    assert res["get_device_info"] == {"foo": "bar"}
+    assert res["invalid_command"] == SmartErrorCode(-1001)
 
 
 @pytest.mark.parametrize("list_sum", [5, 10, 30])


### PR DESCRIPTION
This will avoid crashing when some commands return an error on multi-requests on child devices.

Idea from https://github.com/python-kasa/python-kasa/pull/900/files#r1624803457