### PR TITLE
Add common energy module and deprecate device emeter attributes

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -19,7 +19,6 @@ from .deviceconfig import (
     DeviceEncryptionType,
     DeviceFamily,
 )
-from .emeterstatus import EmeterStatus
 from .exceptions import KasaException
 from .feature import Feature
 from .iotprotocol import IotProtocol
@@ -324,27 +323,6 @@ class Device(ABC):
         """Return the time that the device was turned on or None if turned off."""
 
     @abstractmethod
-    async def get_emeter_realtime(self) -> EmeterStatus:
-        """Retrieve current energy readings."""
-
-    @property
-    @abstractmethod
-    def emeter_realtime(self) -> EmeterStatus:
-        """Get the emeter status."""
-
-    @property
-    @abstractmethod
-    def emeter_this_month(self) -> float | None:
-        """Get the emeter value for this month."""
-
-    @property
-    @abstractmethod
-    def emeter_today(self) -> float | None | Any:
-        """Get the emeter value for today."""
-        # Return type of Any ensures consumers being shielded from the return
-        # type by @update_required are not affected.
-
-    @abstractmethod
     async def wifi_scan(self) -> list[WifiNetwork]:
         """Scan for available wifi networks."""
 
@@ -378,7 +356,7 @@ class Device(ABC):
 
         for attr in attrs:
             if hasattr(self.modules[module_name], attr):
-                return getattr(self.modules[module_name], attr)
+                return attr
 
         return None
 
@@ -411,6 +389,14 @@ class Device(ABC):
         # light preset attributes
         "presets": (Module.LightPreset, ["_deprecated_presets", "preset_states_list"]),
         "save_preset": (Module.LightPreset, ["_deprecated_save_preset"]),
+        # Emeter attribues
+        "get_emeter_realtime": (Module.Energy, ["get_status"]),
+        "emeter_realtime": (Module.Energy, ["status"]),
+        "emeter_today": (Module.Energy, ["consumption_today"]),
+        "emeter_this_month": (Module.Energy, ["consumption_this_month"]),
+        "current_consumption": (Module.Energy, ["current_consumption"]),
+        "get_emeter_daily": (Module.Energy, ["get_daystat"]),
+        "get_emeter_monthly": (Module.Energy, ["get_monthstat"]),
     }
 
     def __getattr__(self, name):
@@ -433,5 +419,5 @@ class Device(ABC):
                 + f"Module.{module_name} in device.modules instead"
             )
             warn(msg, DeprecationWarning, stacklevel=1)
-            return replacing_attr
+            return getattr(self.modules[module_name], replacing_attr)
         raise AttributeError(f"Device has no attribute {name!r}")

--- a/kasa/interfaces/__init__.py
+++ b/kasa/interfaces/__init__.py
@@ -1,5 +1,6 @@
 """Package for interfaces."""
 
+from .energy import Energy
 from .fan import Fan
 from .led import Led
 from .light import Light, LightState
@@ -8,6 +9,7 @@ from .lightpreset import LightPreset
 
 __all__ = [
     "Fan",
+    "Energy",
     "Led",
     "Light",
     "LightEffect",

--- a/kasa/interfaces/energy.py
+++ b/kasa/interfaces/energy.py
@@ -150,14 +150,14 @@ class Energy(Module, ABC):
         """Erase all stats."""
 
     @abstractmethod
-    async def get_daystat(self, *, year=None, month=None, kwh=True) -> dict:
+    async def get_daily_stats(self, *, year=None, month=None, kwh=True) -> dict:
         """Return daily stats for the given year & month.
 
         The return value is a dictionary of {day: energy, ...}.
         """
 
     @abstractmethod
-    async def get_monthstat(self, *, year=None, kwh=True) -> dict:
+    async def get_monthly_stats(self, *, year=None, kwh=True) -> dict:
         """Return monthly stats for the given year."""
 
     _deprecated_attributes = {
@@ -166,6 +166,8 @@ class Energy(Module, ABC):
         "realtime": "status",
         "get_realtime": "get_status",
         "erase_emeter_stats": "erase_stats",
+        "get_daystat": "get_daily_stats",
+        "get_monthstat": "get_monthly_stats",
     }
 
     def __getattr__(self, name):

--- a/kasa/interfaces/energy.py
+++ b/kasa/interfaces/energy.py
@@ -85,7 +85,7 @@ class Energy(Module, ABC):
                     attribute_getter="current",
                     container=self,
                     unit="A",
-                    id="current_a",
+                    id="current",
                     precision_hint=2,
                     category=Feature.Category.Primary,
                 )

--- a/kasa/interfaces/energy.py
+++ b/kasa/interfaces/energy.py
@@ -25,9 +25,11 @@ class Energy(Module, ABC):
         #: and :meth:`get_monthly_stats`
         PERIODIC_STATS = auto()
 
