### PR TITLE
Do not print out all the fixture names at the start of test runs

### DIFF
--- a/tests/fixtureinfo.py
+++ b/tests/fixtureinfo.py
@@ -207,10 +207,6 @@ def filter_fixtures(
 
         filtered.append(fixture_data)
 
-    if desc:
-        print(f"# {desc}")
-        for value in filtered:
-            print(f"\t{value.name}")
     filtered.sort()
     return filtered
 


### PR DESCRIPTION
Not easy to control this with a command option because the fixture filtering happens when the module is loaded.
