### PR TITLE
Cache SmartErrorCode creation

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -140,7 +140,12 @@ class AesTransport(BaseTransport):
         return un, pw
 
     def _handle_response_error_code(self, resp_dict: Any, msg: str) -> None:
-        error_code = SmartErrorCode.from_int(resp_dict.get("error_code"))
+        error_code_raw = resp_dict.get("error_code")
+        try:
+            error_code = SmartErrorCode.from_int(error_code_raw)
+        except ValueError:
+            _LOGGER.warning("Received unknown error code: %s", error_code_raw)
+            error_code = SmartErrorCode.INTERNAL_UNKNOWN_ERROR
         if error_code is SmartErrorCode.SUCCESS:
             return
         msg = f"{msg}: {self._host}: {error_code.name}({error_code.value})"

--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -140,14 +140,8 @@ class AesTransport(BaseTransport):
         return un, pw
 
     def _handle_response_error_code(self, resp_dict: Any, msg: str) -> None:
-        error_code_raw = resp_dict.get("error_code")
-        try:
-            error_code = SmartErrorCode(error_code_raw)  # type: ignore[arg-type]
-        except ValueError:
-            _LOGGER.warning("Received unknown error code: %s", error_code_raw)
-            error_code = SmartErrorCode.INTERNAL_UNKNOWN_ERROR
-
-        if error_code == SmartErrorCode.SUCCESS:
+        error_code = SmartErrorCode.from_int(resp_dict.get("error_code"))
+        if error_code is SmartErrorCode.SUCCESS:
             return
         msg = f"{msg}: {self._host}: {error_code.name}({error_code.value})"
         if error_code in SMART_RETRYABLE_ERRORS:

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -71,11 +71,7 @@ class SmartErrorCode(IntEnum):
     @cache
     def from_int(value: int) -> SmartErrorCode:
         """Convert an integer to a SmartErrorCode."""
-        try:
-            return SmartErrorCode(value)  # type: ignore[arg-type]
-        except ValueError:
-            _LOGGER.warning("Received unknown error code: %s", value)
-            return SmartErrorCode.INTERNAL_UNKNOWN_ERROR
+        return SmartErrorCode(value)  # type: ignore[arg-type]
 
     SUCCESS = 0
 

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
-import logging
 from asyncio import TimeoutError as _asyncioTimeoutError
 from enum import IntEnum
 from functools import cache
 from typing import Any
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class KasaException(Exception):

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -71,7 +71,7 @@ class SmartErrorCode(IntEnum):
     @cache
     def from_int(value: int) -> SmartErrorCode:
         """Convert an integer to a SmartErrorCode."""
-        return SmartErrorCode(value)  # type: ignore[arg-type]
+        return SmartErrorCode(value)
 
     SUCCESS = 0
 

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from asyncio import TimeoutError as _asyncioTimeoutError
 from enum import IntEnum
+from functools import cache
 from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class KasaException(Exception):
@@ -62,6 +66,16 @@ class SmartErrorCode(IntEnum):
 
     def __str__(self):
         return f"{self.name}({self.value})"
+
+    @staticmethod
+    @cache
+    def from_int(value: int) -> SmartErrorCode:
+        """Convert an integer to a SmartErrorCode."""
+        try:
+            return SmartErrorCode(value)  # type: ignore[arg-type]
+        except ValueError:
+            _LOGGER.warning("Received unknown error code: %s", value)
+            return SmartErrorCode.INTERNAL_UNKNOWN_ERROR
 
     SUCCESS = 0
 

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -241,12 +241,12 @@ class SmartProtocol(BaseProtocol):
     def _handle_response_error_code(self, resp_dict: dict, method, raise_on_error=True):
         error_code_raw = resp_dict.get("error_code")
         try:
-            error_code = SmartErrorCode(error_code_raw)  # type: ignore[arg-type]
+            error_code = SmartErrorCode.from_int(error_code_raw)
         except ValueError:
             _LOGGER.warning("Received unknown error code: %s", error_code_raw)
             error_code = SmartErrorCode.INTERNAL_UNKNOWN_ERROR
 
-        if error_code == SmartErrorCode.SUCCESS:
+        if error_code is SmartErrorCode.SUCCESS:
             return
 
         if not raise_on_error:


### PR DESCRIPTION
Avoid the `__call__` and `__new__` overhead to create the singleton by caching the creation.  Since we never overload methods or subclass these, we can avoid all the complexity most of the time. This is a tiny optimization.

before:
![enum_overhead](https://github.com/python-kasa/python-kasa/assets/663432/00064afe-77a9-45a1-9296-cd0713c12ebb)
after
![cached](https://github.com/python-kasa/python-kasa/assets/663432/98788626-6cb4-408d-ba4c-2ba72f3a8596)