-    @abstractmethod
+    _supported: ModuleFeature = ModuleFeature(0)
+
     def supports(self, module_feature: ModuleFeature) -> bool:
         """Return True if module supports the feature."""
+        return module_feature in self._supported
 
     def _initialize_features(self):
         """Initialize features."""

--- a/kasa/interfaces/energy.py
+++ b/kasa/interfaces/energy.py
@@ -1,0 +1,176 @@
+"""Module for base energy module."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from warnings import warn
+
+from ..emeterstatus import EmeterStatus
+from ..feature import Feature
+from ..module import Module
+
+
+class Energy(Module, ABC):
+    """Base interface to represent a LED module."""
+
+    def _initialize_features(self):
+        """Initialize features."""
+        device = self._device
+        self._add_feature(
+            Feature(
+                device,
+                name="Current consumption",
+                attribute_getter="current_consumption",
+                container=self,
+                unit="W",
+                id="current_consumption",
+                precision_hint=1,
+                category=Feature.Category.Primary,
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                name="Today's consumption",
+                attribute_getter="consumption_today",
+                container=self,
+                unit="kWh",
+                id="consumption_today",
+                precision_hint=3,
+                category=Feature.Category.Info,
+            )
+        )
+        self._add_feature(
+            Feature(
+                device,
+                id="consumption_this_month",
+                name="This month's consumption",
+                attribute_getter="consumption_this_month",
+                container=self,
+                unit="kWh",
+                precision_hint=3,
+                category=Feature.Category.Info,
+            )
+        )
+        if self.has_total_consumption:
+            self._add_feature(
+                Feature(
+                    device,
+                    name="Total consumption since reboot",
+                    attribute_getter="consumption_total",
+                    container=self,
+                    unit="kWh",
+                    id="consumption_total",
+                    precision_hint=3,
+                    category=Feature.Category.Info,
+                )
+            )
+        if self.has_voltage_current:
+            self._add_feature(
+                Feature(
+                    device,
+                    name="Voltage",
+                    attribute_getter="voltage",
+                    container=self,
+                    unit="V",
+                    id="voltage",
+                    precision_hint=1,
+                    category=Feature.Category.Primary,
+                )
+            )
+            self._add_feature(
+                Feature(
+                    device,
+                    name="Current",
+                    attribute_getter="current",
+                    container=self,
+                    unit="A",
+                    id="current_a",
+                    precision_hint=2,
+                    category=Feature.Category.Primary,
+                )
+            )
+
+    @property
+    @abstractmethod
+    def status(self) -> EmeterStatus:
+        """Return current energy readings."""
+
+    @property
+    @abstractmethod
+    def current_consumption(self) -> float | None:
+        """Get the current power consumption in Watt."""
+
+    @property
+    @abstractmethod
+    def consumption_today(self) -> float | None:
+        """Return today's energy consumption in kWh."""
+
+    @property
+    @abstractmethod
+    def consumption_this_month(self) -> float | None:
+        """Return this month's energy consumption in kWh."""
+
+    @property
+    @abstractmethod
+    def consumption_total(self) -> float | None:
+        """Return total consumption since last reboot in kWh."""
+
+    @property
+    @abstractmethod
+    def current(self) -> float | None:
+        """Return the current in A."""
+
+    @property
+    @abstractmethod
+    def voltage(self) -> float | None:
+        """Get the current voltage in V."""
+
+    @property
+    @abstractmethod
+    def has_voltage_current(self) -> bool:
+        """Return True if the device reports current and voltage."""
+
+    @property
+    @abstractmethod
+    def has_total_consumption(self) -> bool:
+        """Return True if device reports total energy consumption since last reboot."""
+
+    @abstractmethod
+    async def get_status(self):
+        """Return real-time statistics."""
+
+    @property
+    @abstractmethod
+    def has_periodic_stats(self) -> bool:
+        """Return True if device can report statistics for different time periods."""
+
+    @abstractmethod
+    async def erase_stats(self):
+        """Erase all stats."""
+
+    @abstractmethod
+    async def get_daystat(self, *, year=None, month=None, kwh=True) -> dict:
+        """Return daily stats for the given year & month.
+
+        The return value is a dictionary of {day: energy, ...}.
+        """
+
+    @abstractmethod
+    async def get_monthstat(self, *, year=None, kwh=True) -> dict:
+        """Return monthly stats for the given year."""
+
+    _deprecated_attributes = {
+        "emeter_today": "consumption_today",
+        "emeter_this_month": "consumption_this_month",
+        "realtime": "status",
+        "get_realtime": "get_status",
+        "erase_emeter_stats": "erase_stats",
+    }
+
+    def __getattr__(self, name):
+        if attr := self._deprecated_attributes.get(name):
+            msg = f"{name} is deprecated, use {attr} instead"
+            warn(msg, DeprecationWarning, stacklevel=1)
+            return getattr(self, attr)
+        raise AttributeError(f"Energy module has no attribute {name!r}")

