### PR TITLE
Enforce EOLs for *.rst and *.md

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.sh        text eol=lf
 *.json      text eol=lf
+*.md        text eol=lf
+*.rst       text eol=lf


### PR DESCRIPTION
Looks like everything was fine, but let's do this nevertheless.