### PR TITLE
Enable ruff lint pycodestyle warnings

### DIFF
--- a/kasa/tests/test_bulb.py
+++ b/kasa/tests/test_bulb.py
@@ -251,11 +251,11 @@ async def test_out_of_range_temperature(dev: Device):
     light = dev.modules.get(Module.Light)
     assert light
     with pytest.raises(
-        ValueError, match="Temperature should be between \d+ and \d+, was 1000"
+        ValueError, match=r"Temperature should be between \d+ and \d+, was 1000"
     ):
         await light.set_color_temp(1000)
     with pytest.raises(
-        ValueError, match="Temperature should be between \d+ and \d+, was 10000"
+        ValueError, match=r"Temperature should be between \d+ and \d+, was 10000"
     ):
         await light.set_color_temp(10000)
 

--- a/kasa/tests/test_common_modules.py
+++ b/kasa/tests/test_common_modules.py
@@ -213,10 +213,10 @@ async def test_light_color_temp(dev: Device):
     assert light.color_temp == feature.minimum_value + 20
     assert light.brightness == 60
 
-    with pytest.raises(ValueError, match="Temperature should be between \d+ and \d+"):
+    with pytest.raises(ValueError, match=r"Temperature should be between \d+ and \d+"):
         await light.set_color_temp(feature.minimum_value - 10)
 
-    with pytest.raises(ValueError, match="Temperature should be between \d+ and \d+"):
+    with pytest.raises(ValueError, match=r"Temperature should be between \d+ and \d+"):
         await light.set_color_temp(feature.maximum_value + 10)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,8 @@ target-version = "py38"
 
 [tool.ruff.lint]
 select = [
-  "E",  # pycodestyle
+  "E",  # pycodestyle errors
+  "W", # pycodestyle warnings
   "D",  # pydocstyle
   "F",  # pyflakes
   "UP",  # pyupgrade


### PR DESCRIPTION
Addresses repeated SyntaxWarnings when running linters:
```
kasa/tests/test_bulb.py:254: SyntaxWarning: invalid escape sequence '\d'
  ValueError, match="Temperature should be between \d+ and \d+, was 1000"
kasa/tests/test_bulb.py:258: SyntaxWarning: invalid escape sequence '\d'
  ValueError, match="Temperature should be between \d+ and \d+, was 10000"
kasa/tests/test_common_modules.py:216: SyntaxWarning: invalid escape sequence '\d'
  with pytest.raises(ValueError, match="Temperature should be between \d+ and \d+"):
kasa/tests/test_common_modules.py:219: SyntaxWarning: invalid escape sequence '\d'
  with pytest.raises(ValueError, match="Temperature should be between \d+ and \d+"):
```
