### PR TITLE
Update SMART test framework to use fake child protocols

### DIFF
--- a/kasa/tests/fixtureinfo.py
+++ b/kasa/tests/fixtureinfo.py
@@ -118,10 +118,17 @@ def filter_fixtures(
     """
 
     def _model_match(fixture_data: FixtureInfo, model_filter: set[str]):
+        if isinstance(model_filter, str):
+            model_filter = {model_filter}
+        assert isinstance(model_filter, set), "model filter must be a set"
         model_filter_list = [mf for mf in model_filter]
-        if len(model_filter_list) == 1 and model_filter_list[0].split("_") == 3:
+        if (
+            len(model_filter_list) == 1
+            and (model := model_filter_list[0])
+            and len(model.split("_")) == 3
+        ):
             # return exact match
-            return fixture_data.name == model_filter_list[0]
+            return fixture_data.name == f"{model}.json"
         file_model_region = fixture_data.name.split("_")[0]
         file_model = file_model_region.split("(")[0]
         return file_model in model_filter

--- a/kasa/tests/test_emeter.py
+++ b/kasa/tests/test_emeter.py
@@ -14,6 +14,8 @@ from kasa import Device, EmeterStatus, Module
 from kasa.interfaces.energy import Energy
 from kasa.iot import IotDevice, IotStrip
 from kasa.iot.modules.emeter import Emeter
+from kasa.smart import SmartDevice
+from kasa.smart.modules import Energy as SmartEnergyModule
 
 from .conftest import has_emeter, has_emeter_iot, no_emeter
 
@@ -54,6 +56,11 @@ async def test_no_emeter(dev):
 
 @has_emeter
 async def test_get_emeter_realtime(dev):
+    if isinstance(dev, SmartDevice):
+        mod = SmartEnergyModule(dev, str(Module.Energy))
+        if not await mod._check_supported():
+            pytest.skip(f"Energy module not supported for {dev}.")
+
     assert dev.has_emeter
 
     current_emeter = await dev.get_emeter_realtime()
@@ -178,6 +185,10 @@ async def test_emeter_daily():
 
 @has_emeter
 async def test_supported(dev: Device):
+    if isinstance(dev, SmartDevice):
+        mod = SmartEnergyModule(dev, str(Module.Energy))
+        if not await mod._check_supported():
+            pytest.skip(f"Energy module not supported for {dev}.")
     energy_module = dev.modules.get(Module.Energy)
     assert energy_module
     if isinstance(dev, IotDevice):


### PR DESCRIPTION
Required for the P304M which uses energy modules directly on the child devices.
