### PR TITLE
Add SMART Voltage Monitoring to Fixtures

### DIFF
--- a/devtools/helpers/smartrequests.py
+++ b/devtools/helpers/smartrequests.py
@@ -262,6 +262,8 @@ class SmartRequest:
         """Get energy usage."""
         return [
             SmartRequest("get_energy_usage"),
+            SmartRequest("get_emeter_data"),
+            SmartRequest("get_emeter_vgain_igain"),
             SmartRequest.get_raw_request("get_electricity_price_config"),
         ]
 

--- a/tests/fixtures/smart/KP125M(US)_1.0_1.2.3.json
+++ b/tests/fixtures/smart/KP125M(US)_1.0_1.2.3.json
@@ -94,7 +94,7 @@
         "factory_default": false,
         "ip": "127.0.0.123",
         "is_support_iot_cloud": true,
-        "mac": "48-22-54-00-00-00",
+        "mac": "78-8C-B5-00-00-00",
         "mgt_encrypt_schm": {
             "encrypt_type": "KLAP",
             "http_port": 80,
@@ -127,17 +127,15 @@
         "rule_list": []
     },
     "get_current_power": {
-        "current_power": 69
+        "current_power": 1
     },
     "get_device_info": {
         "auto_off_remain_time": 0,
         "auto_off_status": "off",
-        "avatar": "coffee_maker",
+        "avatar": "egg_boiler",
         "default_states": {
-            "state": {
-                "on": true
-            },
-            "type": "custom"
+            "state": {},
+            "type": "last_states"
         },
         "device_id": "0000000000000000000000000000000000000000",
         "device_on": true,
@@ -150,17 +148,17 @@
         "lang": "en_US",
         "latitude": 0,
         "longitude": 0,
-        "mac": "48-22-54-00-00-00",
+        "mac": "78-8C-B5-00-00-00",
         "model": "KP125M",
         "nickname": "I01BU0tFRF9OQU1FIw==",
         "oem_id": "00000000000000000000000000000000",
-        "on_time": 8818511,
+        "on_time": 936394,
         "overcurrent_status": "normal",
         "overheat_status": "normal",
         "power_protection_status": "normal",
         "region": "America/Denver",
-        "rssi": -40,
-        "signal_level": 3,
+        "rssi": -50,
+        "signal_level": 2,
         "specs": "",
         "ssid": "I01BU0tFRF9TU0lEIw==",
         "time_diff": -420,
@@ -169,169 +167,179 @@
     "get_device_time": {
         "region": "America/Denver",
         "time_diff": -420,
-        "timestamp": 1730957712
+        "timestamp": 1732069933
     },
     "get_device_usage": {
         "power_usage": {
-            "past30": 46786,
-            "past7": 10896,
-            "today": 1507
+            "past30": 971,
+            "past7": 442,
+            "today": 20
         },
         "saved_power": {
-            "past30": 0,
-            "past7": 0,
-            "today": 0
+            "past30": 14896,
+            "past7": 9370,
+            "today": 1152
         },
         "time_usage": {
-            "past30": 43175,
-            "past7": 10055,
-            "today": 1355
+            "past30": 15867,
+            "past7": 9812,
+            "today": 1172
         }
     },
     "get_electricity_price_config": {
         "constant_price": 0,
         "time_of_use_config": {
             "summer": {
-                "midpeak": 120,
-                "offpeak": 60,
-                "onpeak": 170,
+                "midpeak": 0,
+                "offpeak": 0,
+                "onpeak": 0,
                 "period": [
-                    5,
-                    1,
-                    10,
-                    31
+                    0,
+                    0,
+                    0,
+                    0
                 ],
                 "weekday_config": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
                     1,
                     1,
-                    2,
-                    2,
-                    2,
-                    2,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
                 ],
                 "weekend_config": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
                 ]
             },
             "winter": {
-                "midpeak": 90,
-                "offpeak": 60,
-                "onpeak": 110,
+                "midpeak": 0,
+                "offpeak": 0,
+                "onpeak": 0,
                 "period": [
-                    11,
-                    1,
-                    4,
-                    30
+                    0,
+                    0,
+                    0,
+                    0
                 ],
                 "weekday_config": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
                     1,
                     1,
-                    2,
-                    2,
-                    2,
-                    2,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
                 ],
                 "weekend_config": [
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1
                 ]
             }
         },
-        "type": "time_of_use"
+        "type": "constant"
+    },
+    "get_emeter_data": {
+        "current_ma": 33,
+        "energy_wh": 971,
+        "power_mw": 1003,
+        "voltage_mv": 121215
+    },
+    "get_emeter_vgain_igain": {
+        "igain": 10861,
+        "vgain": 118657
     },
     "get_energy_usage": {
-        "current_power": 69737,
+        "current_power": 1003,
         "electricity_charge": [
-            2901,
-            3351,
-            536
+            0,
+            0,
+            0
         ],
-        "local_time": "2024-11-06 22:35:14",
-        "month_energy": 9332,
-        "month_runtime": 8615,
-        "today_energy": 1507,
-        "today_runtime": 1355
+        "local_time": "2024-11-19 19:32:14",
+        "month_energy": 971,
+        "month_runtime": 15867,
+        "today_energy": 20,
+        "today_runtime": 1172
     },
     "get_fw_download_state": {
         "auto_upgrade": false,
@@ -358,19 +366,17 @@
         "led_rule": "always",
         "led_status": true,
         "night_mode": {
-            "end_time": 396,
-            "night_mode_type": "sunrise_sunset",
-            "start_time": 1013,
-            "sunrise_offset": 0,
-            "sunset_offset": 0
+            "end_time": 420,
+            "night_mode_type": "custom",
+            "start_time": 1320
         }
     },
     "get_matter_setup_info": {
         "setup_code": "00000000000",
-        "setup_payload": "00:000000-000000000000"
+        "setup_payload": "00:000000000000-000000"
     },
     "get_max_power": {
-        "max_power": 1537
+        "max_power": 1542
     },
     "get_next_event": {},
     "get_protection_power": {
@@ -441,10 +447,50 @@
                 "key_type": "wpa2_psk",
                 "signal_level": 1,
                 "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 0,
+                "key_type": "none",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
             }
         ],
         "start_index": 0,
-        "sum": 7,
+        "sum": 12,
         "wep_supported": false
     },
     "qs_component_nego": {


### PR DESCRIPTION
- Add: `get_emeter_data` to SMART requests.
- Add: `get_emeter_vgain_igain` to SMART requests.