### PR TITLE
Add unit_getter for feature

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -99,7 +99,7 @@ class Feature:
         Choice = auto()
         Unknown = -1
 
-    # TODO: unsure if this is a great idea..
+    # Aliases for easy access
     Sensor = Type.Sensor
     BinarySensor = Type.BinarySensor
     Switch = Type.Switch
@@ -139,6 +139,9 @@ class Feature:
     icon: str | None = None
     #: Unit, if applicable
     unit: str | None = None
+    #: Attribute containing the name of the unit getter property.
+    #: If set, this property will be used to set *unit*.
+    unit_getter: str | None = None
     #: Category hint for downstreams
     category: Feature.Category = Category.Unset
     #: Type of the feature
@@ -176,6 +179,10 @@ class Feature:
         # Populate choices, if choices_getter is given
         if self.choices_getter is not None:
             self.choices = getattr(container, self.choices_getter)
+
+        # Populate unit, if unit_getter is given
+        if self.unit_getter is not None:
+            self.unit = getattr(container, self.unit_getter)
 
         # Set the category, if unset
         if self.category is Feature.Category.Unset:

--- a/kasa/smart/modules/temperaturesensor.py
+++ b/kasa/smart/modules/temperaturesensor.py
@@ -28,6 +28,7 @@ class TemperatureSensor(SmartModule):
                 attribute_getter="temperature",
                 icon="mdi:thermometer",
                 category=Feature.Category.Primary,
+                unit_getter="temperature_unit",
             )
         )
         if "current_temp_exception" in device.sys_info:
@@ -55,7 +56,6 @@ class TemperatureSensor(SmartModule):
                 choices=["celsius", "fahrenheit"],
             )
         )
-        # TODO: use temperature_unit for feature creation
 
     @property
     def temperature(self):
@@ -68,7 +68,7 @@ class TemperatureSensor(SmartModule):
         return self._device.sys_info.get("current_temp_exception", 0) != 0
 
     @property
-    def temperature_unit(self):
+    def temperature_unit(self) -> Literal["celsius", "fahrenheit"]:
         """Return current temperature unit."""
         return self._device.sys_info["temp_unit"]
 


### PR DESCRIPTION
Allow defining getter for unit, necessary to set the correct unit based on device responses.

![image](https://github.com/python-kasa/python-kasa/assets/3705853/e404e944-5e3c-48c6-bb8e-e43977484a7c)


TBD:
- [x] Tests
- [x] ~~Add indirection to allow changeable units?~~not necessary for now

Fixes #923