--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -220,7 +220,7 @@ class IotBulb(IotDevice):
             Module.IotAntitheft, Antitheft(self, "smartlife.iot.common.anti_theft")
         )
         self.add_module(Module.IotTime, Time(self, "smartlife.iot.common.timesetting"))
-        self.add_module(Module.IotEmeter, Emeter(self, self.emeter_type))
+        self.add_module(Module.Energy, Emeter(self, self.emeter_type))
         self.add_module(Module.IotCountdown, Countdown(self, "countdown"))
         self.add_module(Module.IotCloud, Cloud(self, "smartlife.iot.common.cloud"))
         self.add_module(Module.Light, Light(self, self.LIGHT_SERVICE))

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -274,16 +274,6 @@ class IotDevice(Device):
 
     @property  # type: ignore
     @requires_update
-    def supported_modules(self) -> list[str | ModuleName[Module]]:
-        """Return a set of modules supported by the device."""
-        # TODO: this should rather be called `features`, but we don't want to break
-        #       the API now. Maybe just deprecate it and point the users to use this?
-        if self._supported_modules is None:
-            return []
-        return list(self._supported_modules.keys())
-
-    @property  # type: ignore
-    @requires_update
     def has_emeter(self) -> bool:
         """Return True if device has an energy meter."""
         return "ENE" in self._legacy_features

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Mapping, Sequence, cast
 
 from ..device import Device, WifiNetwork
 from ..deviceconfig import DeviceConfig
-from ..emeterstatus import EmeterStatus
 from ..exceptions import KasaException
 from ..feature import Feature
 from ..module import Module
@@ -188,7 +187,7 @@ class IotDevice(Device):
         super().__init__(host=host, config=config, protocol=protocol)
 
         self._sys_info: Any = None  # TODO: this is here to avoid changing tests
-        self._supported_modules: dict[str, IotModule] | None = None
+        self._supported_modules: dict[str | ModuleName[Module], IotModule] | None = None
         self._legacy_features: set[str] = set()
         self._children: Mapping[str, IotDevice] = {}
         self._modules: dict[str | ModuleName[Module], IotModule] = {}
@@ -199,15 +198,16 @@ class IotDevice(Device):
         return list(self._children.values())
 
     @property
+    @requires_update
     def modules(self) -> ModuleMapping[IotModule]:
         """Return the device modules."""
         if TYPE_CHECKING:
-            return cast(ModuleMapping[IotModule], self._modules)
-        return self._modules
+            return cast(ModuleMapping[IotModule], self._supported_modules)
+        return self._supported_modules
 
     def add_module(self, name: str | ModuleName[Module], module: IotModule):
         """Register a module."""
-        if name in self.modules:
+        if name in self._modules:
             _LOGGER.debug("Module %s already registered, ignoring..." % name)
             return
 
@@ -278,7 +278,9 @@ class IotDevice(Device):
         """Return a set of modules supported by the device."""
         # TODO: this should rather be called `features`, but we don't want to break
         #       the API now. Maybe just deprecate it and point the users to use this?
-        return list(self._modules.keys())
+        if self._supported_modules is None:
+            return []
+        return list(self._supported_modules.keys())
 
     @property  # type: ignore
     @requires_update
@@ -321,6 +323,11 @@ class IotDevice(Device):
 
     async def _initialize_modules(self):
         """Initialize modules not added in init."""
+        if self.has_emeter:
+            _LOGGER.debug(
+                "The device has emeter, querying its information along sysinfo"
+            )
+            self.add_module(Module.Energy, Emeter(self, self.emeter_type))
 
     async def _initialize_features(self):
         """Initialize common features."""
@@ -356,29 +363,13 @@ class IotDevice(Device):
                 )
             )
 
-        for module in self._modules.values():
+        for module in self._supported_modules.values():
             module._initialize_features()
             for module_feat in module._module_features.values():
                 self._add_feature(module_feat)
 
     async def _modular_update(self, req: dict) -> None:
         """Execute an update query."""
-        if self.has_emeter:
-            _LOGGER.debug(
-                "The device has emeter, querying its information along sysinfo"
-            )
-            self.add_module(Module.IotEmeter, Emeter(self, self.emeter_type))
-
-        # TODO: perhaps modules should not have unsupported modules,
-        #  making separate handling for this unnecessary
-        if self._supported_modules is None:
-            supported = {}
-            for module in self._modules.values():
-                if module.is_supported:
-                    supported[module._module] = module
-
-            self._supported_modules = supported
-
         request_list = []
         est_response_size = 1024 if "system" in req else 0
         for module in self._modules.values():
