### PR TITLE
Disable lighttransition module on child devices

### DIFF
--- a/kasa/smart/modules/lighttransition.py
+++ b/kasa/smart/modules/lighttransition.py
@@ -183,11 +183,9 @@ class LightTransition(SmartModule):
             return {self.QUERY_GETTER_NAME: None}
 
     async def _check_supported(self):
-        """Additional check to see if the module is supported by the device.
-
-        Parent devices that report components of children such as ks240 will not have
-        the brightness value is sysinfo.
-        """
-        # Look in _device.sys_info here because self.data is either sys_info or
-        # get_preset_rules depending on whether it's a child device or not.
+        """Additional check to see if the module is supported by the device."""
+        # TODO Temporarily disabled on child light devices until module fixed
+        # to support updates
+        if self._device._parent is not None:
+            return False
         return "brightness" in self._device.sys_info


### PR DESCRIPTION
Module is not working properly for updates on KS240 so temporarily disable until fixed