### PR TITLE
Fix cli command for device off

### DIFF
--- a/kasa/cli/device.py
+++ b/kasa/cli/device.py
@@ -99,7 +99,7 @@ async def on(dev: Device, transition: int):
     return await dev.turn_on(transition=transition)
 
 
-@click.command
+@device.command
 @click.option("--transition", type=int, required=False)
 @pass_dev_or_child
 async def off(dev: Device, transition: int):


### PR DESCRIPTION
Noticed it's missed when using the full `kasa device off` command as opposed to the shortcut.