### PR TITLE
Make __repr__ work on discovery info

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -469,9 +469,11 @@ class Device(ABC):
         """
 
     def __repr__(self):
-        if self._last_update is None:
-            return f"<{self.device_type} at {self.host} - update() needed>"
-        return f"<{self.device_type} at {self.host} - {self.alias} ({self.model})>"
+        update_needed = " - update() needed" if not self._last_update else ""
+        return (
+            f"<{self.device_type} at {self.host} -"
+            f" {self.alias} ({self.model}){update_needed}>"
+        )
 
     _deprecated_device_type_attributes = {
         # is_type

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -732,8 +732,10 @@ class SmartDevice(Device):
         if self._device_type is not DeviceType.Unknown:
             return self._device_type
 
+        # Fallback to device_type (from disco info)
+        type_str = self._info.get("type", self._info.get("device_type"))
         self._device_type = self._get_device_type_from_components(
-            list(self._components.keys()), self._info["type"]
+            list(self._components.keys()), type_str
         )
 
         return self._device_type


### PR DESCRIPTION
This PR will make `__repr__` also work on smartdevices where only discovery data is available by modifying the `model` property to fallback to the data found in the discovery payloads.

May fix #1232