### PR TITLE
Add factory_reset() to iotdevice

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -449,6 +449,13 @@ class Device(ABC):
     async def set_alias(self, alias: str):
         """Set the device name (alias)."""
 
+    @abstractmethod
+    async def factory_reset(self) -> None:
+        """Reset device back to factory settings.
+
+        Note, this does not downgrade the firmware.
+        """
+
     def __repr__(self):
         if self._last_update is None:
             return f"<{self.device_type} at {self.host} - update() needed>"

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -561,6 +561,13 @@ class IotDevice(Device):
         """
         await self._query_helper("system", "reboot", {"delay": delay})
 
+    async def factory_reset(self) -> None:
+        """Reset device back to factory settings.
+
+        Note, this does not downgrade the firmware.
+        """
+        await self._query_helper("system", "reset")
+
     async def turn_off(self, **kwargs) -> dict:
         """Turn off the device."""
         raise NotImplementedError("Device subclass needs to implement this.")


### PR DESCRIPTION
This adds support for device factory reset for IOT devices, tested on KP303.
Also extends the base device class API to make `factory_reset()` to be a part of the common API. This could be extracted into its own PR, if needed.