### PR TITLE
Correctly define SmartModule.call as an async function

### DIFF
--- a/kasa/smart/smartmodule.py
+++ b/kasa/smart/smartmodule.py
@@ -136,12 +136,12 @@ class SmartModule(Module):
         """
         return {self.QUERY_GETTER_NAME: None}
 
-    def call(self, method, params=None):
+    async def call(self, method, params=None):
         """Call a method.
 
         Just a helper method.
         """
-        return self._device._query_helper(method, params)
+        return await self._device._query_helper(method, params)
 
     @property
     def data(self):


### PR DESCRIPTION
The `SmartModule.call` function is always awaited and always calls an awaitable so it should be defined as an `async` function.
