### PR TITLE
Add ADC Value to PIR Enabled Switches

### DIFF
--- a/kasa/cli/feature.py
+++ b/kasa/cli/feature.py
@@ -133,7 +133,7 @@ async def feature(
         echo(f"{feat.name} ({name}): {feat.value}{unit}")
         return feat.value
 
-    value = ast.literal_eval(value)
+    value = feat.parse_value(value, ast.literal_eval)
     echo(f"Changing {name} from {feat.value} to {value}")
     response = await dev.features[name].set_value(value)
     await dev.update()

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -164,9 +164,6 @@ class Feature:
     #: If set, this property will be used to get *choices*.
     choices_getter: str | Callable[[], list[str]] | None = None
 
-    #: Value converter, for when working with complex types.
-    value_parser: str | None = None
-
     def __post_init__(self) -> None:
         """Handle late-binding of members."""
         # Populate minimum & maximum values, if range_getter is given
@@ -259,7 +256,7 @@ class Feature:
         elif self.type == Feature.Type.Choice:  # noqa: SIM102
             if not self.choices or value not in self.choices:
                 raise ValueError(
-                    f"Unexpected value for {self.name}: {value}"
+                    f"Unexpected value for {self.name}: '{value}'"
                     f" - allowed: {self.choices}"
                 )
 
@@ -273,26 +270,6 @@ class Feature:
             return await attribute_setter()
 
         return await attribute_setter(value)
-
-    def parse_value(
-        self, value: str, fallback: Callable[[str], Any | None] = lambda x: None
-    ) -> Any | None:
-        """Attempt to parse a given string into a value accepted by this feature."""
-        parser = self._get_property_value(self.value_parser)
-        parser = parser if parser else fallback
-        allowed = f"{self.choices}" if self.choices else "Unknown"
-        try:
-            parsed = parser(value)
-            if parsed is None:
-                raise ValueError(
-                    f"Unexpected value for {self.name}: {value}"
-                    f" - allowed: {allowed}"
-                )
-            return parsed
-        except SyntaxError as se:
-            raise ValueError(
-                f"{se.msg} for {self.name}: {value}" f" - allowed: {allowed}",
-            ) from se
 
     def __repr__(self) -> str:
         try:

--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -280,7 +280,7 @@ class Feature:
 
         if self.type == Feature.Type.Choice:
             if not isinstance(choices, list):
-                _LOGGER.critical(
+                _LOGGER.error(
                     "Choices are not properly defined for %s (%s). Type: <%s> Value: %s",  # noqa: E501
                     self.name,
                     self.id,

--- a/kasa/iot/modules/motion.py
+++ b/kasa/iot/modules/motion.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 import logging
 from enum import Enum
+from typing import Literal, overload
 
 from ...exceptions import KasaException
 from ...feature import Feature
-from ..iotmodule import IotModule
+from ..iotmodule import IotModule, merge
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -20,6 +21,9 @@ class Range(Enum):
     Near = 2
     Custom = 3
 
+    def __str__(self) -> str:
+        return self.name
+
 
 class Motion(IotModule):
     """Implements the motion detection (PIR) module."""
@@ -28,6 +32,11 @@ class Motion(IotModule):
         """Initialize features after the initial update."""
         # Only add features if the device supports the module
         if "get_config" not in self.data:
+            return
+
+        # Require that ADC value is also present.
+        if "get_adc_value" not in self.data:
+            _LOGGER.warning("%r initialized, but no get_adc_value in response")
             return
 
         if "enable" not in self.config:
@@ -48,19 +57,77 @@ class Motion(IotModule):
             )
         )
 
+        self._add_feature(
+            Feature(
+                device=self._device,
+                container=self,
+                id="pir_range",
+                name="Motion Sensor Range",
+                icon="mdi:motion-sensor",
+                attribute_getter="range",
+                attribute_setter="_set_range_cli",
+                type=Feature.Type.Choice,
+                choices_getter="ranges",
+                value_parser="parse_range_value",
+                category=Feature.Category.Config,
+            )
+        )
+
+        self._add_feature(
+            Feature(
+                device=self._device,
+                container=self,
+                id="pir_threshold",
+                name="Motion Sensor Threshold",
+                icon="mdi:motion-sensor",
+                attribute_getter="threshold",
+                attribute_setter="set_threshold",
+                type=Feature.Type.Number,
+                category=Feature.Category.Config,
+            )
+        )
+
+        self._add_feature(
+            Feature(
+                device=self._device,
+                container=self,
+                id="pir_adc_value",
+                name="PIR ADC Value",
+                icon="mdi:motion-sensor",
+                attribute_getter="adc_value",
+                attribute_setter=None,
+                type=Feature.Type.Sensor,
+                category=Feature.Category.Primary,
+            )
+        )
+
+        self._add_feature(
+            Feature(
+                device=self._device,
+                container=self,
+                id="pir_triggered",
+                name="PIR Triggered",
+                icon="mdi:motion-sensor",
+                attribute_getter="is_triggered",
+                attribute_setter=None,
+                type=Feature.Type.Sensor,
+                category=Feature.Category.Primary,
+            )
+        )
+
     def query(self) -> dict:
         """Request PIR configuration."""
-        return self.query_for_command("get_config")
+        req = merge(
+            self.query_for_command("get_config"),
+            self.query_for_command("get_adc_value"),
+        )
+
+        return req
 
     @property
     def config(self) -> dict:
         """Return current configuration."""
         return self.data["get_config"]
-
-    @property
-    def range(self) -> Range:
-        """Return motion detection range."""
-        return Range(self.config["trigger_index"])
 
     @property
     def enabled(self) -> bool:
@@ -71,22 +138,98 @@ class Motion(IotModule):
         """Enable/disable PIR."""
         return await self.call("set_enable", {"enable": int(state)})
 
-    async def set_range(
-        self, *, range: Range | None = None, custom_range: int | None = None
-    ) -> dict:
-        """Set the range for the sensor.
+    def _parse_range_value(self, value: str) -> int | Range | None:
+        """Attempt to parse a range value from the given string."""
+        _LOGGER.debug("Parse Range Value: %s", value)
+        parsed: int | Range | None = None
+        try:
+            parsed = int(value)
+            _LOGGER.debug("Parse Range Value: %s is an integer.", value)
+            return parsed
+        except ValueError:
+            _LOGGER.debug("Parse Range Value: %s is not an integer.", value)
+        value = value.strip().upper()
+        if value in Range._member_names_:
+            _LOGGER.debug("Parse Range Value: %s is an enumeration.", value)
+            parsed = Range[value]
+            return parsed
+        _LOGGER.debug("Parse Range Value: %s is not a Range Value.", value)
+        return None
 
-        :param range: for using standard ranges
-        :param custom_range: range in decimeters, overrides the range parameter
+    @property
+    def ranges(self) -> list[Range]:
+        """Return set of supported range classes."""
+        range_min = 0
+        range_max = len(self.config["array"])
+        valid_ranges = list()
+        for r in Range:
+            if (r.value >= range_min) and (r.value < range_max):
+                valid_ranges.append(r)
+        return valid_ranges
+
+    @property
+    def range(self) -> Range:
+        """Return motion detection Range."""
+        return Range(self.config["trigger_index"])
+
+    @overload
+    async def set_range(self, *, range: Range) -> dict: ...
+
+    @overload
+    async def set_range(self, *, range: Literal[Range.Custom], value: int) -> dict: ...
+
+    @overload
+    async def set_range(self, *, value: int) -> dict: ...
+
+    async def set_range(
+        self, *, range: Range | None = None, value: int | None = None
+    ) -> dict:
+        """Set the Range for the sensor.
+
+        :param Range: for using standard Ranges
+        :param custom_Range: Range in decimeters, overrides the Range parameter
         """
-        if custom_range is not None:
-            payload = {"index": Range.Custom.value, "value": custom_range}
+        if value is not None:
+            if range is not None and range is not Range.Custom:
+                raise KasaException(
+                    "Refusing to set non-custom range %s to value %d." % (range, value)
+                )
+            elif value is None:
+                raise KasaException("Custom range threshold may not be set to None.")
+            payload = {"index": Range.Custom.value, "value": value}
         elif range is not None:
             payload = {"index": range.value}
         else:
-            raise KasaException("Either range or custom_range need to be defined")
+            raise KasaException("Either range or value needs to be defined")
 
         return await self.call("set_trigger_sens", payload)
+
+    async def _set_range_cli(self, input: Range | int) -> dict:
+        if isinstance(input, Range):
+            return await self.set_range(range=input)
+        elif isinstance(input, int):
+            return await self.set_range(value=input)
+        else:
+            raise KasaException(
+                "Invalid type: %s given to cli motion set." % (type(input))
+            )
+
+    def get_range_threshold(self, range_type: Range) -> int:
+        """Get the distance threshold at which the PIR sensor is will trigger."""
+        if range_type.value < 0 or range_type.value >= len(self.config["array"]):
+            raise KasaException(
+                "Range type is outside the bounds of the configured device ranges."
+            )
+        return int(self.config["array"][range_type.value])
+
+    @property
+    def threshold(self) -> int:
+        """Return motion detection Range."""
+        return self.get_range_threshold(self.range)
+
+    async def set_threshold(self, value: int) -> dict:
+        """Set the distance threshold at which the PIR sensor is will trigger."""
+        return await self.set_range(value=value)
 
     @property
     def inactivity_timeout(self) -> int:
@@ -100,3 +243,13 @@ class Motion(IotModule):
         to avoid reverting this back to 60 seconds after a period of time.
         """
         return await self.call("set_cold_time", {"cold_time": timeout})
+
+    @property
+    def adc_value(self) -> int:
+        """Return motion adc value."""
+        return int(self.data["get_adc_value"]["value"])
+
+    @property
+    def is_triggered(self) -> bool:
+        """Return if the motion sensor has been triggered."""
+        return (self.enabled) and (self.adc_value < self.threshold)

--- a/kasa/iot/modules/motion.py
+++ b/kasa/iot/modules/motion.py
@@ -124,7 +124,7 @@ class Motion(IotModule):
                 name="Motion Sensor Range",
                 icon="mdi:motion-sensor",
                 attribute_getter="range",
-                attribute_setter="_set_range_cli",
+                attribute_setter="_set_range_from_str",
                 type=Feature.Type.Choice,
                 choices_getter="ranges",
                 category=Feature.Category.Config,
@@ -336,7 +336,7 @@ class Motion(IotModule):
             )
         return Range[value]
 
