### PR TITLE
Add alert volume setting to water leak sensor

### DIFF
--- a/kasa/cli/main.py
+++ b/kasa/cli/main.py
@@ -339,7 +339,7 @@ async def cli(
     # Skip update on specific commands, or if device factory,
     # that performs an update was used for the device.
     if ctx.invoked_subcommand not in SKIP_UPDATE_COMMANDS and not device_updated:
-        await dev.update()
+        await dev.update(update_children=True)
 
     @asynccontextmanager
     async def async_wrapped_device(device: Device):

--- a/kasa/tests/smart/modules/test_waterleak.py
+++ b/kasa/tests/smart/modules/test_waterleak.py
@@ -16,6 +16,7 @@ waterleak = parametrize(
     [
         ("water_alert", "alert", int),
         ("water_leak", "status", Enum),
+        ("water_alert_volume", "alert_volume", str),
     ],
 )
 async def test_waterleak_properties(dev, feature, prop_name, type):


### PR DESCRIPTION
This PR makes the water leak alert volume level configurable.

Marking a draft as this requires finding a solution for child device queries, similar to #1141.