### PR TITLE
Better checking of child modules not supported by parent device

### DIFF
--- a/kasa/smart/modules/lightpreset.py
+++ b/kasa/smart/modules/lightpreset.py
@@ -140,3 +140,13 @@ class LightPreset(SmartModule, LightPresetInterface):
         if self._state_in_sysinfo:  # Child lights can have states in the child info
             return {}
         return {self.QUERY_GETTER_NAME: None}
+
+    async def _check_supported(self):
+        """Additional check to see if the module is supported by the device.
+
+        Parent devices that report components of children such as ks240 will not have
+        the brightness value is sysinfo.
+        """
+        # Look in _device.sys_info here because self.data is either sys_info or
+        # get_preset_rules depending on whether it's a child device or not.
+        return "brightness" in self._device.sys_info

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -202,10 +202,6 @@ class SmartDevice(Device):
         child_modules_to_skip = {}
         if self._parent and self._parent.device_type != DeviceType.Hub:
             skip_parent_only_modules = True
-        elif self._children and self.device_type == DeviceType.WallSwitch:
-            # _initialize_modules is called on the parent after the children
-            for child in self._children.values():
-                child_modules_to_skip.update(**child.modules)
 
         for mod in SmartModule.REGISTERED_MODULES.values():
             _LOGGER.debug("%s requires %s", mod, mod.REQUIRED_COMPONENT)


### PR DESCRIPTION
Replaces the logic to skip adding child modules to parent devices based on whether a device is a wall switch and instead relies on the `_check_supported` method.  Is more future proof and will fix issue with the P300 with child `auto_off` modules https://github.com/python-kasa/python-kasa/pull/915 not supported on the parent.