### PR TITLE
Use tzinfo in time constructor instead of astime for iot devices

### DIFF
--- a/kasa/iot/modules/time.py
+++ b/kasa/iot/modules/time.py
@@ -37,8 +37,9 @@ class Time(IotModule):
             res["hour"],
             res["min"],
             res["sec"],
+            tzinfo=self.timezone,
         )
-        return time.astimezone(self.timezone)
+        return time
 
     @property
     def timezone(self) -> tzinfo:


### PR DESCRIPTION
Using `astime` on a non tzinfo aware object causes issues with daylight saving. 