### PR TITLE
Update fixture for ES20M 1.0.11

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -68,6 +68,7 @@ Some newer Kasa devices require authentication. These are marked with <sup>*</su
   - Hardware: 3.0 (US) / Firmware: 1.0.3
 - **KP303**
   - Hardware: 1.0 (UK) / Firmware: 1.0.3
+  - Hardware: 1.0 (UK) / Firmware: 1.0.6
   - Hardware: 2.0 (US) / Firmware: 1.0.3
   - Hardware: 2.0 (US) / Firmware: 1.0.9
 - **KP400**
@@ -251,6 +252,7 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
 - **H100**
   - Hardware: 1.0 (EU) / Firmware: 1.2.3
   - Hardware: 1.0 (EU) / Firmware: 1.5.10
+  - Hardware: 1.0 (EU) / Firmware: 1.5.20
   - Hardware: 1.0 (EU) / Firmware: 1.5.5
 
 ### Hub-Connected Devices

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -68,7 +68,6 @@ Some newer Kasa devices require authentication. These are marked with <sup>*</su
   - Hardware: 3.0 (US) / Firmware: 1.0.3
 - **KP303**
   - Hardware: 1.0 (UK) / Firmware: 1.0.3
-  - Hardware: 1.0 (UK) / Firmware: 1.0.6
   - Hardware: 2.0 (US) / Firmware: 1.0.3
   - Hardware: 2.0 (US) / Firmware: 1.0.9
 - **KP400**
@@ -252,7 +251,6 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
 - **H100**
   - Hardware: 1.0 (EU) / Firmware: 1.2.3
   - Hardware: 1.0 (EU) / Firmware: 1.5.10
-  - Hardware: 1.0 (EU) / Firmware: 1.5.20
   - Hardware: 1.0 (EU) / Firmware: 1.5.5
 
 ### Hub-Connected Devices

--- a/kasa/tests/fixtures/ES20M(US)_1.0_1.0.11.json
+++ b/kasa/tests/fixtures/ES20M(US)_1.0_1.0.11.json
@@ -44,6 +44,10 @@
             ],
             "err_code": 0,
             "ver": "1.0"
+        },
+        "get_current_brt": {
+            "err_code": 0,
+            "value": 16
         }
     },
     "smartlife.iot.PIR": {
@@ -55,11 +59,11 @@
                 0
             ],
             "cold_time": 120000,
-            "enable": 0,
+            "enable": 1,
             "err_code": 0,
             "max_adc": 4095,
             "min_adc": 0,
-            "trigger_index": 1,
+            "trigger_index": 0,
             "version": "1.0"
         }
     },
@@ -71,7 +75,7 @@
             "fadeOnTime": 0,
             "gentleOffTime": 10000,
             "gentleOnTime": 3000,
-            "minThreshold": 5,
+            "minThreshold": 17,
             "rampRate": 30
         }
     },
@@ -88,9 +92,9 @@
             "hw_ver": "1.0",
             "icon_hash": "",
             "latitude_i": 0,
-            "led_off": 0,
+            "led_off": 1,
             "longitude_i": 0,
-            "mac": "28:87:BA:00:00:00",
+            "mac": "B0:A7:B9:00:00:00",
             "mic_type": "IOT.SMARTPLUGSWITCH",
             "model": "ES20M(US)",
             "next_action": {
@@ -98,7 +102,7 @@
             },
             "obd_src": "tplink",
             "oemId": "00000000000000000000000000000000",
-            "on_time": 0,
+            "on_time": 6,
             "preferred_state": [
                 {
                     "brightness": 100,
@@ -117,8 +121,8 @@
                     "index": 3
                 }
             ],
-            "relay_state": 0,
-            "rssi": -54,
+            "relay_state": 1,
+            "rssi": -40,
             "status": "new",
             "sw_ver": "1.0.11 Build 240514 Rel.110351",
             "updating": 0

--- a/kasa/tests/test_dimmer.py
+++ b/kasa/tests/test_dimmer.py
@@ -9,6 +9,7 @@ from .conftest import dimmer_iot, handle_turn_on, turn_on
 @dimmer_iot
 async def test_set_brightness(dev):
     await handle_turn_on(dev, False)
+    await dev.update()
     assert dev.is_on is False
 
     await dev.set_brightness(99)
@@ -89,6 +90,7 @@ async def test_turn_off_transition(dev, mocker):
     original_brightness = dev.brightness
 
     await dev.turn_off(transition=1000)
+    await dev.update()
 
     assert dev.is_off
     assert dev.brightness == original_brightness
@@ -126,6 +128,7 @@ async def test_set_dimmer_transition_to_off(dev, turn_on, mocker):
     query_helper = mocker.spy(IotDimmer, "_query_helper")
 
     await dev.set_dimmer_transition(0, 1000)
+    await dev.update()
 
     assert dev.is_off
     assert dev.brightness == original_brightness


### PR DESCRIPTION
Fixture by courtesy of JetSerge on the HA community forums.
This is the first one to contain `get_current_brt` (#1209).