### PR TITLE
Print formatting for IotLightPreset

### DIFF
--- a/kasa/cli/light.py
+++ b/kasa/cli/light.py
@@ -131,7 +131,11 @@ def presets_list(dev: Device):
         return
 
     for preset in light_preset.preset_states_list:
-        echo(preset)
+        echo(
+            f"[{preset.index}] Hue: {preset.hue:3}  Saturation: {preset.saturation:3}  "
+            f"Brightness/Value: {preset.brightness:3}  Temp: {preset.color_temp:4}  "
+            f"Custom: {preset.custom}  Mode: {preset.mode}  Id: {preset.id}"
+        )
 
     return light_preset.preset_states_list
 

--- a/kasa/cli/light.py
+++ b/kasa/cli/light.py
@@ -130,11 +130,10 @@ def presets_list(dev: Device):
         error("Presets not supported on device")
         return
 
-    for preset in light_preset.preset_states_list:
+    for idx, preset in enumerate(light_preset.preset_states_list):
         echo(
-            f"[{preset.index}] Hue: {preset.hue:3}  Saturation: {preset.saturation:3}  "
-            f"Brightness/Value: {preset.brightness:3}  Temp: {preset.color_temp:4}  "
-            f"Custom: {preset.custom}  Mode: {preset.mode}  Id: {preset.id}"
+            f"[{idx}] Hue: {preset.hue:3}  Saturation: {preset.saturation:3}  "
+            f"Brightness/Value: {preset.brightness:3}  Temp: {preset.color_temp:4}"
         )
 
     return light_preset.preset_states_list


### PR DESCRIPTION
Now prints presets as such:

```
[0] Hue:   0  Saturation:   0  Brightness/Value: 100  Temp: 6000  Custom: None  Mode: None  Id: None
[1] Hue:   0  Saturation:   0  Brightness/Value: 100  Temp: 2500  Custom: None  Mode: None  Id: None
[2] Hue:   0  Saturation:   0  Brightness/Value:  60  Temp: 2500  Custom: None  Mode: None  Id: None
[3] Hue: 240  Saturation: 100  Brightness/Value: 100  Temp:    0  Custom: None  Mode: None  Id: None
```

Apparently NoneType doesn't like f-strings (`unsupported format string passed to NoneType.__format__`), so I didn't add spaced formatting to the last 3 properties. 