### PR TITLE
Add screensetting module

### DIFF
--- a/kasa/cli/main.py
+++ b/kasa/cli/main.py
@@ -339,7 +339,7 @@ async def cli(
     # Skip update on specific commands, or if device factory,
     # that performs an update was used for the device.
     if ctx.invoked_subcommand not in SKIP_UPDATE_COMMANDS and not device_updated:
-        await dev.update()
+        await dev.update(update_children=True)
 
     @asynccontextmanager
     async def async_wrapped_device(device: Device):

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -24,6 +24,7 @@ from .lightstripeffect import LightStripEffect
 from .lighttransition import LightTransition
 from .motionsensor import MotionSensor
 from .reportmode import ReportMode
+from .screensetting import ScreenSetting
 from .temperaturecontrol import TemperatureControl
 from .temperaturesensor import TemperatureSensor
 from .time import Time
@@ -58,4 +59,5 @@ __all__ = [
     "MotionSensor",
     "FrostProtection",
     "SmartLightEffect",
+    "ScreenSetting",
 ]

--- a/kasa/smart/modules/screensetting.py
+++ b/kasa/smart/modules/screensetting.py
@@ -1,0 +1,36 @@
+"""Screen setting module."""
+
+from __future__ import annotations
+
+from ...feature import Feature
+from ..smartmodule import SmartModule
+
+
+class ScreenSetting(SmartModule):
+    """Implementation for display rotation."""
+
+    REQUIRED_COMPONENT = "screen_setting"
+    QUERY_GETTER_NAME = "get_screen_setting_info"
+
+    def _initialize_features(self):
+        """Initialize features after the initial update."""
+        self._add_feature(
+            Feature(
+                device=self._device,
+                id="rotate_display",
+                name="Rotate display",
+                container=self,
+                attribute_getter="rotate_display",
+                attribute_setter="set_rotate_display",
+                type=Feature.Type.Switch,
+            )
+        )
+
+    @property
+    def rotate_display(self) -> bool:
+        """Return screen orientation."""
+        return self.data["led_rotation"]
+
+    async def set_rotate_display(self, enabled: bool) -> None:
+        """Set screen orientation."""
+        await self.call("set_screen_setting_info", {"led_rotation": enabled})


### PR DESCRIPTION
Allows changing the rotation/orientation of the thermostat display.

Similar to #1141, marking as a draft, as we need to find a workable solution for child device update cycle handling.