### PR TITLE
Improve supported module checks for hub children

### DIFF
--- a/kasa/smart/modules/devicemodule.py
+++ b/kasa/smart/modules/devicemodule.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from ...device_type import DeviceType
 from ..smartmodule import SmartModule
 
 
@@ -25,10 +24,7 @@ class DeviceModule(SmartModule):
         }
         # Device usage is not available on older firmware versions
         # or child devices of hubs
-        if self.supported_version >= 2 and (
-            self._device.parent is None
-            or self._device.parent.device_type is not DeviceType.Hub
-        ):
+        if self.supported_version >= 2 and not self._device._is_hub_child:
             query["get_device_usage"] = None
 
         return query

--- a/kasa/smart/modules/devicemodule.py
+++ b/kasa/smart/modules/devicemodule.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ...device_type import DeviceType
 from ..smartmodule import SmartModule
 
 
@@ -23,7 +24,11 @@ class DeviceModule(SmartModule):
             "get_device_info": None,
         }
         # Device usage is not available on older firmware versions
-        if self.supported_version >= 2:
+        # or child devices of hubs
+        if self.supported_version >= 2 and (
+            self._device.parent is None
+            or self._device.parent.device_type is not DeviceType.Hub
+        ):
             query["get_device_usage"] = None
 
         return query

--- a/kasa/smart/modules/time.py
+++ b/kasa/smart/modules/time.py
@@ -8,6 +8,7 @@ from typing import cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...cachedzoneinfo import CachedZoneInfo
+from ...device_type import DeviceType
 from ...feature import Feature
 from ...interfaces import Time as TimeInterface
 from ..smartmodule import SmartModule
@@ -83,3 +84,12 @@ class Time(SmartModule, TimeInterface):
             if region:
                 params["region"] = region
         return await self.call("set_device_time", params)
+
+    async def _check_supported(self):
+        """Additional check to see if the module is supported by the device.
+
+        Hub attached sensors report the time module but do return device time.
+        """
+        if (parent := self._device.parent) and parent.device_type == DeviceType.Hub:
+            return False
+        return await super()._check_supported()

--- a/kasa/smart/modules/time.py
+++ b/kasa/smart/modules/time.py
@@ -8,7 +8,6 @@ from typing import cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...cachedzoneinfo import CachedZoneInfo
-from ...device_type import DeviceType
 from ...feature import Feature
 from ...interfaces import Time as TimeInterface
 from ..smartmodule import SmartModule
@@ -90,6 +89,6 @@ class Time(SmartModule, TimeInterface):
 
         Hub attached sensors report the time module but do return device time.
         """
-        if (parent := self._device.parent) and parent.device_type == DeviceType.Hub:
+        if self._device._is_hub_child:
             return False
         return await super()._check_supported()

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -485,8 +485,8 @@ class SmartDevice(Device):
     @property
     def time(self) -> datetime:
         """Return the time."""
-        if (self._parent and (time_mod := self._parent.modules.get(Module.Time))) or (
-            time_mod := self.modules.get(Module.Time)
+        if (time_mod := self.modules.get(Module.Time)) or (
+            self._parent and (time_mod := self._parent.modules.get(Module.Time))
         ):
             return time_mod.time
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -458,6 +458,11 @@ class SmartDevice(Device):
             await child._initialize_features()
 
     @property
+    def _is_hub_child(self) -> bool:
+        """Returns true if the device is a child of a hub."""
+        return self.parent is not None and self.parent.device_type is DeviceType.Hub
+
+    @property
     def is_cloud_connected(self) -> bool:
         """Returns if the device is connected to the cloud."""
         if Module.Cloud not in self.modules:

--- a/kasa/tests/test_childdevice.py
+++ b/kasa/tests/test_childdevice.py
@@ -1,7 +1,9 @@
 import inspect
 import sys
+from datetime import datetime, timezone
 
 import pytest
+from freezegun.api import FrozenDateTimeFactory
 
 from kasa import Device
 from kasa.device_type import DeviceType
@@ -120,3 +122,15 @@ async def test_parent_property(dev: Device):
     assert dev.parent is None
     for child in dev.children:
         assert child.parent == dev
+
+
+@has_children_smart
+async def test_child_time(dev: Device, freezer: FrozenDateTimeFactory):
+    """Test a child device gets the time from it's parent module."""
+    if not dev.children:
+        pytest.skip(f"Device {dev} fixture does not have any children")
+
+    fallback_time = datetime.now(timezone.utc).astimezone().replace(microsecond=0)
+    assert dev.parent is None
+    for child in dev.children:
+        assert child.time != fallback_time


### PR DESCRIPTION
No devices in `fixtures/smart/child` support the `get_device_time` or `get_device_usage` methods so this PR tests for whether the device is a hub child and marks those modules/methods as not supported. This prevents features being erroneously created on child devices.

It also moves the logic for getting the time from the parent module behind getting it from the child module which was masking the creation of these unsupported modules.