### PR TITLE
Handle unknown error codes gracefully

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -140,7 +140,13 @@ class AesTransport(BaseTransport):
         return un, pw
 
     def _handle_response_error_code(self, resp_dict: Any, msg: str) -> None:
-        error_code = SmartErrorCode(resp_dict.get("error_code"))  # type: ignore[arg-type]
+        error_code_raw = resp_dict.get("error_code")
+        try:
+            error_code = SmartErrorCode(error_code_raw)  # type: ignore[arg-type]
+        except ValueError:
+            _LOGGER.warning("Received unknown error code: %s", error_code_raw)
+            error_code = SmartErrorCode.INTERNAL_UNKNOWN_ERROR
+
         if error_code == SmartErrorCode.SUCCESS:
             return
         msg = f"{msg}: {self._host}: {error_code.name}({error_code.value})"

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -119,6 +119,9 @@ class SmartErrorCode(IntEnum):
     DST_ERROR = -2301
     DST_SAVE_ERROR = -2302
 
+    # Library internal for unknown error codes
+    UNKNOWN_ERROR = -100_000
+
 
 SMART_RETRYABLE_ERRORS = [
     SmartErrorCode.TRANSPORT_NOT_AVAILABLE_ERROR,

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -120,7 +120,7 @@ class SmartErrorCode(IntEnum):
     DST_SAVE_ERROR = -2302
 
     # Library internal for unknown error codes
-    UNKNOWN_ERROR = -100_000
+    INTERNAL_UNKNOWN_ERROR = -100_000
 
 
 SMART_RETRYABLE_ERRORS = [

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -244,7 +244,7 @@ class SmartProtocol(BaseProtocol):
             error_code = SmartErrorCode(error_code_raw)  # type: ignore[arg-type]
         except ValueError:
             _LOGGER.warning("Received unknown error code: %s", error_code_raw)
-            error_code = SmartErrorCode.UNKNOWN_ERROR
+            error_code = SmartErrorCode.INTERNAL_UNKNOWN_ERROR
 
         if error_code == SmartErrorCode.SUCCESS:
             return

--- a/kasa/tests/test_smartprotocol.py
+++ b/kasa/tests/test_smartprotocol.py
@@ -48,7 +48,7 @@ async def test_smart_device_unknown_errors(
 
     with pytest.raises(KasaException):
         res = await dummy_protocol.query(DUMMY_QUERY)
-        assert res is SmartErrorCode.UNKNOWN_ERROR
+        assert res is SmartErrorCode.INTERNAL_UNKNOWN_ERROR
 
     send_mock.assert_called_once()
     assert f"Received unknown error code: {error_code}" in caplog.text


### PR DESCRIPTION
Makes unknown error codes to be reported through KasaException which may be recoverable in some cases (i.e., a single command failing in the multi request).

Related to https://github.com/home-assistant/core/issues/118446