### PR TITLE
Fix light preset module when list contains lighting effects

### DIFF
--- a/kasa/smart/modules/lightpreset.py
+++ b/kasa/smart/modules/lightpreset.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Sequence
 from dataclasses import asdict
 from typing import TYPE_CHECKING
@@ -12,6 +13,8 @@ from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
     from ..smartdevice import SmartDevice
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class LightPreset(SmartModule, LightPresetInterface):
@@ -38,6 +41,14 @@ class LightPreset(SmartModule, LightPresetInterface):
         state_key = "states" if not self._state_in_sysinfo else self.SYS_INFO_STATE_KEY
         if preset_states := self.data.get(state_key):
             for preset_state in preset_states:
+                if "brightness" not in preset_state:
+                    # Some devices can store effects as a preset. These will be ignored
+                    # and handled in the effects module
+                    if "lighting_effect" not in preset_state:
+                        _LOGGER.info(
+                            "Unexpected keys %s in preset", list(preset_state.keys())
+                        )
+                    continue
                 color_temp = preset_state.get("color_temp")
                 hue = preset_state.get("hue")
                 saturation = preset_state.get("saturation")

--- a/kasa/tests/fixtures/smart/L920-5(EU)_1.0_1.1.3.json
+++ b/kasa/tests/fixtures/smart/L920-5(EU)_1.0_1.1.3.json
@@ -122,7 +122,7 @@
         "factory_default": false,
         "ip": "127.0.0.123",
         "is_support_iot_cloud": true,
-        "mac": "1C-61-B4-00-00-00",
+        "mac": "B4-B0-24-00-00-00",
         "mgt_encrypt_schm": {
             "encrypt_type": "KLAP",
             "http_port": 80,
@@ -138,12 +138,12 @@
         "rule_list": []
     },
     "get_auto_update_info": {
-        "enable": false,
+        "enable": true,
         "random_range": 120,
         "time": 180
     },
     "get_connect_cloud_state": {
-        "status": 1
+        "status": 0
     },
     "get_countdown_rules": {
         "countdown_rule_max_count": 1,
@@ -152,7 +152,7 @@
     },
     "get_device_info": {
         "avatar": "light_strip",
-        "brightness": 65,
+        "brightness": 100,
         "color_temp": 0,
         "color_temp_range": [
             9000,
@@ -160,10 +160,10 @@
         ],
         "default_states": {
             "state": {
-                "brightness": 65,
+                "brightness": 100,
                 "color_temp": 0,
-                "hue": 9,
-                "saturation": 67
+                "hue": 30,
+                "saturation": 0
             },
             "type": "last_states"
         },
@@ -171,78 +171,85 @@
         "device_on": false,
         "fw_id": "00000000000000000000000000000000",
         "fw_ver": "1.1.3 Build 231229 Rel.164316",
-        "has_set_location_info": false,
-        "hue": 9,
+        "has_set_location_info": true,
+        "hue": 30,
         "hw_id": "00000000000000000000000000000000",
         "hw_ver": "1.0",
         "ip": "127.0.0.123",
-        "lang": "de_DE",
+        "lang": "en_US",
+        "latitude": 0,
         "lighting_effect": {
-            "brightness": 65,
+            "brightness": 100,
             "custom": 0,
             "display_colors": [
                 [
-                    136,
-                    98,
+                    30,
+                    0,
                     100
                 ],
                 [
-                    350,
-                    97,
+                    30,
+                    95,
+                    100
+                ],
+                [
+                    0,
+                    100,
                     100
                 ]
             ],
             "enable": 0,
-            "id": "TapoStrip_5zkiG6avJ1IbhjiZbRlWvh",
-            "name": "Christmas"
+            "id": "TapoStrip_1OVSyXIsDxrt4j7OxyRvqi",
+            "name": "Sunrise"
         },
-        "mac": "1C-61-B4-00-00-00",
+        "longitude": 0,
+        "mac": "B4-B0-24-00-00-00",
         "model": "L920",
         "music_rhythm_enable": false,
         "music_rhythm_mode": "single_lamp",
         "nickname": "I01BU0tFRF9OQU1FIw==",
         "oem_id": "00000000000000000000000000000000",
         "overheated": false,
-        "region": "Europe/Berlin",
-        "rssi": -56,
-        "saturation": 67,
+        "region": "Europe/Bucharest",
+        "rssi": -57,
+        "saturation": 0,
         "segment_effect": {
             "brightness": 97,
             "custom": 0,
             "display_colors": [],
             "enable": 0,
             "id": "",
-            "name": "Lightning"
+            "name": "Warm Aurora"
         },
         "signal_level": 2,
         "specs": "",
         "ssid": "I01BU0tFRF9TU0lEIw==",
-        "time_diff": 60,
+        "time_diff": 120,
         "type": "SMART.TAPOBULB"
     },
     "get_device_segment": {
         "segment": 50
     },
     "get_device_time": {
-        "region": "Europe/Berlin",
-        "time_diff": 60,
-        "timestamp": 1719920893
+        "region": "Europe/Bucharest",
+        "time_diff": 120,
+        "timestamp": 1720089009
     },
     "get_device_usage": {
         "power_usage": {
-            "past30": 20,
-            "past7": 20,
-            "today": 0
+            "past30": 1211,
+            "past7": 183,
+            "today": 7
         },
         "saved_power": {
-            "past30": 319,
-            "past7": 319,
-            "today": 0
+            "past30": 6124,
+            "past7": 1204,
+            "today": 30
         },
         "time_usage": {
-            "past30": 339,
-            "past7": 339,
-            "today": 0
+            "past30": 7335,
+            "past7": 1387,
+            "today": 37
         }
     },
     "get_fw_download_state": {
@@ -253,74 +260,133 @@
         "upgrade_time": 5
     },
     "get_inherit_info": null,
