### PR TITLE
Add supported check to light transition module

### DIFF
--- a/kasa/smart/modules/lighttransition.py
+++ b/kasa/smart/modules/lighttransition.py
@@ -181,3 +181,13 @@ class LightTransition(SmartModule):
             return {}
         else:
             return {self.QUERY_GETTER_NAME: None}
+
+    async def _check_supported(self):
+        """Additional check to see if the module is supported by the device.
+
+        Parent devices that report components of children such as ks240 will not have
+        the brightness value is sysinfo.
+        """
+        # Look in _device.sys_info here because self.data is either sys_info or
+        # get_preset_rules depending on whether it's a child device or not.
+        return "brightness" in self._device.sys_info


### PR DESCRIPTION
Fixes issue with ks240 adding module to parent:
```
        == Configuration ==
        Auto update enabled (auto_update_enabled): False
        LED (led): False
        Unable to read value (smooth_transition_on): argument of type 'SmartErrorCode' is not iterable
        Unable to read value (smooth_transition_off): argument of type 'SmartErrorCode' is not iterable
```
Issue https://github.com/python-kasa/python-kasa/issues/970 created to track doing this for all smart modules for better future proofing.