### PR TITLE
Fix switching off light effects for iot lights strips

### DIFF
--- a/kasa/iot/modules/lighteffect.py
+++ b/kasa/iot/modules/lighteffect.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...interfaces.lighteffect import LightEffect as LightEffectInterface
+from ...module import Module
 from ..effects import EFFECT_MAPPING_V1, EFFECT_NAMES_V1
 from ..iotmodule import IotModule
 
@@ -59,19 +60,24 @@ class LightEffect(IotModule, LightEffectInterface):
         :param int transition: The wanted transition time
         """
         if effect == self.LIGHT_EFFECTS_OFF:
-            effect_dict = dict(self.data["lighting_effect_state"])
-            effect_dict["enable"] = 0
+            light_module = self._device.modules[Module.Light]
+            effect_off_state = light_module.state
+            if brightness is not None:
+                effect_off_state.brightness = brightness
+            if transition is not None:
+                effect_off_state.transition = transition
+            await light_module.set_state(effect_off_state)
         elif effect not in EFFECT_MAPPING_V1:
             raise ValueError(f"The effect {effect} is not a built in effect.")
         else:
             effect_dict = EFFECT_MAPPING_V1[effect]
 
-        if brightness is not None:
-            effect_dict["brightness"] = brightness
-        if transition is not None:
-            effect_dict["transition"] = transition
+            if brightness is not None:
+                effect_dict["brightness"] = brightness
+            if transition is not None:
+                effect_dict["transition"] = transition
 
-        await self.set_custom_effect(effect_dict)
+            await self.set_custom_effect(effect_dict)
 
     async def set_custom_effect(
         self,

--- a/kasa/tests/fakeprotocol_iot.py
+++ b/kasa/tests/fakeprotocol_iot.py
@@ -317,6 +317,12 @@ class FakeIotTransport(BaseTransport):
         _LOGGER.debug("New light state: %s", new_state)
         self.proto["system"]["get_sysinfo"]["light_state"] = new_state
 
+        # Setting the light state on a device will turn off any active lighting effects.
+        if lighting_effect_state := self.proto["system"]["get_sysinfo"].get(
+            "lighting_effect_state"
+        ):
+            lighting_effect_state["enable"] = 0
+
     def set_preferred_state(self, new_state, *args):
         """Implement set_preferred_state."""
         self.proto["system"]["get_sysinfo"]["preferred_state"][new_state["index"]] = (

--- a/kasa/tests/test_common_modules.py
+++ b/kasa/tests/test_common_modules.py
@@ -78,7 +78,7 @@ async def test_light_effect_module(dev: Device, mocker: MockerFixture):
     assert light_effect_module
     feat = dev.features["light_effect"]
 
-    call = mocker.spy(light_effect_module, "call")
+    call = mocker.spy(dev, "_query_helper")
     effect_list = light_effect_module.effect_list
     assert "Off" in effect_list
     assert effect_list.index("Off") == 0


### PR DESCRIPTION
Previously there was not option to switch off a light effect.  Now there is the implemented method of setting enable to 0 does not work with a real device so this PR sets the light state to the previous state which switches off the effect.