### PR TITLE
Expose reboot action

### DIFF
--- a/docs/tutorial.py
+++ b/docs/tutorial.py
@@ -91,5 +91,5 @@ False
 True
 >>> for feat in dev.features.values():
 >>>     print(f"{feat.name}: {feat.value}")
-Device ID: 0000000000000000000000000000000000000000\nState: True\nSignal Level: 2\nRSSI: -52\nSSID: #MASKED_SSID#\nOverheated: False\nBrightness: 50\nCloud connection: True\nHSV: HSV(hue=0, saturation=100, value=50)\nColor temperature: 2700\nAuto update enabled: True\nUpdate available: False\nCurrent firmware version: 1.1.6 Build 240130 Rel.173828\nAvailable firmware version: 1.1.6 Build 240130 Rel.173828\nLight effect: Party\nLight preset: Light preset 1\nSmooth transition on: 2\nSmooth transition off: 2\nDevice time: 2024-02-23 02:40:15+01:00
+Device ID: 0000000000000000000000000000000000000000\nState: True\nSignal Level: 2\nRSSI: -52\nSSID: #MASKED_SSID#\nOverheated: False\nReboot: <Action>\nBrightness: 50\nCloud connection: True\nHSV: HSV(hue=0, saturation=100, value=50)\nColor temperature: 2700\nAuto update enabled: True\nUpdate available: False\nCurrent firmware version: 1.1.6 Build 240130 Rel.173828\nAvailable firmware version: 1.1.6 Build 240130 Rel.173828\nLight effect: Party\nLight preset: Light preset 1\nSmooth transition on: 2\nSmooth transition off: 2\nDevice time: 2024-02-23 02:40:15+01:00
 """

--- a/kasa/device.py
+++ b/kasa/device.py
@@ -84,6 +84,7 @@ added to the API.
 state
 rssi
 on_since
+reboot
 current_consumption
 consumption_today
 consumption_this_month

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -25,6 +25,7 @@ Signal Level (signal_level): 2
 RSSI (rssi): -52
 SSID (ssid): #MASKED_SSID#
 Overheated (overheated): False
+Reboot (reboot): <Action>
 Brightness (brightness): 100
 Cloud connection (cloud_connection): True
 HSV (hsv): HSV(hue=0, saturation=100, value=100)

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -359,6 +359,18 @@ class IotDevice(Device):
                 )
             )
 
+        self._add_feature(
+            Feature(
+                device=self,
+                id="reboot",
+                name="Reboot",
+                attribute_setter="reboot",
+                icon="mdi:restart",
+                category=Feature.Category.Debug,
+                type=Feature.Type.Action,
+            )
+        )
+
         for module in self._supported_modules.values():
             module._initialize_features()
             for module_feat in module._module_features.values():

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -441,6 +441,18 @@ class SmartDevice(Device):
                 )
             )
 
+        self._add_feature(
+            Feature(
+                device=self,
+                id="reboot",
+                name="Reboot",
+                attribute_setter="reboot",
+                icon="mdi:restart",
+                category=Feature.Category.Debug,
+                type=Feature.Type.Action,
+            )
+        )
+
         for module in self.modules.values():
             module._initialize_features()
             for feat in module._module_features.values():


### PR DESCRIPTION
Expose reboot through the feature interface.
This can be useful in situations where one wants to reboot the device, e.g., in recent cases where frequent update calls will render the device unresponsive after a specific amount of time.

As I don't have access to test devices at the moment, this has not been tested against a real device.