### PR TITLE
Fix smart led status to report rule status

### DIFF
--- a/kasa/smart/modules/led.py
+++ b/kasa/smart/modules/led.py
@@ -27,7 +27,7 @@ class Led(SmartModule, LedInterface):
     @property
     def led(self):
         """Return current led status."""
-        return self.data["led_status"]
+        return self.data["led_rule"] != "never"
 
     async def set_led(self, enable: bool):
         """Set led.

--- a/kasa/tests/test_cli.py
+++ b/kasa/tests/test_cli.py
@@ -890,7 +890,7 @@ async def test_feature_set(mocker, runner):
     )
 
     led_setter.assert_called_with(True)
-    assert "Changing led from False to True" in res.output
+    assert "Changing led from True to True" in res.output
     assert res.exit_code == 0
 
 


### PR DESCRIPTION
The behaviour of the led on most smart devices when set to "always" is:
- the led is on if the device is on
- the led is off if the device is off

It appears to be different for wall switches where the led is on/off if always/never respectively.

This PR changes the reporting of the state to match the setter which sets the rule to `always` or `never`. Will open a new issue to improve the shared interface to include the mode and determine whether the status is read only or not.