### PR TITLE
Fix generate_supported pre commit to run in venv

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   - id: mypy
     name: mypy
     entry: devtools/run-in-env.sh mypy
-    language: script
+    language: system
     types_or: [python, pyi]
     require_serial: true
     exclude: |  # exclude required because --all-files passes py and pyi
@@ -39,7 +39,7 @@ repos:
   - id: generate-supported
     name: Generate supported devices
     description: This hook generates the supported device sections of README.md and SUPPORTED.md
-    entry: devtools/generate_supported.py
+    entry: devtools/run-in-env.sh ./devtools/generate_supported.py
     language: system # Required or pre-commit creates a new venv
     verbose: true # Show output on success
     types: [json]

--- a/devtools/run-in-env.sh
+++ b/devtools/run-in-env.sh
@@ -5,7 +5,8 @@ OS_VER=$(uname -v)
 if  [[ ( $OS_KERNEL == "Linux" && $OS_VER == *"Microsoft"* ) ]]; then
     echo "Pre-commit hook needs git-bash to run.  It cannot run in the windows linux subsystem."
     echo "Add git bin directory to the front of your path variable, e.g:"
-    echo "set PATH=C:\Program Files\Git\bin;%PATH%"
+    echo "set PATH=C:\Program Files\Git\bin;%PATH% (for CMD prompt)"
+    echo "\$env:Path = 'C:\Program Files\Git\bin;' + \$env:Path (for Powershell prompt)"
     exit 1
 fi
 if [[ "$(expr substr $OS_KERNEL 1 10)" == "MINGW64_NT" ]]; then

--- a/devtools/run-in-env.sh
+++ b/devtools/run-in-env.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# pre-commit by default runs hooks in an isolated environment.
+# For some hooks it's needed to run in the virtual environment so this script will activate it.
+
 OS_KERNEL=$(uname -s)
 OS_VER=$(uname -v)
 if  [[ ( $OS_KERNEL == "Linux" && $OS_VER == *"Microsoft"* ) ]]; then


### PR DESCRIPTION
I noticed after building a new linux instance that running `git commit` when the virtual environment is not active causes the pre-commit to fail, as the `generate_supported` hook is not explicitly configured to run in the virtual env.  This PR calls `generate_supported` via the `run-in-env.sh` script.