-    async def _set_range_cli(self, input: str) -> dict:
+    async def _set_range_from_str(self, input: str) -> dict:
         value = self._parse_range_value(input)
         return await self.set_range(range=value)
 

--- a/tests/fakeprotocol_iot.py
+++ b/tests/fakeprotocol_iot.py
@@ -192,6 +192,7 @@ AMBIENT_MODULE = {
 
 
 MOTION_MODULE = {
+    "get_adc_value": {"value": 50, "err_code": 0},
     "get_config": {
         "enable": 0,
         "version": "1.0",
@@ -201,7 +202,7 @@ MOTION_MODULE = {
         "max_adc": 4095,
         "array": [80, 50, 20, 0],
         "err_code": 0,
-    }
+    },
 }
 
 LIGHT_DETAILS = {

--- a/tests/iot/modules/test_motion.py
+++ b/tests/iot/modules/test_motion.py
@@ -69,6 +69,15 @@ async def test_motion_threshold(dev: IotDimmer, mocker: MockerFixture):
 
 
 @dimmer_iot
+async def test_motion_realtime(dev: IotDimmer, mocker: MockerFixture):
+    motion: Motion = dev.modules[Module.IotMotion]
+    query_helper = mocker.patch("kasa.iot.IotDimmer._query_helper")
+
+    await motion.get_pir_state()
+    query_helper.assert_called_with("smartlife.iot.PIR", "get_adc_value", None)
+
+
+@dimmer_iot
 def test_motion_feature(dev: IotDimmer):
     assert Module.IotMotion in dev.modules
     motion: Motion = dev.modules[Module.IotMotion]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1185,7 +1185,7 @@ async def test_feature_set_unquoted(mocker, runner):
     dummy_device = await get_device_for_fixture_protocol(
         "ES20M(US)_1.0_1.0.11.json", "IOT"
     )
-    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_cli")
+    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_from_str")
     mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
 
     res = await runner.invoke(
@@ -1204,7 +1204,7 @@ async def test_feature_set_badquoted(mocker, runner):
     dummy_device = await get_device_for_fixture_protocol(
         "ES20M(US)_1.0_1.0.11.json", "IOT"
     )
-    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_cli")
+    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_from_str")
     mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
 
     res = await runner.invoke(
@@ -1216,6 +1216,25 @@ async def test_feature_set_badquoted(mocker, runner):
     range_setter.assert_not_called()
     assert "Error: Invalid value: " in res.output
     assert res.exit_code != 0
+
+
+async def test_feature_set_goodquoted(mocker, runner):
+    """Test feature command's set value."""
+    dummy_device = await get_device_for_fixture_protocol(
+        "ES20M(US)_1.0_1.0.11.json", "IOT"
+    )
+    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_from_str")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature", "pir_range", "'Far'"],
+        catch_exceptions=False,
+    )
+
+    range_setter.assert_called()
+    assert "Error: Invalid value: " not in res.output
+    assert res.exit_code == 0
 
 
 async def test_cli_child_commands(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1180,6 +1180,44 @@ async def test_feature_set_child(mocker, runner):
     assert res.exit_code == 0
 
 
+async def test_feature_set_unquoted(mocker, runner):
+    """Test feature command's set value."""
+    dummy_device = await get_device_for_fixture_protocol(
+        "ES20M(US)_1.0_1.0.11.json", "IOT"
+    )
+    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_cli")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature", "pir_range", "Far"],
+        catch_exceptions=False,
+    )
+
+    range_setter.assert_not_called()
+    assert "Error: Invalid value: " in res.output
+    assert res.exit_code != 0
+
+
+async def test_feature_set_badquoted(mocker, runner):
+    """Test feature command's set value."""
+    dummy_device = await get_device_for_fixture_protocol(
+        "ES20M(US)_1.0_1.0.11.json", "IOT"
+    )
+    range_setter = mocker.patch("kasa.iot.modules.motion.Motion._set_range_cli")
+    mocker.patch("kasa.discover.Discover.discover_single", return_value=dummy_device)
+
+    res = await runner.invoke(
+        cli,
+        ["--host", "127.0.0.123", "--debug", "feature", "pir_range", "`Far"],
+        catch_exceptions=False,
+    )
+
+    range_setter.assert_not_called()
+    assert "Error: Invalid value: " in res.output
+    assert res.exit_code != 0
+
+
 async def test_cli_child_commands(
     dev: Device, runner: CliRunner, mocker: MockerFixture
 ):

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -141,7 +141,10 @@ async def test_feature_choice_list(dummy_feature, caplog, mocker: MockerFixture)
     mock_setter.assert_called_with("first")
     mock_setter.reset_mock()
 
-    with pytest.raises(ValueError, match="Unexpected value for dummy_feature: invalid"):  # noqa: PT012
+    with pytest.raises(  # noqa: PT012
+        ValueError,
+        match="Unexpected value for dummy_feature: 'invalid' (?: - allowed: .*)?",
+    ):
         await dummy_feature.set_value("invalid")
         assert "Unexpected value" in caplog.text
 


### PR DESCRIPTION
- Add: ADC value reporting to PIR enabled switches, so that it may be used in polling automations.
- Add: ADC trigger state value reporting, for simpler automations.
- Add: Ability for features to use custom value parsers.