### PR TITLE
Add PIR ADC Values to Test Fixtures

### DIFF
--- a/devtools/dump_devinfo.py
+++ b/devtools/dump_devinfo.py
@@ -425,7 +425,10 @@ async def get_legacy_fixture(
         Call(module="smartlife.iot.lightStrip", method="get_light_details"),
         Call(module="smartlife.iot.LAS", method="get_config"),
         Call(module="smartlife.iot.LAS", method="get_current_brt"),
+        Call(module="smartlife.iot.LAS", method="get_dark_status"),
+        Call(module="smartlife.iot.LAS", method="get_adc_value"),
         Call(module="smartlife.iot.PIR", method="get_config"),
+        Call(module="smartlife.iot.PIR", method="get_adc_value"),
     ]
 
     successes = []

--- a/tests/fixtures/ES20M(US)_1.0_1.0.11.json
+++ b/tests/fixtures/ES20M(US)_1.0_1.0.11.json
@@ -1,5 +1,41 @@
 {
+    "cnCloud": {
+        "get_info": {
+            "binded": 1,
+            "cld_connection": 1,
+            "err_code": 0,
+            "fwDlPage": "",
+            "fwNotifyType": -1,
+            "illegalType": 0,
+            "server": "n-devs.tplinkcloud.com",
+            "stopConnect": 0,
+            "tcspInfo": "",
+            "tcspStatus": 1,
+            "username": "#MASKED_NAME#"
+        },
+        "get_intl_fw_list": {
+            "err_code": 0,
+            "fw_list": []
+        }
+    },
+    "schedule": {
+        "get_next_action": {
+            "err_code": 0,
+            "type": -1
+        },
+        "get_rules": {
+            "enable": 1,
+            "err_code": 0,
+            "rule_list": [],
+            "version": 2
+        }
+    },
     "smartlife.iot.LAS": {
+        "get_adc_value": {
+            "err_code": 0,
+            "type": 2,
+            "value": 0
+        },
         "get_config": {
             "devs": [
                 {
@@ -47,10 +83,18 @@
         },
         "get_current_brt": {
             "err_code": 0,
-            "value": 16
+            "value": 0
+        },
+        "get_dark_status": {
+            "bDark": 1,
+            "err_code": 0
         }
     },
     "smartlife.iot.PIR": {
+        "get_adc_value": {
+            "err_code": 0,
+            "value": 2107
+        },
         "get_config": {
             "array": [
                 80,
@@ -59,15 +103,24 @@
                 0
             ],
             "cold_time": 120000,
-            "enable": 1,
+            "enable": 0,
             "err_code": 0,
             "max_adc": 4095,
             "min_adc": 0,
-            "trigger_index": 0,
+            "trigger_index": 1,
             "version": "1.0"
         }
     },
     "smartlife.iot.dimmer": {
+        "get_default_behavior": {
+            "double_click": {
+                "mode": "unknown"
+            },
+            "err_code": 0,
+            "long_press": {
+                "mode": "unknown"
+            }
+        },
         "get_dimmer_parameters": {
             "bulb_type": 1,
             "err_code": 0,
@@ -75,7 +128,7 @@
             "fadeOnTime": 0,
             "gentleOffTime": 10000,
             "gentleOnTime": 3000,
-            "minThreshold": 17,
+            "minThreshold": 5,
             "rampRate": 30
         }
     },
@@ -92,9 +145,9 @@
             "hw_ver": "1.0",
             "icon_hash": "",
             "latitude_i": 0,
-            "led_off": 1,
+            "led_off": 0,
             "longitude_i": 0,
-            "mac": "B0:A7:B9:00:00:00",
+            "mac": "28:87:BA:00:00:00",
             "mic_type": "IOT.SMARTPLUGSWITCH",
             "model": "ES20M(US)",
             "next_action": {
@@ -102,7 +155,7 @@
             },
             "obd_src": "tplink",
             "oemId": "00000000000000000000000000000000",
-            "on_time": 6,
+            "on_time": 0,
             "preferred_state": [
                 {
                     "brightness": 100,
@@ -121,8 +174,8 @@
                     "index": 3
                 }
             ],
-            "relay_state": 1,
-            "rssi": -40,
+            "relay_state": 0,
+            "rssi": -57,
             "status": "new",
             "sw_ver": "1.0.11 Build 240514 Rel.110351",
             "updating": 0

--- a/tests/fixtures/KL135(US)_1.0_1.0.15.json
+++ b/tests/fixtures/KL135(US)_1.0_1.0.15.json
@@ -1,22 +1,71 @@
 {
+    "smartlife.iot.common.cloud": {
+        "get_info": {
+            "binded": 1,
+            "cld_connection": 1,
+            "err_code": 0,
+            "fwDlPage": "",
+            "fwNotifyType": -1,
+            "illegalType": 0,
+            "server": "n-devs.tplinkcloud.com",
+            "stopConnect": 0,
+            "tcspInfo": "",
+            "tcspStatus": 1,
+            "username": "#MASKED_NAME#"
+        },
+        "get_intl_fw_list": {
+            "err_code": 0,
+            "fw_list": []
+        }
+    },
     "smartlife.iot.common.emeter": {
         "get_realtime": {
             "err_code": 0,
-            "power_mw": 0,
-            "total_wh": 25
+            "power_mw": 10800,
+            "total_wh": 48
+        }
+    },
+    "smartlife.iot.common.schedule": {
+        "get_next_action": {
+            "err_code": 0,
+            "type": -1
+        },
+        "get_rules": {
+            "enable": 0,
+            "err_code": 0,
+            "rule_list": [],
+            "version": 2
         }
     },
     "smartlife.iot.smartbulb.lightingservice": {
-        "get_light_state": {
-            "dft_on_state": {
-                "brightness": 98,
-                "color_temp": 6500,
-                "hue": 28,
-                "mode": "normal",
-                "saturation": 72
-            },
+        "get_default_behavior": {
             "err_code": 0,
-            "on_off": 0
+            "hard_on": {
+                "mode": "last_status"
+            },
+            "re_power_type": "always_on",
+            "soft_on": {
+                "mode": "last_status"
+            }
+        },
+        "get_light_details": {
+            "color_rendering_index": 90,
+            "err_code": 0,
+            "incandescent_equivalent": 60,
+            "lamp_beam_angle": 220,
+            "max_lumens": 800,
+            "max_voltage": 120,
+            "min_voltage": 100,
+            "wattage": 10
+        },
+        "get_light_state": {
+            "brightness": 100,
+            "color_temp": 2700,
+            "err_code": 0,
+            "hue": 0,
+            "mode": "normal",
+            "on_off": 1,
+            "saturation": 0
         }
     },
     "system": {
@@ -40,24 +89,22 @@
             "is_variable_color_temp": 1,
             "latitude_i": 0,
             "light_state": {
-                "dft_on_state": {
-                    "brightness": 98,
-                    "color_temp": 6500,
-                    "hue": 28,
-                    "mode": "normal",
-                    "saturation": 72
-                },
-                "on_off": 0
+                "brightness": 100,
+                "color_temp": 2700,
+                "hue": 0,
+                "mode": "normal",
+                "on_off": 1,
+                "saturation": 0
             },
             "longitude_i": 0,
-            "mic_mac": "000000000000",
+            "mic_mac": "54AF97000000",
             "mic_type": "IOT.SMARTBULB",
             "model": "KL135(US)",
             "obd_src": "tplink",
             "oemId": "00000000000000000000000000000000",
             "preferred_state": [
                 {
-                    "brightness": 50,
+                    "brightness": 100,
                     "color_temp": 2700,
                     "hue": 0,
                     "index": 0,
@@ -85,7 +132,7 @@
                     "saturation": 100
                 }
             ],
-            "rssi": -41,
+            "rssi": -69,
             "status": "new",
             "sw_ver": "1.0.15 Build 240429 Rel.154143"
         }

--- a/tests/fixtures/KS200M(US)_1.0_1.0.10.json
+++ b/tests/fixtures/KS200M(US)_1.0_1.0.10.json
@@ -1,5 +1,52 @@
 {
+    "cnCloud": {
+        "get_info": {
+            "binded": 1,
+            "cld_connection": 1,
+            "err_code": 0,
+            "fwDlPage": "",
+            "fwNotifyType": -1,
+            "illegalType": 0,
+            "server": "n-devs.tplinkcloud.com",
+            "stopConnect": 0,
+            "tcspInfo": "",
+            "tcspStatus": 1,
+            "username": "#MASKED_NAME#"
+        },
+        "get_intl_fw_list": {
+            "err_code": 0,
+            "fw_list": [
+                {
+                    "fwLocation": 0,
+                    "fwReleaseDate": "2024-06-19",
+                    "fwReleaseLog": "Modifications and Bug Fixes:\n1. Added \"Hold on\" feature, now you can quickly double-click the switch to keep it on without being affected by the Smart Control rules.\n2. Fixed a bug where Motion & Dark rules could still be triggered under bright light conditions.\n3. Fixed some minor bugs.",
+                    "fwReleaseLogUrl": "undefined yet",
+                    "fwTitle": "Hi, a new firmware with bug fixes and performance improvement is available for your KS200M.",
+                    "fwType": 2,
+                    "fwUrl": "http://download.tplinkcloud.com/firmware/KS200M_FCC_1.0.12_Build_240507_Rel.143458_2024-05-07_14.37.42_1718767325443.bin",
+                    "fwVer": "1.0.12 Build 240507 Rel.143458"
+                }
+            ]
+        }
+    },
+    "schedule": {
+        "get_next_action": {
+            "err_code": 0,
+            "type": -1
+        },
+        "get_rules": {
+            "enable": 1,
+            "err_code": 0,
+            "rule_list": [],
+            "version": 2
+        }
+    },
     "smartlife.iot.LAS": {
+        "get_adc_value": {
+            "err_code": 0,
+            "type": 2,
+            "value": 0
+        },
         "get_config": {
             "devs": [
                 {
@@ -44,9 +91,21 @@
             ],
             "err_code": 0,
             "ver": "1.0"
+        },
+        "get_current_brt": {
+            "err_code": 0,
+            "value": 0
+        },
+        "get_dark_status": {
+            "bDark": 1,
+            "err_code": 0
         }
     },
     "smartlife.iot.PIR": {
+        "get_adc_value": {
+            "err_code": 0,
+            "value": 2025
+        },
         "get_config": {
             "array": [
                 80,
@@ -59,7 +118,7 @@
             "err_code": 0,
             "max_adc": 4095,
             "min_adc": 0,
-            "trigger_index": 0,
+            "trigger_index": 2,
             "version": "1.0"
         }
     },
@@ -87,7 +146,7 @@
             "oemId": "00000000000000000000000000000000",
             "on_time": 0,
             "relay_state": 0,
-            "rssi": -39,
+            "rssi": -38,
             "status": "new",
             "sw_ver": "1.0.10 Build 221019 Rel.194527",
             "updating": 0

--- a/tests/fixtures/KS220(US)_1.0_1.0.13.json
+++ b/tests/fixtures/KS220(US)_1.0_1.0.13.json
@@ -1,5 +1,51 @@
 {
+    "cnCloud": {
+        "get_info": {
+            "binded": 1,
+            "cld_connection": 1,
+            "err_code": 0,
+            "fwDlPage": "",
+            "fwNotifyType": -1,
+            "illegalType": 0,
+            "server": "n-devs.tplinkcloud.com",
+            "stopConnect": 0,
+            "tcspInfo": "",
+            "tcspStatus": 1,
+            "username": "#MASKED_NAME#"
+        },
+        "get_intl_fw_list": {
+            "err_code": 0,
+            "fw_list": []
+        }
+    },
+    "schedule": {
+        "get_next_action": {
+            "err_code": 0,
+            "type": -1
+        },
+        "get_rules": {
+            "enable": 0,
+            "err_code": 0,
+            "rule_list": [],
+            "version": 2
+        }
+    },
     "smartlife.iot.dimmer": {
+        "get_default_behavior": {
+            "double_click": {
+                "mode": "gentle_on_off"
+            },
+            "err_code": 0,
+            "hard_on": {
+                "mode": "last_status"
+            },
+            "long_press": {
+                "mode": "instant_on_off"
+            },
+            "soft_on": {
+                "mode": "last_status"
+            }
+        },
         "get_dimmer_parameters": {
             "bulb_type": 1,
             "calibration_type": 1,
@@ -8,7 +54,7 @@
             "fadeOnTime": 1000,
             "gentleOffTime": 10000,
             "gentleOnTime": 3000,
-            "minThreshold": 1,
+            "minThreshold": 9,
             "rampRate": 30
         }
     },
@@ -56,7 +102,7 @@
                 }
             ],
             "relay_state": 0,
-            "rssi": -47,
+            "rssi": -50,
             "status": "configured",
             "sw_ver": "1.0.13 Build 240424 Rel.102214",
             "updating": 0


### PR DESCRIPTION
Updated LAS/PIR fixtures:
- Add: `get_dark_status` for LAS enabled IOT devices.
- Add: `get_adc_value` for LAS enabled IOT devices.
- Add: `get_adc_value` for PIR enabled IOT devices.

Also made updates to the following fixtures as a bonus:
- Add: Updated test fixture for KL135 showing updated `lightingservice` response.
- Add: Real values for `get_default_behavior` from KS220.