### PR TITLE
Send empty dictionary instead of null for iot queries

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -285,7 +285,7 @@ async def get_legacy_fixture(device):
         try:
             click.echo(f"Testing {test_call}..", nl=False)
             info = await device.protocol.query(
-                {test_call.module: {test_call.method: None}}
+                {test_call.module: {test_call.method: {}}}
             )
             resp = info[test_call.module]
         except Exception as ex:

--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -302,7 +302,7 @@ async def get_legacy_fixture(device):
     final_query = defaultdict(defaultdict)
     final = defaultdict(defaultdict)
     for succ, resp in successes:
-        final_query[succ.module][succ.method] = None
+        final_query[succ.module][succ.method] = {}
         final[succ.module][succ.method] = resp
 
     final = default_to_regular(final)

--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -32,8 +32,8 @@ from .xortransport import XorTransport
 
 _LOGGER = logging.getLogger(__name__)
 
-GET_SYSINFO_QUERY = {
-    "system": {"get_sysinfo": None},
+GET_SYSINFO_QUERY: dict[str, dict[str, dict]] = {
+    "system": {"get_sysinfo": {}},
 }
 
 

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -296,8 +296,8 @@ class Discover:
 
     DISCOVERY_PORT = 9999
 
-    DISCOVERY_QUERY = {
-        "system": {"get_sysinfo": None},
+    DISCOVERY_QUERY: dict[str, dict[str, dict]] = {
+        "system": {"get_sysinfo": {}},
     }
 
     DISCOVERY_PORT_2 = 20002

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -207,6 +207,8 @@ class IotDevice(Device):
     def _create_request(
         self, target: str, cmd: str, arg: dict | None = None, child_ids=None
     ):
+        if arg is None:
+            arg = {}
         request: dict[str, Any] = {target: {cmd: arg}}
         if child_ids is not None:
             request = {"context": {"child_ids": child_ids}, target: {cmd: arg}}

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -88,7 +88,7 @@ class KlapTransport(BaseTransport):
     """
 
     DEFAULT_PORT: int = 80
-    DISCOVERY_QUERY = {"system": {"get_sysinfo": None}}
+    DISCOVERY_QUERY: dict[str, dict[str, dict]] = {"system": {"get_sysinfo": {}}}
     SESSION_COOKIE_NAME = "TP_SESSIONID"
     TIMEOUT_COOKIE_NAME = "TIMEOUT"
 

--- a/kasa/klaptransport.py
+++ b/kasa/klaptransport.py
@@ -88,7 +88,6 @@ class KlapTransport(BaseTransport):
     """
 
     DEFAULT_PORT: int = 80
-    DISCOVERY_QUERY: dict[str, dict[str, dict]] = {"system": {"get_sysinfo": {}}}
     SESSION_COOKIE_NAME = "TP_SESSIONID"
     TIMEOUT_COOKIE_NAME = "TIMEOUT"
 


### PR DESCRIPTION
Fixes: #1120

UDP query from TAPO app is
```
{"system":{"get_sysinfo":{}},"cnCloud":{"get_info":{}},"smartlife.iot.common.cloud":{"get_info":{}},"smartlife.cam.ipcamera.cloud":{"get_info":{}}}
```