### PR TITLE
Support smart child modules queries

### DIFF
--- a/kasa/smart/modules/autooff.py
+++ b/kasa/smart/modules/autooff.py
@@ -99,3 +99,11 @@ class AutoOff(SmartModule):
         sysinfo = self._device.sys_info
 
         return self._device.time + timedelta(seconds=sysinfo["auto_off_remain_time"])
+
+    async def _check_supported(self):
+        """Additional check to see if the module is supported by the device.
+
+        Parent devices that report components of children such as P300 will not have
+        the auto_off_status is sysinfo.
+        """
+        return "auto_off_status" in self._device.sys_info

--- a/kasa/smart/smartchilddevice.py
+++ b/kasa/smart/smartchilddevice.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
@@ -34,7 +35,17 @@ class SmartChildDevice(SmartDevice):
         self.protocol = _ChildProtocolWrapper(self._id, parent.protocol)
 
     async def update(self, update_children: bool = True):
-        """Noop update. The parent updates our internals."""
+        """Update child module info.
+
+        The parent updates our internal info so just update modules with
+        their own queries.
+        """
+        req: dict[str, Any] = {}
+        for module in self.modules.values():
+            if mod_query := module.query():
+                req.update(mod_query)
+        if req:
+            self._last_update = await self.protocol.query(req)
 
     @classmethod
     async def create(cls, parent: SmartDevice, child_info, child_components):


### PR DESCRIPTION
Required for the P300 firmware update with `auto_off` module on child devices. Will query child modules for parent devices that are not hubs.

Coverage will be fixed when the P300 fixture is added https://github.com/python-kasa/python-kasa/pull/915