### PR TITLE
Remove anyio dependency from pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2185,4 +2185,4 @@ speedups = ["kasa-crypt", "orjson"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "871ef421fe7d48608bcea18b4c41d8bb368e84d74bf7b29db832dc97c5b980ae"
+content-hash = "f8edc1401028d0654bd4622bf471668dd84b323434f0fa40e783e5c9b45511f6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ kasa = "kasa.cli:cli"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-anyio = "*"  # see https://github.com/python-trio/asyncclick/issues/18
-asyncclick = ">=8"
+asyncclick = ">=8.1.7"
 pydantic = ">=1.10.15"
 cryptography = ">=1.9"
 async-timeout = ">=3.0.0"


### PR DESCRIPTION
This is no longer required as it's correctly configured in [async click release 8.1.7.1](https://pypi.org/project/asyncclick/8.1.7.1/) released in January. 
 Fixed in https://github.com/python-trio/asyncclick/pull/27