### PR TITLE
Add flake8-logging (LOG) and flake8-logging-format (G) for ruff

### DIFF
--- a/kasa/aestransport.py
+++ b/kasa/aestransport.py
@@ -278,9 +278,8 @@ class AesTransport(BaseTransport):
             + "\n-----END PUBLIC KEY-----\n"
         )
         handshake_params = {"key": pub_key}
-        _LOGGER.debug(f"Handshake params: {handshake_params}")
         request_body = {"method": "handshake", "params": handshake_params}
-        _LOGGER.debug(f"Request {request_body}")
+        _LOGGER.debug("Handshake request: %s", request_body)
         yield json_dumps(request_body).encode()
 
     async def perform_handshake(self) -> None:

--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -84,8 +84,11 @@ async def _connect(config: DeviceConfig, protocol: BaseProtocol) -> Device:
         if debug_enabled:
             end_time = time.perf_counter()
             _LOGGER.debug(
-                f"Device {config.host} with connection params {has_params} "
-                + f"took {end_time - start_time:.2f} seconds to {perf_type}",
+                "Device %s with connection params %s took %.2f seconds to %s",
+                config.host,
+                has_params,
+                end_time - start_time,
+                perf_type,
             )
             start_time = time.perf_counter()
 

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -262,7 +262,7 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
             self._handle_discovered_event()
             return
         except KasaException as ex:
-            _LOGGER.debug(f"[DISCOVERY] Unable to find device type for {ip}: {ex}")
+            _LOGGER.debug("[DISCOVERY] Unable to find device type for %s: %s", ip, ex)
             self.invalid_device_exceptions[ip] = ex
             self._handle_discovered_event()
             return

--- a/kasa/emeterstatus.py
+++ b/kasa/emeterstatus.py
@@ -87,5 +87,5 @@ class EmeterStatus(dict):
                     ):
                         return value / 1000
 
-                _LOGGER.debug(f"Unable to find value for '{item}'")
+                _LOGGER.debug("Unable to find value for '%s'", item)
                 return None

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -198,7 +198,7 @@ class IotDevice(Device):
     def add_module(self, name: str | ModuleName[Module], module: IotModule):
         """Register a module."""
         if name in self._modules:
-            _LOGGER.debug("Module %s already registered, ignoring..." % name)
+            _LOGGER.debug("Module %s already registered, ignoring...", name)
             return
 
         _LOGGER.debug("Adding module %s", module)

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -153,8 +153,8 @@ class KlapTransport(BaseTransport):
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
-                "Handshake1 posted at %s. Host is %s, Response"
-                + "status is %s, Request was %s",
+                "Handshake1 posted at %s. Host is %s, "
+                "Response status is %s, Request was %s",
                 datetime.datetime.now(),
                 self._host,
                 response_status,
@@ -179,7 +179,7 @@ class KlapTransport(BaseTransport):
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
                 "Handshake1 success at %s. Host is %s, "
-                + "Server remote_seed is: %s, server hash is: %s",
+                "Server remote_seed is: %s, server hash is: %s",
                 datetime.datetime.now(),
                 self._host,
                 remote_seed.hex(),
@@ -211,9 +211,10 @@ class KlapTransport(BaseTransport):
 
             if default_credentials_seed_auth_hash == server_hash:
                 _LOGGER.debug(
-                    "Server response doesn't match our expected hash on ip %s"
-                    + f" but an authentication with {key} default credentials matched",
+                    "Server response doesn't match our expected hash on ip %s, "
+                    "but an authentication with %s default credentials matched",
                     self._host,
+                    key,
                 )
                 return local_seed, remote_seed, self._default_credentials_auth_hash[key]  # type: ignore
 
@@ -231,8 +232,8 @@ class KlapTransport(BaseTransport):
 
             if blank_seed_auth_hash == server_hash:
                 _LOGGER.debug(
-                    "Server response doesn't match our expected hash on ip %s"
-                    + " but an authentication with blank credentials matched",
+                    "Server response doesn't match our expected hash on ip %s, "
+                    "but an authentication with blank credentials matched",
                     self._host,
                 )
                 return local_seed, remote_seed, self._blank_auth_hash  # type: ignore
