### PR TITLE
Enable setting brightness with color temp for smart devices

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -211,14 +211,14 @@ class Feature:
         """Range of values if applicable."""
         return self._get_property_value(self.range_getter)
 
-    @cached_property
+    @property
     def maximum_value(self) -> int:
         """Maximum value."""
         if range := self.range:
             return range[1]
         return self.DEFAULT_MAX
 
-    @cached_property
+    @property
     def minimum_value(self) -> int:
         """Minimum value."""
         if range := self.range:

--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -429,7 +429,7 @@ class IotBulb(IotDevice):
         if not self._is_variable_color_temp:
             raise KasaException("Bulb does not support colortemp.")
 
-        valid_temperature_range = self.valid_temperature_range
+        valid_temperature_range = self._valid_temperature_range
         if temp < valid_temperature_range[0] or temp > valid_temperature_range[1]:
             raise ValueError(
                 "Temperature should be between {} and {}, was {}".format(

--- a/kasa/smart/modules/colortemperature.py
+++ b/kasa/smart/modules/colortemperature.py
@@ -3,15 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 from ...feature import Feature
 from ...interfaces.light import ColorTempRange
 from ..smartmodule import SmartModule
-
-if TYPE_CHECKING:
-    pass
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/kasa/smart/modules/colortemperature.py
+++ b/kasa/smart/modules/colortemperature.py
@@ -10,7 +10,7 @@ from ...interfaces.light import ColorTempRange
 from ..smartmodule import SmartModule
 
 if TYPE_CHECKING:
-    from ..smartdevice import SmartDevice
+    pass
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,11 +23,11 @@ class ColorTemperature(SmartModule):
 
     REQUIRED_COMPONENT = "color_temperature"
 
-    def __init__(self, device: SmartDevice, module: str):
-        super().__init__(device, module)
+    def _initialize_features(self):
+        """Initialize features."""
         self._add_feature(
             Feature(
-                device,
+                self._device,
                 "color_temperature",
                 "Color temperature",
                 container=self,
@@ -61,7 +61,7 @@ class ColorTemperature(SmartModule):
         """Return current color temperature."""
         return self.data["color_temp"]
 
-    async def set_color_temp(self, temp: int):
+    async def set_color_temp(self, temp: int, *, brightness=None):
         """Set the color temperature."""
         valid_temperature_range = self.valid_temperature_range
         if temp < valid_temperature_range[0] or temp > valid_temperature_range[1]:
@@ -70,8 +70,10 @@ class ColorTemperature(SmartModule):
                     *valid_temperature_range, temp
                 )
             )
-
-        return await self.call("set_device_info", {"color_temp": temp})
+        params = {"color_temp": temp}
+        if brightness:
+            params["brightness"] = brightness
+        return await self.call("set_device_info", params)
 
     async def _check_supported(self) -> bool:
         """Check the color_temp_range has more than one value."""

--- a/kasa/smart/modules/light.py
+++ b/kasa/smart/modules/light.py
@@ -107,7 +107,9 @@ class Light(SmartModule, LightInterface):
         """
         if not self.is_variable_color_temp:
             raise KasaException("Bulb does not support colortemp.")
-        return await self._device.modules[Module.ColorTemperature].set_color_temp(temp)
+        return await self._device.modules[Module.ColorTemperature].set_color_temp(
+            temp, brightness=brightness
+        )
 
     async def set_brightness(
         self, brightness: int, *, transition: int | None = None


### PR DESCRIPTION
Fixes [HA Issue 122401](https://github.com/home-assistant/core/issues/122401)

The addition of the tests here highlighted that the iot module was calling the deprecated `valid_temperature_range` function on the device. Whilst debugging I discovered that nesting `cached_property` prevents the debugger from accessing the lower level property so removed the `cached_property` for maximum and minimum values.