### PR TITLE
Make calling update on child devices consistent and give control over whether to update the parent

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -233,7 +233,7 @@ class Device(ABC):
         return await connect(host=host, config=config)  # type: ignore[arg-type]
 
     @abstractmethod
-    async def update(self, update_children: bool = True):
+    async def update(self, update_children: bool = True, update_parent: bool = True):
         """Update the device."""
 
     async def disconnect(self):

--- a/kasa/smart/smartchilddevice.py
+++ b/kasa/smart/smartchilddevice.py
@@ -19,6 +19,8 @@ class SmartChildDevice(SmartDevice):
     This wraps the protocol communications and sets internal data for the child.
     """
 
+    _parent: SmartDevice
+
     def __init__(
         self,
         parent: SmartDevice,
@@ -34,12 +36,26 @@ class SmartChildDevice(SmartDevice):
         self._id = info["device_id"]
         self.protocol = _ChildProtocolWrapper(self._id, parent.protocol)
 
-    async def update(self, update_children: bool = True):
+    async def update(self, update_children: bool = True, update_parent: bool = True):
+        """Update the device.
+
+        Calling update directly on a child device will update the parent
+        and only this child.
+        """
+        if update_parent:
+            await self._parent._update(update_children=False, called_from_child=self)
+        else:
+            await self._update()
+
+    async def _update(self):
         """Update child module info.
 
         The parent updates our internal info so just update modules with
         their own queries.
         """
+        # Hubs attached devices only update via the parent hub
+        if self._parent.device_type == DeviceType.Hub:
+            return
         req: dict[str, Any] = {}
         for module in self.modules.values():
             if mod_query := module.query():


### PR DESCRIPTION
This PR is normalising the behaviour of `update` across `iot` and `smart` devices such that:
 - `update` can be called by consumers on child devices without them being surprised that it is a noop or partial for some devices and not for others.
 - `update_children` has the same default value of `True` across devices.
 - `smart` devices don't call `update` on children if `update_children` is `False`.
 - Child devices can be updated with `update_parent=False` so they just update their own module queries.

Currently Hubs do not support updates on children directly but this could be a good feature to implement in another PR to allow finer grained control for hubs with many attached devices.

N.B. This PR will require a change to the HA coordinator in the way it currently defers emeter updates on the HS300. That PR could include logic to drop the child coordinator altogether and control the `update_children` parameters based on elapsed time.