### PR TITLE
Use first known thermostat state as main state (pick #1054)

### DIFF
--- a/kasa/tests/smart/modules/test_temperaturecontrol.py
+++ b/kasa/tests/smart/modules/test_temperaturecontrol.py
@@ -94,7 +94,7 @@ async def test_temperature_offset(dev):
         ),
         pytest.param(
             ThermostatState.Heating,
-            [ThermostatState.Heating],
+            ["heating"],
             False,
             id="heating is heating",
         ),
@@ -135,3 +135,11 @@ async def test_thermostat_mode_warnings(dev, mode, states, msg, caplog):
     temp_module.data["trv_states"] = states
     assert temp_module.mode is mode
     assert msg in caplog.text
+
+
+@thermostats_smart
+async def test_thermostat_heating_with_low_battery(dev):
+    """Test that mode is reported correctly with extra states."""
+    temp_module: TemperatureControl = dev.modules["TemperatureControl"]
+    temp_module.data["trv_states"] = ["low_battery", "heating"]
+    assert temp_module.mode is ThermostatState.Heating


### PR DESCRIPTION
Pick of https://github.com/python-kasa/python-kasa/pull/1054

Instead of trying to use the first state when multiple are reported, iterate over the known states and pick the first matching.
This will fix an issue where the device reports extra states (like low_battery) while having a known mode active.

Related to https://github.com/home-assistant/core/issues/121335