### PR TITLE
Require update in cli for wifi commands

### DIFF
--- a/kasa/cli.py
+++ b/kasa/cli.py
@@ -92,7 +92,7 @@ ENCRYPT_TYPES = [encrypt_type.value for encrypt_type in DeviceEncryptionType]
 DEVICE_FAMILY_TYPES = [device_family_type.value for device_family_type in DeviceFamily]
 
 # Block list of commands which require no update
-SKIP_UPDATE_COMMANDS = ["wifi", "raw-command", "command"]
+SKIP_UPDATE_COMMANDS = ["raw-command", "command"]
 
 click.anyio_backend = "asyncio"
 


### PR DESCRIPTION
Executing `wifi join` requires passing the current time information for smart devices which we read from the device.
This removes `wifi` from the block list to make it work.

It should be checked why this was added in the first place though..