### PR TITLE
Fix post update hook for iot child devices

### DIFF
--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -360,6 +360,9 @@ class IotStripPlug(IotPlug):
         Needed for properties that are decorated with `requires_update`.
         """
         await self._modular_update({})
+        for module in self._modules.values():
+            module._post_update_hook()
+
         if not self._features:
             await self._initialize_features()
 

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -21,7 +21,7 @@ from .iotdevice import (
 )
 from .iotmodule import IotModule
 from .iotplug import IotPlug
-from .modules import Antitheft, Countdown, Schedule, Time, Usage
+from .modules import Antitheft, Cloud, Countdown, Emeter, Led, Schedule, Time, Usage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -107,6 +107,8 @@ class IotStrip(IotDevice):
         self.add_module(Module.IotUsage, Usage(self, "schedule"))
         self.add_module(Module.IotTime, Time(self, "time"))
         self.add_module(Module.IotCountdown, Countdown(self, "countdown"))
+        self.add_module(Module.Led, Led(self, "system"))
+        self.add_module(Module.IotCloud, Cloud(self, "cnCloud"))
         if self.has_emeter:
             _LOGGER.debug(
                 "The device has emeter, querying its information along sysinfo"
@@ -317,8 +319,12 @@ class IotStripPlug(IotPlug):
 
     async def _initialize_modules(self):
         """Initialize modules not added in init."""
-        await super()._initialize_modules()
-        self.add_module("time", Time(self, "time"))
+        if self.has_emeter:
+            self.add_module(Module.Energy, Emeter(self, self.emeter_type))
+        self.add_module(Module.IotUsage, Usage(self, "schedule"))
+        self.add_module(Module.IotAntitheft, Antitheft(self, "anti_theft"))
+        self.add_module(Module.IotSchedule, Schedule(self, "schedule"))
+        self.add_module(Module.IotCountdown, Countdown(self, "countdown"))
 
     async def _initialize_features(self):
         """Initialize common features."""

--- a/kasa/tests/test_strip.py
+++ b/kasa/tests/test_strip.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 import pytest
 
-from kasa import KasaException
+from kasa import Device, KasaException, Module
 from kasa.iot import IotStrip
 
-from .conftest import handle_turn_on, strip, turn_on
+from .conftest import handle_turn_on, strip, strip_iot, turn_on
 
 
 @strip
@@ -147,3 +147,16 @@ def test_children_api(dev):
     first = dev.children[0]
     first_by_get_child_device = dev.get_child_device(first.device_id)
     assert first == first_by_get_child_device
+
+
+@strip_iot
+async def test_children_energy(dev: Device):
+    if Module.Energy not in dev.modules:
+        pytest.skip(f"skipping device {dev.model} does not support energy")
+
+    for plug in dev.children:
+        # For now all known strips with energy support these
+        energy = plug.modules[Module.Energy]
+        assert "voltage" in energy._module_features
+        assert "current" in energy._module_features
+        assert "current_consumption" in energy._module_features


### PR DESCRIPTION
`_post_update_hook` not being called on child `iot` devices, causing missing emeter features for children