@@ -409,6 +400,15 @@ class IotDevice(Device):
         for response in responses:
             update = {**update, **response}
         self._last_update = update
+
+        # IOT modules are added as default but could be unsupported post first update
+        if self._supported_modules is None:
+            supported = {}
+            for module_name, module in self._modules.items():
+                if module.is_supported:
+                    supported[module_name] = module
+
+            self._supported_modules = supported
 
     def update_from_discover_info(self, info: dict[str, Any]) -> None:
         """Update state from info from the discover call."""
@@ -555,74 +555,6 @@ class IotDevice(Device):
         :param str mac: mac in hexadecimal with colons, e.g. 01:23:45:67:89:ab
         """
         return await self._query_helper("system", "set_mac_addr", {"mac": mac})
-
-    @property
-    @requires_update
-    def emeter_realtime(self) -> EmeterStatus:
-        """Return current energy readings."""
-        self._verify_emeter()
-        return EmeterStatus(self.modules[Module.IotEmeter].realtime)
-
-    async def get_emeter_realtime(self) -> EmeterStatus:
-        """Retrieve current energy readings."""
-        self._verify_emeter()
-        return EmeterStatus(await self.modules[Module.IotEmeter].get_realtime())
-
-    @property
-    @requires_update
-    def emeter_today(self) -> float | None:
-        """Return today's energy consumption in kWh."""
-        self._verify_emeter()
-        return self.modules[Module.IotEmeter].emeter_today
-
-    @property
-    @requires_update
-    def emeter_this_month(self) -> float | None:
-        """Return this month's energy consumption in kWh."""
-        self._verify_emeter()
-        return self.modules[Module.IotEmeter].emeter_this_month
-
-    async def get_emeter_daily(
-        self, year: int | None = None, month: int | None = None, kwh: bool = True
-    ) -> dict:
-        """Retrieve daily statistics for a given month.
-
-        :param year: year for which to retrieve statistics (default: this year)
-        :param month: month for which to retrieve statistics (default: this
-                      month)
-        :param kwh: return usage in kWh (default: True)
-        :return: mapping of day of month to value
-        """
-        self._verify_emeter()
-        return await self.modules[Module.IotEmeter].get_daystat(
-            year=year, month=month, kwh=kwh
-        )
-
-    @requires_update
-    async def get_emeter_monthly(
-        self, year: int | None = None, kwh: bool = True
-    ) -> dict:
-        """Retrieve monthly statistics for a given year.
-
-        :param year: year for which to retrieve statistics (default: this year)
-        :param kwh: return usage in kWh (default: True)
-        :return: dict: mapping of month to value
-        """
-        self._verify_emeter()
-        return await self.modules[Module.IotEmeter].get_monthstat(year=year, kwh=kwh)
-
-    @requires_update
-    async def erase_emeter_stats(self) -> dict:
-        """Erase energy meter statistics."""
-        self._verify_emeter()
-        return await self.modules[Module.IotEmeter].erase_stats()
-
-    @requires_update
-    async def current_consumption(self) -> float:
-        """Get the current power consumption in Watt."""
-        self._verify_emeter()
-        response = self.emeter_realtime
-        return float(response["power"])
 
     async def reboot(self, delay: int = 1) -> None:
         """Reboot the device.

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -166,9 +166,15 @@ class IotStrip(IotDevice):
 class StripEmeter(IotModule, Energy):
     """Energy module implementation to aggregate child modules."""
 
-    def __init__(self, device: IotStrip, module: str):
-        super().__init__(device, module)
-        self._device = device
+    _supported = (
+        Energy.ModuleFeature.CONSUMPTION_TOTAL
+        | Energy.ModuleFeature.PERIODIC_STATS
+        | Energy.ModuleFeature.VOLTAGE_CURRENT
+    )
+
+    def supports(self, module_feature: Energy.ModuleFeature) -> bool:
+        """Return True if module supports the feature."""
+        return self._supported & module_feature == module_feature
 
     def query(self):
         """Return the base query."""
@@ -228,11 +234,6 @@ class StripEmeter(IotModule, Energy):
             ]
         )
 
-    @property
-    def has_periodic_stats(self) -> bool:
-        """Return True if device can report statistics for different time periods."""
-        return True
-
     async def erase_stats(self):
         """Erase energy meter statistics for all plugs."""
         for plug in self._device.children:
@@ -282,16 +283,6 @@ class StripEmeter(IotModule, Energy):
     def voltage(self) -> float | None:
         """Get the current voltage in V."""
         return self.status.voltage
-
-    @property
-    def has_voltage_current(self) -> bool:
-        """Return True if the device reports current and voltage."""
-        return True
-
-    @property
-    def has_total_consumption(self) -> bool:
-        """Return True if device reports total energy consumption since last reboot."""
-        return True
 
 
 class IotStripPlug(IotPlug):

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -192,7 +192,7 @@ class StripEmeter(IotModule, Energy):
         )
         return EmeterStatus(emeter_rt)
 
-    async def get_daystat(
+    async def get_daily_stats(
         self, year: int | None = None, month: int | None = None, kwh: bool = True
     ) -> dict:
         """Retrieve daily statistics for a given month.
