### PR TITLE
Stabilise on_since value for smart devices

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -435,7 +435,11 @@ class Device(ABC):
     @property
     @abstractmethod
     def on_since(self) -> datetime | None:
-        """Return the time that the device was turned on or None if turned off."""
+        """Return the time that the device was turned on or None if turned off.
+
+        Could be inprecise by up to 5 seconds due to device jitter between
+        the device reporting time and on_time.
+        """
 
     @abstractmethod
     async def wifi_scan(self) -> list[WifiNetwork]:

--- a/kasa/device.py
+++ b/kasa/device.py
@@ -437,8 +437,8 @@ class Device(ABC):
     def on_since(self) -> datetime | None:
         """Return the time that the device was turned on or None if turned off.
 
-        Could be inprecise by up to 5 seconds due to device jitter between
-        the device reporting time and on_time.
+        This returns a cached value if the device reported value difference is under
+        five seconds to avoid device-caused jitter.
         """
 
     @abstractmethod

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -18,7 +18,7 @@ import functools
 import inspect
 import logging
 from collections.abc import Mapping, Sequence
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
 from ..device import Device, WifiNetwork
@@ -604,7 +604,9 @@ class IotDevice(Device):
 
         on_time = self._sys_info["on_time"]
 
-        on_since = self.time - timedelta(seconds=on_time)
+        time = datetime.now(timezone.utc).astimezone().replace(microsecond=0)
+
+        on_since = time - timedelta(seconds=on_time)
         if not self._on_since or timedelta(
             seconds=0
         ) < on_since - self._on_since > timedelta(seconds=5):

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -597,8 +597,8 @@ class IotDevice(Device):
     def on_since(self) -> datetime | None:
         """Return the time that the device was turned on or None if turned off.
 
-        Could be inprecise by up to 5 seconds due to device jitter between
-        the device reporting time and on_time.
+        This returns a cached value if the device reported value difference is under
+        five seconds to avoid device-caused jitter.
         """
         if self.is_off or "on_time" not in self._sys_info:
             self._on_since = None

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -318,6 +318,7 @@ class IotStripPlug(IotPlug):
         self._set_sys_info(parent.sys_info)
         self._device_type = DeviceType.StripSocket
         self.protocol = parent.protocol  # Must use the same connection as the parent
+        self._on_since: datetime | None = None
 
     async def _initialize_modules(self):
         """Initialize modules not added in init."""
@@ -443,9 +444,14 @@ class IotStripPlug(IotPlug):
         info = self._get_child_info()
         on_time = info["on_time"]
 
-        return datetime.now(timezone.utc).astimezone().replace(
-            microsecond=0
-        ) - timedelta(seconds=on_time)
+        time = datetime.now(timezone.utc).astimezone().replace(microsecond=0)
+
+        on_since = time - timedelta(seconds=on_time)
+        if not self._on_since or timedelta(
+            seconds=0
+        ) < on_since - self._on_since > timedelta(seconds=5):
+            self._on_since = on_since
+        return self._on_since
 
     @property  # type: ignore
     @requires_update

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -439,6 +439,7 @@ class IotStripPlug(IotPlug):
     def on_since(self) -> datetime | None:
         """Return on-time, if available."""
         if self.is_off:
+            self._on_since = None
             return None
 
         info = self._get_child_info()

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -497,8 +497,8 @@ class SmartDevice(Device):
     def on_since(self) -> datetime | None:
         """Return the time that the device was turned on or None if turned off.
 
-        Could be inprecise by up to 5 seconds due to device jitter between
-        the device reporting time and on_time.
+        This returns a cached value if the device reported value difference is under
+        five seconds to avoid device-caused jitter.
         """
         if (
             not self._info.get("device_on")

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -504,11 +504,12 @@ class SmartDevice(Device):
 
         on_time = cast(float, on_time)
         on_since = self.time - timedelta(seconds=on_time)
-        # Ensure slight variations between time module and on_time do not cause the
-        # on_since time to change. More likely to happen with child devices.
+        # Ensure slight variations between time module and on_time do not cause
+        # the on_since time to change. More likely to happen with child devices
+        # or P100s that do not do multi-queries.
         if not self._on_since or timedelta(
             seconds=0
-        ) < on_since - self._on_since > timedelta(seconds=2):
+        ) < on_since - self._on_since > timedelta(seconds=5):
             self._on_since = on_since
         return self._on_since
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -500,6 +500,7 @@ class SmartDevice(Device):
             not self._info.get("device_on")
             or (on_time := self._info.get("on_time")) is None
         ):
+            self._on_since = None
             return None
 
         on_time = cast(float, on_time)

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -66,6 +66,7 @@ class SmartDevice(Device):
         self._children: Mapping[str, SmartDevice] = {}
         self._last_update = {}
         self._last_update_time: float | None = None
+        self._on_since: datetime | None = None
 
     async def _initialize_children(self):
         """Initialize children for power strips."""
@@ -502,7 +503,14 @@ class SmartDevice(Device):
             return None
 
         on_time = cast(float, on_time)
-        return self.time - timedelta(seconds=on_time)
+        on_since = self.time - timedelta(seconds=on_time)
+        # Ensure slight variations between time module and on_time do not cause the
+        # on_since time to change. More likely to happen with child devices.
+        if not self._on_since or timedelta(
+            seconds=0
+        ) < on_since - self._on_since > timedelta(seconds=2):
+            self._on_since = on_since
+        return self._on_since
 
     @property
     def timezone(self) -> dict:

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -495,7 +495,11 @@ class SmartDevice(Device):
 
     @property
     def on_since(self) -> datetime | None:
-        """Return the time that the device was turned on or None if turned off."""
+        """Return the time that the device was turned on or None if turned off.
+
+        Could be inprecise by up to 5 seconds due to device jitter between
+        the device reporting time and on_time.
+        """
         if (
             not self._info.get("device_on")
             or (on_time := self._info.get("on_time")) is None
@@ -505,9 +509,6 @@ class SmartDevice(Device):
 
         on_time = cast(float, on_time)
         on_since = self.time - timedelta(seconds=on_time)
-        # Ensure slight variations between time module and on_time do not cause
-        # the on_since time to change. More likely to happen with child devices
-        # or P100s that do not do multi-queries.
         if not self._on_since or timedelta(
             seconds=0
         ) < on_since - self._on_since > timedelta(seconds=5):


### PR DESCRIPTION
Should address [HA issue 126852](https://github.com/home-assistant/core/issues/126852).

It's difficult to know for certain how many seconds to set this to but I suspect the variation is just 1 second.