### PR TITLE
Add PIR&LAS for wall switches mentioning PIR support

### DIFF
--- a/kasa/iot/iotplug.py
+++ b/kasa/iot/iotplug.py
@@ -9,7 +9,7 @@ from ..deviceconfig import DeviceConfig
 from ..module import Module
 from ..protocol import BaseProtocol
 from .iotdevice import IotDevice, requires_update
-from .modules import Antitheft, Cloud, Led, Schedule, Time, Usage
+from .modules import AmbientLight, Antitheft, Cloud, Led, Motion, Schedule, Time, Usage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -92,3 +92,12 @@ class IotWallSwitch(IotPlug):
     ) -> None:
         super().__init__(host=host, config=config, protocol=protocol)
         self._device_type = DeviceType.WallSwitch
+
+    async def _initialize_modules(self) -> None:
+        """Initialize modules."""
+        await super()._initialize_modules()
+        if (dev_name := self.sys_info["dev_name"]) and "PIR" in dev_name:
+            self.add_module(Module.IotMotion, Motion(self, "smartlife.iot.PIR"))
+            self.add_module(
+                Module.IotAmbientLight, AmbientLight(self, "smartlife.iot.LAS")
+            )

--- a/kasa/tests/iot/test_wallswitch.py
+++ b/kasa/tests/iot/test_wallswitch.py
@@ -5,9 +5,5 @@ from ..device_fixtures import wallswitch_iot
 def test_wallswitch_motion(dev):
     """Check that wallswitches with motion sensor get modules enabled."""
     has_motion = "PIR" in dev.sys_info["dev_name"]
-    if has_motion:
-        assert "motion" in dev.modules
-        assert "ambient" in dev.modules
-    else:
-        assert "motion" not in dev.modules
-        assert "ambient" not in dev.modules
+    assert "motion" in dev.modules if has_motion else True
+    assert "ambient" in dev.modules if has_motion else True

--- a/kasa/tests/iot/test_wallswitch.py
+++ b/kasa/tests/iot/test_wallswitch.py
@@ -1,4 +1,4 @@
-from ..device_fixtures import wallswitch_iot
+from kasa.tests.device_fixtures import wallswitch_iot
 
 
 @wallswitch_iot

--- a/kasa/tests/iot/test_wallswitch.py
+++ b/kasa/tests/iot/test_wallswitch.py
@@ -1,0 +1,13 @@
+from ..device_fixtures import wallswitch_iot
+
+
+@wallswitch_iot
+def test_wallswitch_motion(dev):
+    """Check that wallswitches with motion sensor get modules enabled."""
+    has_motion = "PIR" in dev.sys_info["dev_name"]
+    if has_motion:
+        assert "motion" in dev.modules
+        assert "ambient" in dev.modules
+    else:
+        assert "motion" not in dev.modules
+        assert "ambient" not in dev.modules


### PR DESCRIPTION
Some devices (like KS200M) support ambient and motion, but as they are detected as wall switches, they don't get the modules added.
This PR enables the respective modules for wall switches when the `dev_name` contains `PIR`.

Fixes #1226