+    "get_latest_fw": {
+        "fw_size": 0,
+        "fw_ver": "1.1.3 Build 231229 Rel.164316",
+        "hw_id": "",
+        "need_to_upgrade": false,
+        "oem_id": "",
+        "release_date": "",
+        "release_note": "",
+        "type": 0
+    },
     "get_lighting_effect": {
-        "backgrounds": [
-            [
-                136,
-                98,
-                75
-            ],
-            [
-                136,
-                0,
-                0
-            ],
-            [
-                350,
-                0,
-                100
-            ],
-            [
-                350,
-                97,
-                94
-            ]
-        ],
-        "brightness": 65,
-        "brightness_range": [
-            50,
-            100
-        ],
+        "brightness": 100,
         "custom": 0,
+        "direction": 1,
         "display_colors": [
             [
-                136,
-                98,
+                30,
+                0,
                 100
             ],
             [
-                350,
-                97,
+                30,
+                95,
                 100
-            ]
-        ],
-        "duration": 5000,
-        "enable": 0,
-        "expansion_strategy": 1,
-        "fadeoff": 2000,
-        "hue_range": [
-            136,
-            146
-        ],
-        "id": "TapoStrip_5zkiG6avJ1IbhjiZbRlWvh",
-        "init_states": [
+            ],
             [
-                136,
                 0,
+                100,
                 100
             ]
         ],
-        "name": "Christmas",
-        "random_seed": 100,
-        "saturation_range": [
-            90,
-            100
-        ],
+        "duration": 600,
+        "enable": 0,
+        "expansion_strategy": 2,
+        "id": "TapoStrip_1OVSyXIsDxrt4j7OxyRvqi",
+        "name": "Sunrise",
+        "repeat_times": 1,
+        "run_time": 0,
         "segments": [
             0
         ],
