### PR TITLE
Add missing typing_extensions dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2277,4 +2277,4 @@ speedups = ["kasa-crypt", "orjson"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "77c2a966172a89c0119dba1fdc03dab67d80fd33939424633cd02731b699d6af"
+content-hash = "c29200a35b10776b74812daf37b88bf400f7f496825954f7a9eba718f215ae3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ docutils = { version = ">=0.17", optional = true }
 # enhanced cli support
 ptpython = { version = "*", optional = true }
 rich = { version = "*", optional = true }
+typing-extensions = ">=4.12.2,<5.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
`typing_extensions` is a dependency of `pydantic` so it's getting installed by default but it should be an explicit dependency of python-kasa.