### PR TITLE
Demote device_time back to debug

### DIFF
--- a/kasa/smart/modules/time.py
+++ b/kasa/smart/modules/time.py
@@ -29,7 +29,7 @@ class Time(SmartModule):
                 name="Device time",
                 attribute_getter="time",
                 container=self,
-                category=Feature.Category.Info,
+                category=Feature.Category.Debug,
             )
         )
 


### PR DESCRIPTION
This hides it from the entities enabled by default for HA.