### PR TITLE
Extend KL135 ct range up to 9000K

### DIFF
--- a/kasa/iot/iotbulb.py
+++ b/kasa/iot/iotbulb.py
@@ -85,7 +85,7 @@ TPLINK_KELVIN = {
     "KB130": ColorTempRange(2500, 9000),
     "KL130": ColorTempRange(2500, 9000),
     "KL125": ColorTempRange(2500, 6500),
-    "KL135": ColorTempRange(2500, 6500),
+    "KL135": ColorTempRange(2500, 9000),
     r"KL120\(EU\)": ColorTempRange(2700, 6500),
     r"KL120\(US\)": ColorTempRange(2700, 5000),
     r"KL430": ColorTempRange(2500, 9000),


### PR DESCRIPTION
Apparently (newer?) KL135 bulbs support ct ranges up to 9000K as reported at https://github.com/home-assistant/core/issues/126300 .
[tplink-smarthome-api](https://github.com/plasticrake/tplink-smarthome-api/blob/33f55531e6d5935d57a065fb95fa5dc340c4f392/src/bulb/index.ts#L38) is also using this range, and it is the same as mentioned in the official manual, so I think we can also extend this.

[The original reporter for the missing ct range](https://github.com/python-kasa/python-kasa/issues/252#issuecomment-974187853) had a KL135 marketed only to support up to 6500K, but I don't see any relevant changes in the fixture (#1122) that could be used to differentiate between these versions.

Related to https://github.com/home-assistant/core/issues/126300