### PR TITLE
Only refresh smart LightEffect module daily

### DIFF
--- a/kasa/smart/modules/lighteffect.py
+++ b/kasa/smart/modules/lighteffect.py
@@ -17,7 +17,7 @@ class LightEffect(SmartModule, SmartLightEffect):
 
     REQUIRED_COMPONENT = "light_effect"
     QUERY_GETTER_NAME = "get_dynamic_light_effect_rules"
-    MINIMUM_UPDATE_INTERVAL_SECS = 60
+    MINIMUM_UPDATE_INTERVAL_SECS = 60 * 60 * 24
     AVAILABLE_BULB_EFFECTS = {
         "L1": "Party",
         "L2": "Relax",
@@ -74,6 +74,7 @@ class LightEffect(SmartModule, SmartLightEffect):
         """Return effect name."""
         return self._effect
 
+    @allow_update_after
     async def set_effect(
         self,
         effect: str,


### PR DESCRIPTION
Fixes an issue with L530 bulbs on HW version 1.0 whereby the light effect query causes the device to crash with `JSON_ENCODE_FAIL_ERROR` after approximately 60 calls.

Similar behaviour to the `get_led_info` issue fixed in https://github.com/python-kasa/python-kasa/pull/1052 except setting an effect does not fix the device like it did with the Led rule.

Fixes [HA issue #121362](https://github.com/home-assistant/core/issues/121362) although the devices could still fail after around 60 days if not restarted in the meantime.

Many thanks to @zetaho2003 for helping with the testing for this issue.