### PR TITLE
Ensure http delay logic works during default login attempt

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -28,6 +28,8 @@ from .exceptions import (
     DeviceError,
     KasaException,
     SmartErrorCode,
+    TimeoutError,
+    _ConnectionError,
     _RetryableError,
 )
 from .httpclient import HttpClient
@@ -220,7 +222,7 @@ class AesTransport(BaseTransport):
                     "%s: logged in with default credentials",
                     self._host,
                 )
-            except AuthenticationError:
+            except (AuthenticationError, _ConnectionError, TimeoutError):
                 raise
             except Exception as ex:
                 raise KasaException(


### PR DESCRIPTION
Issue encountered while connecting to P100 with the wrong `login_version` results in giving a misleading error message that cannot write to the client as opposed to the real `LOGIN_ERROR`.