### PR TITLE
Add time sync command

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -58,6 +58,11 @@ As with all other commands, you can also pass ``--help`` to both ``join`` and ``
     However, note that communications with devices provisioned using this method will stop working
     when connected to the cloud.
 
+.. note::
+
+    Some commands do not work if the device time is out-of-sync.
+    You can use ``kasa time sync`` command to set the device time from the system where the command is run.
+
 .. warning::
 
     At least some devices (e.g., Tapo lights L530 and L900) are known to have a watchdog that reboots them every 10 minutes if they are unable to connect to the cloud.

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -998,7 +998,8 @@ async def time_sync(dev: SmartDevice):
 
     echo("Old time: %s" % time.time)
 
-    await time.set_time(datetime.now(tz=time.time.tzinfo))
+    local_tz = datetime.now().astimezone().tzinfo
+    await time.set_time(datetime.now(tz=local_tz))
 
     await dev.update()
     echo("New time: %s" % time.time)

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -992,9 +992,7 @@ async def time_sync(dev: SmartDevice):
     if not isinstance(dev, SmartDevice):
         raise NotImplementedError("setting time currently only implemented on smart")
 
-    from .smart.modules import Time
-
-    if (time := dev.get_module(Time)) is None:
+    if (time := dev.modules.get(Module.Time)) is None:
         echo("Device does not have time module")
         return
 

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -993,10 +993,10 @@ async def time_sync(dev: SmartDevice):
 
     from datetime import datetime
 
-    from .smart.modules import TimeModule
+    from .smart.modules import Time
 
-    if (time := dev.get_module(TimeModule)) is None:
-        echo("Device does not have timemodule")
+    if (time := dev.get_module(Time)) is None:
+        echo("Device does not have time module")
         return
 
     echo("Old time: %s" % time.time)

--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -9,6 +9,7 @@ import logging
 import re
 import sys
 from contextlib import asynccontextmanager
+from datetime import datetime
 from functools import singledispatch, wraps
 from pprint import pformat as pf
 from typing import Any, cast
@@ -990,8 +991,6 @@ async def time_sync(dev: SmartDevice):
     """Set the device time to current time."""
     if not isinstance(dev, SmartDevice):
         raise NotImplementedError("setting time currently only implemented on smart")
-
-    from datetime import datetime
 
     from .smart.modules import Time
 

--- a/kasa/smart/modules/time.py
+++ b/kasa/smart/modules/time.py
@@ -51,7 +51,13 @@ class Time(SmartModule):
     async def set_time(self, dt: datetime):
         """Set device time."""
         unixtime = mktime(dt.timetuple())
+        offset = cast(timedelta, dt.utcoffset())
+        diff = offset / timedelta(minutes=1)
         return await self.call(
             "set_device_time",
-            {"timestamp": unixtime, "time_diff": dt.utcoffset(), "region": dt.tzname()},
+            {
+                "timestamp": int(unixtime),
+                "time_diff": int(diff),
+                "region": dt.tzname(),
+            },
         )

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -31,6 +31,7 @@ from kasa.cli import (
     state,
     sysinfo,
     temperature,
+    time,
     toggle,
     update_credentials,
     wifi,
@@ -258,6 +259,37 @@ async def test_update_credentials(dev, runner):
         "Do you really want to replace the existing credentials? [y/N]: y\n"
         in res.output
     )
+
+
+async def test_time_get(dev, runner):
+    """Test time get command."""
+    res = await runner.invoke(
+        time,
+        obj=dev,
+    )
+    assert res.exit_code == 0
+    assert "Current time: " in res.output
+
+
+@device_smart
+async def test_time_sync(dev, mocker, runner):
+    """Test time sync command.
+
+    Currently implemented only for SMART.
+    """
+    update = mocker.patch.object(dev, "update")
+    set_time_mock = mocker.spy(dev.modules[Module.Time], "set_time")
+    res = await runner.invoke(
+        time,
+        ["sync"],
+        obj=dev,
+    )
+    set_time_mock.assert_called()
+    update.assert_called()
+
+    assert res.exit_code == 0
+    assert "Old time: " in res.output
+    assert "New time: " in res.output
 
 
 async def test_emeter(dev: Device, mocker, runner):


### PR DESCRIPTION
Allows setting the device time (on SMART devices) to the current time.
Fixes also setting the time which was previously completely broken.

TBD:
- [x] Add tests
- [x] Update docs to instruct to set the time when getting errors on non-provisioned devices

Fixes #852
Fixes #818 