### PR TITLE
dump_devinfo: query smartlife.iot.common.cloud for fw updates

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -401,6 +401,8 @@ async def get_legacy_fixture(
         Call(module="emeter", method="get_realtime"),
         Call(module="cnCloud", method="get_info"),
         Call(module="cnCloud", method="get_intl_fw_list"),
+        Call(module="smartlife.iot.common.cloud", method="get_info"),
+        Call(module="smartlife.iot.common.cloud", method="get_intl_fw_list"),
         Call(module="smartlife.iot.common.schedule", method="get_next_action"),
         Call(module="smartlife.iot.common.schedule", method="get_rules"),
         Call(module="schedule", method="get_next_action"),

--- a/tests/fixtures/KL130(EU)_1.0_1.8.8.json
+++ b/tests/fixtures/KL130(EU)_1.0_1.8.8.json
@@ -1,19 +1,81 @@
 {
+    "smartlife.iot.common.cloud": {
+        "get_info": {
+            "binded": 1,
+            "cld_connection": 1,
+            "err_code": 0,
+            "fwDlPage": "",
+            "fwNotifyType": 0,
+            "illegalType": 0,
+            "server": "n-devs.tplinkcloud.com",
+            "stopConnect": 0,
+            "tcspInfo": "",
+            "tcspStatus": 1,
+            "username": "#MASKED_NAME#"
+        },
+        "get_intl_fw_list": {
+            "err_code": 0,
+            "fw_list": [
+                {
+                    "fwLocation": 0,
+                    "fwReleaseDate": "2019-11-27",
+                    "fwReleaseLog": "New Features/Enhancements:\n1. Added the offset feature when scheduling sunset/sunrise.\n2. Improved the overall performance of schedule feature.",
+                    "fwReleaseLogUrl": "undefined yet",
+                    "fwTitle": "Hi, a new firmware with bug fixes is available for your product.",
+                    "fwType": 0,
+                    "fwUrl": "http://download.tplinkcloud.com/firmware/smartBulb_FCC_1.8.11_Build_191113_Rel.105336__1574839035801.bin",
+                    "fwVer": "1.8.11 Build 191113 Rel.105336"
+                }
+            ]
+        }
+    },
     "smartlife.iot.common.emeter": {
         "get_realtime": {
             "err_code": 0,
-            "power_mw": 2500
+            "power_mw": 0
+        }
+    },
+    "smartlife.iot.common.schedule": {
+        "get_next_action": {
+            "err_code": 0,
+            "type": -1
+        },
+        "get_rules": {
+            "enable": 1,
+            "err_code": 0,
+            "rule_list": []
         }
     },
     "smartlife.iot.smartbulb.lightingservice": {
-        "get_light_state": {
-            "brightness": 17,
-            "color_temp": 2500,
+        "get_default_behavior": {
             "err_code": 0,
-            "hue": 0,
-            "mode": "normal",
-            "on_off": 1,
-            "saturation": 0
+            "hard_on": {
+                "mode": "last_status"
+            },
+            "soft_on": {
+                "mode": "last_status"
+            }
+        },
+        "get_light_details": {
+            "color_rendering_index": 80,
+            "err_code": 0,
+            "incandescent_equivalent": 60,
+            "lamp_beam_angle": 150,
+            "max_lumens": 800,
+            "max_voltage": 120,
+            "min_voltage": 110,
+            "wattage": 10
+        },
+        "get_light_state": {
+            "dft_on_state": {
+                "brightness": 16,
+                "color_temp": 2500,
+                "hue": 0,
+                "mode": "normal",
+                "saturation": 0
+            },
+            "err_code": 0,
+            "on_off": 0
         }
     },
     "system": {
@@ -29,7 +91,7 @@
             "deviceId": "0000000000000000000000000000000000000000",
             "disco_ver": "1.0",
             "err_code": 0,
-            "heapsize": 334708,
+            "heapsize": 308388,
             "hwId": "00000000000000000000000000000000",
             "hw_ver": "1.0",
             "is_color": 1,
@@ -37,12 +99,14 @@
             "is_factory": false,
             "is_variable_color_temp": 1,
             "light_state": {
-                "brightness": 17,
-                "color_temp": 2500,
-                "hue": 0,
-                "mode": "normal",
-                "on_off": 1,
-                "saturation": 0
+                "dft_on_state": {
+                    "brightness": 16,
+                    "color_temp": 2500,
+                    "hue": 0,
+                    "mode": "normal",
+                    "saturation": 0
+                },
+                "on_off": 0
             },
             "mic_mac": "1C3BF3000000",
             "mic_type": "IOT.SMARTBULB",
@@ -51,7 +115,7 @@
             "preferred_state": [
                 {
                     "brightness": 50,
-                    "color_temp": 2500,
+                    "color_temp": 2700,
                     "hue": 0,
                     "index": 0,
                     "saturation": 0
@@ -59,9 +123,9 @@
                 {
                     "brightness": 100,
                     "color_temp": 0,
-                    "hue": 299,
+                    "hue": 0,
                     "index": 1,
-                    "saturation": 95
+                    "saturation": 75
                 },
                 {
                     "brightness": 100,
@@ -78,7 +142,7 @@
                     "saturation": 75
                 }
             ],
-            "rssi": -60,
+            "rssi": -57,
             "sw_ver": "1.8.8 Build 190613 Rel.123436"
         }
     }

--- a/tests/fixtures/KL130(EU)_1.0_1.8.8.json
+++ b/tests/fixtures/KL130(EU)_1.0_1.8.8.json
@@ -32,7 +32,7 @@
     "smartlife.iot.common.emeter": {
         "get_realtime": {
             "err_code": 0,
-            "power_mw": 0
+            "power_mw": 10800
         }
     },
     "smartlife.iot.common.schedule": {
@@ -50,10 +50,15 @@
         "get_default_behavior": {
             "err_code": 0,
             "hard_on": {
-                "mode": "last_status"
+                "mode": "circadian"
             },
             "soft_on": {
-                "mode": "last_status"
+                "brightness": 50,
+                "color_temp": 2700,
+                "hue": 0,
+                "index": 0,
+                "mode": "customize_preset",
+                "saturation": 0
             }
         },
         "get_light_details": {
@@ -67,15 +72,13 @@
             "wattage": 10
         },
         "get_light_state": {
-            "dft_on_state": {
-                "brightness": 16,
-                "color_temp": 2500,
-                "hue": 0,
-                "mode": "normal",
-                "saturation": 0
-            },
+            "brightness": 100,
+            "color_temp": 2700,
             "err_code": 0,
-            "on_off": 0
+            "hue": 0,
+            "mode": "normal",
+            "on_off": 1,
+            "saturation": 0
         }
     },
     "system": {
@@ -91,7 +94,7 @@
             "deviceId": "0000000000000000000000000000000000000000",
             "disco_ver": "1.0",
             "err_code": 0,
-            "heapsize": 308388,
+            "heapsize": 308144,
             "hwId": "00000000000000000000000000000000",
             "hw_ver": "1.0",
             "is_color": 1,
@@ -99,14 +102,12 @@
             "is_factory": false,
             "is_variable_color_temp": 1,
             "light_state": {
-                "dft_on_state": {
-                    "brightness": 16,
-                    "color_temp": 2500,
-                    "hue": 0,
-                    "mode": "normal",
-                    "saturation": 0
-                },
-                "on_off": 0
+                "brightness": 100,
+                "color_temp": 2700,
+                "hue": 0,
+                "mode": "normal",
+                "on_off": 1,
+                "saturation": 0
             },
             "mic_mac": "1C3BF3000000",
             "mic_type": "IOT.SMARTBULB",
@@ -121,7 +122,7 @@
                     "saturation": 0
                 },
                 {
-                    "brightness": 100,
+                    "brightness": 20,
                     "color_temp": 0,
                     "hue": 0,
                     "index": 1,
@@ -142,7 +143,7 @@
                     "saturation": 75
                 }
             ],
-            "rssi": -57,
+            "rssi": -60,
             "sw_ver": "1.8.8 Build 190613 Rel.123436"
         }
     }


### PR DESCRIPTION
* Some devices (like iot bulbs) use a different module names, this fixes dumping for the cloud interface
* Updates KL130 fixture, containing new additions from #1278