### PR TITLE
Fix fan speed level when off and derive smart fan module from common fan interface

### DIFF
--- a/kasa/smart/modules/fan.py
+++ b/kasa/smart/modules/fan.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from ...feature import Feature
+from ...interfaces.fan import Fan as FanInterface
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
     from ..smartdevice import SmartDevice
 
 
-class Fan(SmartModule):
+class Fan(SmartModule, FanInterface):
     """Implementation of fan_control module."""
 
     REQUIRED_COMPONENT = "fan_control"
@@ -54,7 +55,7 @@ class Fan(SmartModule):
     @property
     def fan_speed_level(self) -> int:
         """Return fan speed level."""
-        return self.data["fan_speed_level"]
+        return 0 if self.data["device_on"] is False else self.data["fan_speed_level"]
 
     async def set_fan_speed_level(self, level: int):
         """Set fan speed level, 0 for off, 1-4 for on."""

--- a/kasa/tests/smart/modules/test_fan.py
+++ b/kasa/tests/smart/modules/test_fan.py
@@ -64,6 +64,11 @@ async def test_fan_module(dev: SmartDevice, mocker: MockerFixture):
     assert fan.fan_speed_level == 1
     assert device.is_on
 
+    # Check that if the device is off the speed level is 0.
+    await device.set_state(False)
+    await dev.update()
+    assert fan.fan_speed_level == 0
+
     await fan.set_fan_speed_level(4)
     await dev.update()
     assert fan.fan_speed_level == 4


### PR DESCRIPTION
Picked this up while updating the [Fan platform PR](https://github.com/home-assistant/core/pull/116605) for HA. The smart fan module was not correctly deriving from the common interface and the speed_level is reported as >0 when off.