@@ -204,17 +204,19 @@ class StripEmeter(IotModule, Energy):
         :return: mapping of day of month to value
         """
         return await self._async_get_emeter_sum(
-            "get_daystat", {"year": year, "month": month, "kwh": kwh}
+            "get_daily_stats", {"year": year, "month": month, "kwh": kwh}
         )
 
-    async def get_monthstat(self, year: int | None = None, kwh: bool = True) -> dict:
+    async def get_monthly_stats(
+        self, year: int | None = None, kwh: bool = True
+    ) -> dict:
         """Retrieve monthly statistics for a given year.
 
         :param year: year for which to retrieve statistics (default: this year)
         :param kwh: return usage in kWh (default: True)
         """
         return await self._async_get_emeter_sum(
-            "get_monthstat", {"year": year, "kwh": kwh}
+            "get_monthly_stats", {"year": year, "kwh": kwh}
         )
 
     async def _async_get_emeter_sum(self, func: str, kwargs: dict[str, Any]) -> dict:

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -145,6 +145,16 @@ class IotStrip(IotDevice):
             for plug in self.children:
                 await plug.update()
 
+        if not self.features:
+            await self._initialize_features()
+
+    async def _initialize_features(self):
+        """Initialize common features."""
+        # Do not initialize features until children are created
+        if not self.children:
+            return
+        await super()._initialize_features()
+
     async def turn_on(self, **kwargs):
         """Turn the strip on."""
         await self._query_helper("system", "set_relay_state", {"state": 1})
@@ -174,7 +184,7 @@ class StripEmeter(IotModule, Energy):
 
     def supports(self, module_feature: Energy.ModuleFeature) -> bool:
         """Return True if module supports the feature."""
-        return self._supported & module_feature == module_feature
+        return module_feature in self._supported
 
     def query(self):
         """Return the base query."""

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -27,7 +27,7 @@ class Emeter(Usage, EnergyInterface):
         raw_data = self.daily_data
         today = datetime.now().day
         data = self._convert_stat_data(raw_data, entry_key="day", key=today)
-        return data.get(today)
+        return data.get(today, 0.0)
 
     @property
     def consumption_this_month(self) -> float | None:
@@ -35,7 +35,7 @@ class Emeter(Usage, EnergyInterface):
         raw_data = self.monthly_data
         current_month = datetime.now().month
         data = self._convert_stat_data(raw_data, entry_key="month", key=current_month)
-        return data.get(current_month)
+        return data.get(current_month, 0.0)
 
     @property
     def current_consumption(self) -> float | None:

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -83,7 +83,7 @@ class Emeter(Usage, EnergyInterface):
         """Return real-time statistics."""
         return EmeterStatus(await self.call("get_realtime"))
 
-    async def get_daystat(self, *, year=None, month=None, kwh=True) -> dict:
+    async def get_daily_stats(self, *, year=None, month=None, kwh=True) -> dict:
         """Return daily stats for the given year & month.
 
         The return value is a dictionary of {day: energy, ...}.
@@ -92,7 +92,7 @@ class Emeter(Usage, EnergyInterface):
         data = self._convert_stat_data(data["day_list"], entry_key="day", kwh=kwh)
         return data
 