@@ -260,8 +261,8 @@ class KlapTransport(BaseTransport):
 
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
-                "Handshake2 posted %s.  Host is %s, Response status is %s, "
-                + "Request was %s",
+                "Handshake2 posted %s. Host is %s, "
+                "Response status is %s, Request was %s",
                 datetime.datetime.now(),
                 self._host,
                 response_status,
@@ -338,18 +339,17 @@ class KlapTransport(BaseTransport):
             + f"Response status is {response_status}, Request was {request}"
         )
         if response_status != 200:
-            _LOGGER.error("Query failed after successful authentication " + msg)
+            _LOGGER.error("Query failed after successful authentication: %s", msg)
             # If we failed with a security error, force a new handshake next time.
             if response_status == 403:
                 self._handshake_done = False
                 raise _RetryableError(
-                    f"Got a security error from {self._host} after handshake "
-                    + "completed"
+                    "Got a security error from %s after handshake completed", self._host
                 )
             else:
                 raise KasaException(
-                    f"Device {self._host} responded with {response_status} to"
-                    + f"request with seq {seq}"
+                    f"Device {self._host} responded with {response_status} to "
+                    f"request with seq {seq}"
                 )
         else:
             _LOGGER.debug("Device %s query posted %s", self._host, msg)

--- a/kasa/smart/modules/firmware.py
+++ b/kasa/smart/modules/firmware.py
@@ -181,7 +181,7 @@ class Firmware(SmartModule):
                     )
                     continue
 
-                _LOGGER.debug("Update state: %s" % state)
+                _LOGGER.debug("Update state: %s", state)
                 if progress_cb is not None:
                     asyncio.create_task(progress_cb(state))
 

--- a/kasa/smart/smartmodule.py
+++ b/kasa/smart/smartmodule.py
@@ -77,7 +77,7 @@ class SmartModule(Module):
 
     def __init_subclass__(cls, **kwargs):
         name = getattr(cls, "NAME", cls.__name__)
-        _LOGGER.debug("Registering %s" % cls)
+        _LOGGER.debug("Registering %s", cls)
         cls.REGISTERED_MODULES[name] = cls
 
     def _set_error(self, err: Exception | None):

--- a/kasa/smartprotocol.py
+++ b/kasa/smartprotocol.py
@@ -309,8 +309,9 @@ class SmartProtocol(BaseProtocol):
             # In case the device returns empty lists avoid infinite looping
             if not next_batch[response_list_name]:
                 _LOGGER.error(
-                    f"Device {self._host} returned empty "
-                    + f"results list for method {method}"
+                    "Device %s returned empty results list for method %s",
+                    self._host,
+                    method,
                 )
                 break
             response_result[response_list_name].extend(next_batch[response_list_name])

--- a/kasa/tests/fakeprotocol_iot.py
+++ b/kasa/tests/fakeprotocol_iot.py
@@ -425,7 +425,9 @@ class FakeIotTransport(BaseTransport):
                     return error(msg=f"command {cmd} not found")
 
                 params = request[target][cmd]
-                _LOGGER.debug(f"Going to execute {target}.{cmd} (params: {params}).. ")
+                _LOGGER.debug(
+                    "Going to execute %s.%s (params: %s).. ", target, cmd, params
+                )
 
                 if callable(proto[target][cmd]):
                     res = proto[target][cmd](self, params, child_ids)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ select = [
   "FA", # flake8-future-annotations
   "I",  # isort
   "S",  # bandit
+  "LOG",  # flake8-logging
+  "G",  # flake8-logging-format
 ]
 ignore = [
   "D105",  # Missing docstring in magic method


### PR DESCRIPTION
Enables rules LOG (flake8-logging) and G (flake8-logging-format) for ruff. This will catch eager log message formatting, among other similar issues.