### PR TITLE
Fix logging in iotdevice when a module is module not supported

### DIFF
--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -371,7 +371,7 @@ class IotDevice(Device):
         est_response_size = 1024 if "system" in req else 0
         for module in self._modules.values():
             if not module.is_supported:
-                _LOGGER.debug("Module %s not supported, skipping" % module)
+                _LOGGER.debug("Module %s not supported, skipping", module)
                 continue
 
             est_response_size += module.estimated_query_response_size


### PR DESCRIPTION
This debug logger was generating the `repr()` of each module and throwing it away because it had a `%` instead of a `,`
<img width="1223" alt="Screenshot 2024-08-22 at 6 41 10 PM" src="https://github.com/user-attachments/assets/4e2568e6-ee7f-4020-95f2-fbc33597f9fe">