-    async def get_monthstat(self, *, year=None, kwh=True) -> dict:
+    async def get_monthly_stats(self, *, year=None, kwh=True) -> dict:
         """Return monthly stats for the given year.
 
         The return value is a dictionary of {month: energy, ...}.

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -12,15 +12,22 @@ from .usage import Usage
 class Emeter(Usage, EnergyInterface):
     """Emeter module."""
 
-    _supported = (
-        EnergyInterface.ModuleFeature.CONSUMPTION_TOTAL
-        | EnergyInterface.ModuleFeature.PERIODIC_STATS
-        | EnergyInterface.ModuleFeature.VOLTAGE_CURRENT
-    )
-
-    def supports(self, module_feature: EnergyInterface.ModuleFeature) -> bool:
-        """Return True if module supports the feature."""
-        return self._supported & module_feature == module_feature
+    def _post_update_hook(self) -> None:
+        self._supported = EnergyInterface.ModuleFeature.PERIODIC_STATS
+        if (
+            "voltage_mv" in self.data["get_realtime"]
+            or "voltage" in self.data["get_realtime"]
+        ):
+            self._supported = (
+                self._supported | EnergyInterface.ModuleFeature.VOLTAGE_CURRENT
+            )
+        if (
+            "total_wh" in self.data["get_realtime"]
+            or "total" in self.data["get_realtime"]
+        ):
+            self._supported = (
+                self._supported | EnergyInterface.ModuleFeature.CONSUMPTION_TOTAL
+            )
 
     @property  # type: ignore
     def status(self) -> EmeterStatus:

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from ... import Device
 from ...emeterstatus import EmeterStatus
 from ...interfaces.energy import Energy as EnergyInterface
 from .usage import Usage
@@ -13,8 +12,15 @@ from .usage import Usage
 class Emeter(Usage, EnergyInterface):
     """Emeter module."""
 
-    def __init__(self, device: Device, module: str):
-        super().__init__(device, module)
+    _supported = (
+        EnergyInterface.ModuleFeature.CONSUMPTION_TOTAL
+        | EnergyInterface.ModuleFeature.PERIODIC_STATS
+        | EnergyInterface.ModuleFeature.VOLTAGE_CURRENT
+    )
+
+    def supports(self, module_feature: EnergyInterface.ModuleFeature) -> bool:
+        """Return True if module supports the feature."""
+        return self._supported & module_feature == module_feature
 
     @property  # type: ignore
     def status(self) -> EmeterStatus:
@@ -56,21 +62,6 @@ class Emeter(Usage, EnergyInterface):
     def voltage(self) -> float | None:
         """Get the current voltage in V."""
         return self.status.voltage
-
-    @property
-    def has_voltage_current(self) -> bool:
-        """Return True if the device reports current and voltage."""
-        return True
-
-    @property
-    def has_total_consumption(self) -> bool:
-        """Return True if device reports total energy consumption since last reboot."""
-        return True
-
-    @property
-    def has_periodic_stats(self) -> bool:
-        """Return True if device can report statistics for different time periods."""
-        return True
 
     async def erase_stats(self):
         """Erase all stats.

--- a/kasa/iot/modules/led.py
+++ b/kasa/iot/modules/led.py
@@ -30,3 +30,8 @@ class Led(IotModule, LedInterface):
     async def set_led(self, state: bool):
         """Set the state of the led (night mode)."""
         return await self.call("set_led_off", {"off": int(not state)})