-        "transition": 0,
-        "type": "random"
+        "sequence": [
+            [
+                0,
+                100,
+                5
+            ],
+            [
+                0,
+                100,
+                5
+            ],
+            [
+                10,
+                100,
+                6
+            ],
+            [
+                15,
+                100,
+                7
+            ],
+            [
+                20,
+                100,
+                8
+            ],
+            [
+                20,
+                100,
+                10
+            ],
+            [
+                30,
+                100,
+                12
+            ],
+            [
+                30,
+                95,
+                15
+            ],
+            [
+                30,
+                90,
+                20
+            ],
+            [
+                30,
+                80,
+                25
+            ],
+            [
+                30,
+                75,
+                30
+            ],
+            [
+                30,
+                70,
+                40
+            ],
+            [
+                30,
+                60,
+                50
+            ],
+            [
+                30,
+                50,
+                60
+            ],
+            [
+                30,
+                20,
+                70
+            ],
+            [
+                30,
+                0,
+                100
+            ]
+        ],
+        "spread": 1,
+        "trans_sequence": [],
+        "transition": 60000,
+        "type": "pulse"
     },
     "get_next_event": {},
     "get_on_off_gradually_info": {
@@ -336,39 +402,438 @@
                 "saturation": 100
             },
             {
-                "brightness": 100,
-                "color_temp": 0,
-                "hue": 240,
-                "saturation": 100
+                "lighting_effect": {
+                    "brightness": 100,
+                    "custom": 0,
+                    "direction": 1,
+                    "display_colors": [
+                        [
+                            30,
+                            0,
+                            100
+                        ],
+                        [
+                            30,
+                            95,
+                            100
+                        ],
+                        [
+                            0,
+                            100,
+                            100
+                        ]
+                    ],
+                    "duration": 600,
+                    "enable": 1,
+                    "expansion_strategy": 2,
+                    "id": "TapoStrip_1OVSyXIsDxrt4j7OxyRvqi",
+                    "name": "Sunrise",
+                    "repeat_times": 1,
+                    "run_time": 0,
+                    "segments": [
+                        0
+                    ],
+                    "sequence": [
+                        [
+                            0,
+                            100,
+                            5
+                        ],
+                        [
+                            0,
+                            100,
+                            5
+                        ],
+                        [
+                            10,
+                            100,
+                            6
+                        ],
+                        [
+                            15,
+                            100,
+                            7
+                        ],
+                        [
+                            20,
+                            100,
+                            8
+                        ],
+                        [
+                            20,
+                            100,
+                            10
+                        ],
+                        [
+                            30,
+                            100,
+                            12
+                        ],
+                        [
+                            30,
+                            95,
+                            15
+                        ],
+                        [
+                            30,
+                            90,
+                            20
+                        ],
+                        [
+                            30,
+                            80,
+                            25
+                        ],
+                        [
+                            30,
+                            75,
+                            30
+                        ],
+                        [
+                            30,
+                            70,
+                            40
+                        ],
+                        [
+                            30,
+                            60,
+                            50
+                        ],
+                        [
+                            30,
+                            50,
+                            60
+                        ],
+                        [
+                            30,
+                            20,
+                            70
+                        ],
+                        [
+                            30,
+                            0,
+                            100
+                        ]
+                    ],
+                    "spread": 1,
+                    "trans_sequence": [],
+                    "transition": 60000,
+                    "type": "pulse"
+                }
+            },
+            {
+                "lighting_effect": {
+                    "brightness": 100,
+                    "custom": 0,
+                    "direction": 1,
+                    "display_colors": [
+                        [
+                            0,
+                            100,
+                            100
+                        ],
+                        [
+                            30,
+                            95,
+                            100
+                        ],
+                        [
+                            30,
+                            0,
+                            100
+                        ]
+                    ],
+                    "duration": 600,
+                    "enable": 1,
+                    "expansion_strategy": 2,
+                    "id": "TapoStrip_5NiN0Y8GAUD78p4neKk9EL",
+                    "name": "Sunset",
+                    "repeat_times": 1,
+                    "run_time": 0,
+                    "segments": [
+                        0
+                    ],
+                    "sequence": [
+                        [
+                            30,
+                            0,
+                            100
+                        ],
+                        [
+                            30,
+                            20,
+                            100
+                        ],
+                        [
+                            30,
+                            50,
+                            99
+                        ],
+                        [
+                            30,
+                            60,
+                            98
+                        ],
+                        [
+                            30,
+                            70,
+                            97
+                        ],
+                        [
+                            30,
+                            75,
+                            95
+                        ],
+                        [
+                            30,
+                            80,
+                            93
+                        ],
+                        [
+                            30,
+                            90,
+                            90
+                        ],
+                        [
+                            30,
+                            95,
+                            85
+                        ],
+                        [
+                            30,
+                            100,
+                            80
+                        ],
+                        [
+                            20,
+                            100,
+                            70
+                        ],
+                        [
+                            20,
+                            100,
+                            60
+                        ],
+                        [
+                            15,
+                            100,
+                            50
+                        ],
+                        [
+                            10,
+                            100,
+                            40
+                        ],
+                        [
+                            0,
+                            100,
+                            30
+                        ],
+                        [
+                            0,
+                            100,
+                            0
+                        ]
+                    ],
+                    "spread": 1,
+                    "trans_sequence": [],
+                    "transition": 60000,
+                    "type": "pulse"
+                }
+            },
+            {
+                "lighting_effect": {
+                    "brightness": 100,
+                    "custom": 0,
+                    "direction": 1,
+                    "display_colors": [
+                        [
+                            0,
+                            100,
+                            100
+                        ],
+                        [
+                            100,
+                            100,
+                            100
+                        ],
+                        [
+                            200,
+                            100,
+                            100
+                        ],
+                        [
+                            300,
+                            100,
+                            100
+                        ]
+                    ],
+                    "duration": 0,
+                    "enable": 1,
+                    "expansion_strategy": 1,
+                    "id": "TapoStrip_7CC5y4lsL8pETYvmz7UOpQ",
+                    "name": "Rainbow",
+                    "repeat_times": 0,
+                    "segments": [
+                        0
+                    ],
+                    "sequence": [
+                        [
+                            0,
+                            100,
+                            100
+                        ],
+                        [
+                            100,
+                            100,
+                            100
+                        ],
+                        [
+                            200,
+                            100,
+                            100
+                        ],
+                        [
+                            300,
+                            100,
+                            100
+                        ]
+                    ],
+                    "spread": 12,
+                    "transition": 1500,
+                    "type": "sequence"
+                }
+            },
+            {
+                "lighting_effect": {
+                    "brightness": 100,
+                    "custom": 0,
+                    "direction": 4,
+                    "display_colors": [
+                        [
+                            120,
+                            100,
+                            100
+                        ],
+                        [
+                            240,
+                            100,
+                            100
+                        ],
+                        [
+                            260,
+                            100,
+                            100
+                        ],
+                        [
+                            280,
+                            100,
+                            100
+                        ]
+                    ],
+                    "duration": 0,
+                    "enable": 1,
+                    "expansion_strategy": 1,
+                    "id": "TapoStrip_1MClvV18i15Jq3bvJVf0eP",
+                    "name": "Aurora",
+                    "repeat_times": 0,
+                    "segments": [
+                        0
+                    ],
+                    "sequence": [
+                        [
+                            120,
+                            100,
+                            100
+                        ],
+                        [
+                            240,
+                            100,
+                            100
+                        ],
+                        [
+                            260,
+                            100,
+                            100
+                        ],
+                        [
+                            280,
+                            100,
+                            100
+                        ]
+                    ],
+                    "spread": 7,
+                    "transition": 1500,
+                    "type": "sequence"
+                }
+            },
+            {
+                "lighting_effect": {
+                    "brightness": 100,
+                    "custom": 1,
+                    "direction": 4,
+                    "display_colors": [
+                        [
+                            103,
+                            100,
+                            100
+                        ],
+                        [
+                            73,
+                            100,
+                            100
+                        ],
+                        [
+                            16,
+                            100,
+                            100
+                        ],
+                        [
+                            44,
+                            100,
+                            100
+                        ]
+                    ],
+                    "duration": 0,
+                    "enable": 1,
+                    "expansion_strategy": 1,
+                    "id": "TapoStrip_639hjRuGECd1gsSbFAINNn",
+                    "name": "Warm Aurora",
+                    "repeat_times": 0,
+                    "segments": [
+                        0
+                    ],
+                    "sequence": [
+                        [
+                            103,
+                            100,
+                            100
+                        ],
+                        [
+                            73,
+                            100,
+                            100
+                        ],
+                        [
+                            16,
+                            100,
+                            100
+                        ],
+                        [
+                            44,
+                            100,
+                            100
+                        ]
+                    ],
+                    "spread": 7,
+                    "transition": 5000,
+                    "type": "sequence"
+                }
             },
             {
                 "brightness": 100,
                 "color_temp": 0,
                 "hue": 0,
-                "saturation": 100
-            },
-            {
-                "brightness": 100,
-                "color_temp": 0,
-                "hue": 120,
-                "saturation": 100
-            },
-            {
-                "brightness": 100,
-                "color_temp": 0,
-                "hue": 277,
-                "saturation": 86
-            },
-            {
-                "brightness": 100,
-                "color_temp": 0,
-                "hue": 60,
-                "saturation": 100
-            },
-            {
-                "brightness": 100,
-                "color_temp": 0,
-                "hue": 300,
                 "saturation": 100
             }
         ],
@@ -387,7 +852,7 @@
         "display_colors": [],
         "enable": 0,
         "id": "",
-        "name": "Lightning"
+        "name": "Warm Aurora"
     },
     "get_wireless_scan_info": {
         "ap_list": [
@@ -398,10 +863,194 @@
                 "key_type": "wpa2_psk",
                 "signal_level": 2,
                 "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
             }
         ],
         "start_index": 0,
-        "sum": 1,
+        "sum": 24,
         "wep_supported": false
     },
     "qs_component_nego": {


### PR DESCRIPTION
Fixes the residual issues with the light preset module not handling unexpected `lighting_effect` items in the presets list.

Completes the fixes started with PR https://github.com/python-kasa/python-kasa/pull/1043 to fix https://github.com/python-kasa/python-kasa/issues/1040, [HA #121115](https://github.com/home-assistant/core/issues/121115) and [HA #121119](https://github.com/home-assistant/core/issues/121119)

With this PR affected devices will no longer have the light preset functionality disabled.  As this is a new feature this does not warrant a hotfix so will go into the next release.

Updated fixture for testing thanks to @szssamuel, many thanks!