### PR TITLE
Update changelog generator config

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,5 +1,11 @@
-breaking_labels=breaking change
-add-sections={"new-device":{"prefix":"**Added support for devices:**","labels":["new device"]},"docs":{"prefix":"**Documentation updates:**","labels":["documentation"]},"maintenance":{"prefix":"**Project maintenance:**","labels":["maintenance"]}}
+output=CHANGELOG.md
+base=HISTORY.md
+user=python-kasa
+project=python-kasa
+since-tag=0.3.5
 release_branch=master
 usernames-as-github-logins=true
+breaking_labels=breaking change
+add-sections={"new-device":{"prefix":"**Added support for devices:**","labels":["new device"]},"docs":{"prefix":"**Documentation updates:**","labels":["documentation"]},"maintenance":{"prefix":"**Project maintenance:**","labels":["maintenance"]}}
 exclude-labels=duplicate,question,invalid,wontfix,release-prep
+issues-wo-labels=false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,6 +73,8 @@ gh issue close ISSUE_NUMBER
 
 ## Generate changelog
 
+Configuration settings are in `.github_changelog_generator`
+
 ### For pre-release
 
 EXCLUDE_TAGS will exclude all dev tags except for the current release dev tags.
@@ -82,13 +84,13 @@ Regex should be something like this `^((?!0\.7\.0)(.*dev\d))+`. The first match 
 ```bash
 EXCLUDE_TAGS=${NEW_RELEASE%.dev*}; EXCLUDE_TAGS=${EXCLUDE_TAGS//"."/"\."}; EXCLUDE_TAGS="^((?!"$EXCLUDE_TAGS")(.*dev\d))+"
 echo "$EXCLUDE_TAGS"
-github_changelog_generator --base HISTORY.md --user python-kasa --project python-kasa --since-tag $PREVIOUS_RELEASE --future-release $NEW_RELEASE -o CHANGELOG.md --no-issues --exclude-tags-regex "$EXCLUDE_TAGS"
+github_changelog_generator --future-release $NEW_RELEASE --exclude-tags-regex "$EXCLUDE_TAGS"
 ```
 
 ### For production
 
 ```bash
-github_changelog_generator --base HISTORY.md --user python-kasa --project python-kasa --since-tag $PREVIOUS_RELEASE --future-release $NEW_RELEASE -o CHANGELOG.md --no-issues --exclude-tags-regex 'dev\d$'
+github_changelog_generator --future-release $NEW_RELEASE --exclude-tags-regex 'dev\d$'
 ```
 
 You can ignore warnings about missing PR commits like below as these relate to PRs to branches other than master:


### PR DESCRIPTION
Move the static command line options into the config file for consistency and remove `--no-issues` in favour of `issues-wo-labels=false` to fix the problem where `release-summary` issues are being excluded from the changelog.