+
+    @property
+    def is_supported(self) -> bool:
+        """Return whether the module is supported by the device."""
+        return "led_off" in self.data

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -33,6 +33,8 @@ class Module(ABC):
     """
 
     # Common Modules
+    Energy: Final[ModuleName[interfaces.Energy]] = ModuleName("Energy")
+    Fan: Final[ModuleName[interfaces.Fan]] = ModuleName("Fan")
     LightEffect: Final[ModuleName[interfaces.LightEffect]] = ModuleName("LightEffect")
     Led: Final[ModuleName[interfaces.Led]] = ModuleName("Led")
     Light: Final[ModuleName[interfaces.Light]] = ModuleName("Light")
@@ -42,7 +44,6 @@ class Module(ABC):
     IotAmbientLight: Final[ModuleName[iot.AmbientLight]] = ModuleName("ambient")
     IotAntitheft: Final[ModuleName[iot.Antitheft]] = ModuleName("anti_theft")
     IotCountdown: Final[ModuleName[iot.Countdown]] = ModuleName("countdown")
-    IotEmeter: Final[ModuleName[iot.Emeter]] = ModuleName("emeter")
     IotMotion: Final[ModuleName[iot.Motion]] = ModuleName("motion")
     IotSchedule: Final[ModuleName[iot.Schedule]] = ModuleName("schedule")
     IotUsage: Final[ModuleName[iot.Usage]] = ModuleName("usage")
@@ -62,8 +63,6 @@ class Module(ABC):
     )
     ContactSensor: Final[ModuleName[smart.ContactSensor]] = ModuleName("ContactSensor")
     DeviceModule: Final[ModuleName[smart.DeviceModule]] = ModuleName("DeviceModule")
-    Energy: Final[ModuleName[smart.Energy]] = ModuleName("Energy")
-    Fan: Final[ModuleName[smart.Fan]] = ModuleName("Fan")
     Firmware: Final[ModuleName[smart.Firmware]] = ModuleName("Firmware")
     FrostProtection: Final[ModuleName[smart.FrostProtection]] = ModuleName(
         "FrostProtection"

--- a/kasa/smart/modules/energy.py
+++ b/kasa/smart/modules/energy.py
@@ -18,6 +18,10 @@ class Energy(SmartModule, EnergyInterface):
 
     REQUIRED_COMPONENT = "energy_monitoring"
 
+    def supports(self, module_feature: EnergyInterface.ModuleFeature) -> bool:
+        """Return True if module supports the feature."""
+        return False
+
     def query(self) -> dict:
         """Query to execute during the update cycle."""
         req = {
@@ -84,24 +88,9 @@ class Energy(SmartModule, EnergyInterface):
         """Get the current voltage in V."""
         return None
 
-    @property
-    def has_voltage_current(self) -> bool:
-        """Return True if the device reports current and voltage."""
-        return False
-
-    @property
-    def has_total_consumption(self) -> bool:
-        """Return True if device reports total energy consumption since last reboot."""
-        return False
-
     async def _deprecated_get_realtime(self) -> EmeterStatus:
         """Retrieve current energy readings."""
         return self.status
-
-    @property
-    def has_periodic_stats(self) -> bool:
-        """Return True if device can report statistics for different time periods."""
-        return False
 
     async def erase_stats(self):
         """Erase all stats."""

--- a/kasa/smart/modules/energy.py
+++ b/kasa/smart/modules/energy.py
@@ -30,7 +30,7 @@ class Energy(SmartModule, EnergyInterface):
     @property
     def current_consumption(self) -> float | None:
         """Current power in watts."""
-        if power := self.energy.get("current_power"):
+        if (power := self.energy.get("current_power")) is not None:
             return power / 1_000
         return None
 
@@ -61,13 +61,13 @@ class Energy(SmartModule, EnergyInterface):
 
     @property
     def consumption_this_month(self) -> float | None:
-        """Get the emeter value for this month."""
-        return self.energy.get("month_energy")
+        """Get the emeter value for this month in kWh."""
+        return self.energy.get("month_energy") / 1_000
 
     @property
     def consumption_today(self) -> float | None:
-        """Get the emeter value for today."""
-        return self.energy.get("today_energy")
+        """Get the emeter value for today in kWh."""
+        return self.energy.get("today_energy") / 1_000
 
     @property
     def consumption_total(self) -> float | None:
@@ -107,13 +107,13 @@ class Energy(SmartModule, EnergyInterface):
         """Erase all stats."""
         raise KasaException("Device does not support periodic statistics")
 
-    async def get_daystat(self, *, year=None, month=None, kwh=True) -> dict:
+    async def get_daily_stats(self, *, year=None, month=None, kwh=True) -> dict:
         """Return daily stats for the given year & month.
 
         The return value is a dictionary of {day: energy, ...}.
         """
         raise KasaException("Device does not support periodic statistics")
 
-    async def get_monthstat(self, *, year=None, kwh=True) -> dict:
+    async def get_monthly_stats(self, *, year=None, kwh=True) -> dict:
         """Return monthly stats for the given year."""
         raise KasaException("Device does not support periodic statistics")

--- a/kasa/smart/modules/energy.py
+++ b/kasa/smart/modules/energy.py
@@ -2,25 +2,16 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from ...emeterstatus import EmeterStatus
 from ...exceptions import KasaException
 from ...interfaces.energy import Energy as EnergyInterface
 from ..smartmodule import SmartModule
-
-if TYPE_CHECKING:
-    pass
 
 
 class Energy(SmartModule, EnergyInterface):
     """Implementation of energy monitoring module."""
 
     REQUIRED_COMPONENT = "energy_monitoring"
-
-    def supports(self, module_feature: EnergyInterface.ModuleFeature) -> bool:
-        """Return True if module supports the feature."""
-        return False
 
     def query(self) -> dict:
         """Query to execute during the update cycle."""

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -11,7 +11,6 @@ from ..aestransport import AesTransport
 from ..device import Device, WifiNetwork
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
-from ..emeterstatus import EmeterStatus
 from ..exceptions import AuthenticationError, DeviceError, KasaException, SmartErrorCode
 from ..feature import Feature
 from ..module import Module
@@ -463,31 +462,6 @@ class SmartDevice(Device):
         """Update state from info from the discover call."""
         self._discovery_info = info
         self._info = info
-
-    async def get_emeter_realtime(self) -> EmeterStatus:
-        """Retrieve current energy readings."""
-        _LOGGER.warning("Deprecated, use `emeter_realtime`.")
-        if not self.has_emeter:
-            raise KasaException("Device has no emeter")
-        return self.emeter_realtime
-
-    @property
-    def emeter_realtime(self) -> EmeterStatus:
-        """Get the emeter status."""
-        energy = self.modules[Module.Energy]
-        return energy.emeter_realtime
-
-    @property
-    def emeter_this_month(self) -> float | None:
-        """Get the emeter value for this month."""
-        energy = self.modules[Module.Energy]
-        return energy.emeter_this_month
-
-    @property
-    def emeter_today(self) -> float | None:
-        """Get the emeter value for today."""
-        energy = self.modules[Module.Energy]
-        return energy.emeter_today
 
     @property
     def on_since(self) -> datetime | None:

--- a/kasa/tests/test_device.py
+++ b/kasa/tests/test_device.py
@@ -163,12 +163,7 @@ async def _test_attribute(
     if is_expected and will_raise:
         ctx = pytest.raises(will_raise)
     elif is_expected:
-        ctx = pytest.deprecated_call(
-            match=(
-                f"{attribute_name} is deprecated, use: Module."
-                + f"{module_name} in device.modules instead"
-            )
-        )
+        ctx = pytest.deprecated_call(match=(f"{attribute_name} is deprecated, use:"))
     else:
         ctx = pytest.raises(
             AttributeError, match=f"Device has no attribute '{attribute_name}'"
@@ -239,6 +234,19 @@ async def test_deprecated_other_attributes(dev: Device):
 
     await _test_attribute(dev, "led", bool(led_module), "Led")
     await _test_attribute(dev, "set_led", bool(led_module), "Led", True)
+    await _test_attribute(dev, "supported_modules", True, None)
+
+
+async def test_deprecated_emeter_attributes(dev: Device):
+    energy_module = dev.modules.get(Module.Energy)
+
+    await _test_attribute(dev, "get_emeter_realtime", bool(energy_module), "Energy")
+    await _test_attribute(dev, "emeter_realtime", bool(energy_module), "Energy")
+    await _test_attribute(dev, "emeter_today", bool(energy_module), "Energy")
+    await _test_attribute(dev, "emeter_this_month", bool(energy_module), "Energy")
+    await _test_attribute(dev, "current_consumption", bool(energy_module), "Energy")
+    await _test_attribute(dev, "get_emeter_daily", bool(energy_module), "Energy")
+    await _test_attribute(dev, "get_emeter_monthly", bool(energy_module), "Energy")
 
 
 async def test_deprecated_light_preset_attributes(dev: Device):

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -10,7 +10,7 @@ from voluptuous import (
     Schema,
 )
 
-from kasa import EmeterStatus, KasaException
+from kasa import EmeterStatus
 from kasa.iot import IotDevice
 from kasa.iot.modules.emeter import Emeter
 
@@ -47,7 +47,7 @@ async def test_no_emeter(dev):
             await dev.get_emeter_daily()
         with pytest.raises(AttributeError):
             await dev.get_emeter_monthly()
-        with pytest.raises(KasaException):
+        with pytest.raises(AttributeError):
             await dev.erase_emeter_stats()
 
 
@@ -99,7 +99,7 @@ async def test_get_emeter_monthly(dev):
     assert v * 1000 == v2
 
 
-@has_emeter
+@has_emeter_iot
 async def test_emeter_status(dev):
     assert dev.has_emeter
 

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -38,14 +38,14 @@ CURRENT_CONSUMPTION_SCHEMA = Schema(
 async def test_no_emeter(dev):
     assert not dev.has_emeter
 
-    with pytest.raises(KasaException):
+    with pytest.raises(AttributeError):
         await dev.get_emeter_realtime()
     # Only iot devices support the historical stats so other
     # devices will not implement the methods below
     if isinstance(dev, IotDevice):
-        with pytest.raises(KasaException):
+        with pytest.raises(AttributeError):
             await dev.get_emeter_daily()
-        with pytest.raises(KasaException):
+        with pytest.raises(AttributeError):
             await dev.get_emeter_monthly()
         with pytest.raises(KasaException):
             await dev.erase_emeter_stats()
@@ -99,7 +99,7 @@ async def test_get_emeter_monthly(dev):
     assert v * 1000 == v2
 
 
-@has_emeter_iot
+@has_emeter
 async def test_emeter_status(dev):
     assert dev.has_emeter
 
@@ -128,11 +128,11 @@ async def test_erase_emeter_stats(dev):
 @has_emeter_iot
 async def test_current_consumption(dev):
     if dev.has_emeter:
-        x = await dev.current_consumption()
+        x = dev.current_consumption
         assert isinstance(x, float)
         assert x >= 0.0
     else:
-        assert await dev.current_consumption() is None
+        assert dev.current_consumption is None
 
 
 async def test_emeterstatus_missing_current():

--- a/kasa/tests/test_iotdevice.py
+++ b/kasa/tests/test_iotdevice.py
@@ -116,9 +116,16 @@ async def test_initial_update_no_emeter(dev, mocker):
     dev._legacy_features = set()
     spy = mocker.spy(dev.protocol, "query")
     await dev.update()
-    # 2 calls are necessary as some devices crash on unexpected modules
+    # child calls will happen if a child has a module with a query (e.g. schedule)
+    child_calls = 0
+    for child in dev.children:
+        for module in child.modules.values():
+            if module.query():
+                child_calls += 1
+                break
+    # 2 parent are necessary as some devices crash on unexpected modules
     # See #105, #120, #161
-    assert spy.call_count == 2
+    assert spy.call_count == 2 + child_calls
 
 
 @device_iot


### PR DESCRIPTION
Decided to bite the bullet on this as it was starting to make the HR PR less simple.  Minimal changes to tests which should be reassuring.

Tested with `iot` hs300.