### PR TITLE
Run CI lint&tests only on python changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,12 @@ name: CI
 on:
   push:
     branches: ["master"]
+    paths:
+      - '**.py'
   pull_request:
     branches: ["master"]
+    paths:
+      - '**.py'
   workflow_dispatch:  # to allow manual re-runs
 
 env:


### PR DESCRIPTION
There is no need to run the whole CI if no code files are changed, e.g., as a part of the release preparations.
If needed in the future, we could have separate CI for doc/markdown changes.