### PR TITLE
Run tests with caplog in a single worker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ markers = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 10
-addopts = "--disable-socket --allow-unix-socket"
+addopts = "--disable-socket --allow-unix-socket --dist=loadgroup"
 
 [tool.doc8]
 paths = ["docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,8 @@ markers = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 10
+# dist=loadgroup enables grouping of tests into single worker.
+# required as caplog doesn't play nicely with multiple workers.
 addopts = "--disable-socket --allow-unix-socket --dist=loadgroup"
 
 [tool.doc8]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,13 @@ async def handle_turn_on(dev, turn_on):
 
 
 @pytest.fixture
+@pytest.mark.xdist_group(name="caplog")
+def caplog(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """Foo."""
+    return caplog
+
+
+@pytest.fixture
 def dummy_protocol():
     """Return a smart protocol instance with a mocking-ready dummy transport."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,13 +37,6 @@ async def handle_turn_on(dev, turn_on):
 
 
 @pytest.fixture
-@pytest.mark.xdist_group(name="caplog")
-def caplog(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
-    """Foo."""
-    return caplog
-
-
-@pytest.fixture
 def dummy_protocol():
     """Return a smart protocol instance with a mocking-ready dummy transport."""
 

--- a/tests/iot/modules/test_schedule.py
+++ b/tests/iot/modules/test_schedule.py
@@ -7,6 +7,7 @@ from ...device_fixtures import device_iot
 
 
 @device_iot
+@pytest.mark.xdist_group(name="caplog")
 def test_schedule(dev: Device, caplog: pytest.LogCaptureFixture):
     schedule = dev.modules.get(Module.IotSchedule)
     assert schedule

--- a/tests/iot/modules/test_schedule.py
+++ b/tests/iot/modules/test_schedule.py
@@ -7,7 +7,6 @@ from ...device_fixtures import device_iot
 
 
 @device_iot
-@pytest.mark.xdist_group(name="caplog")
 def test_schedule(dev: Device, caplog: pytest.LogCaptureFixture):
     schedule = dev.modules.get(Module.IotSchedule)
     assert schedule

--- a/tests/smart/modules/test_firmware.py
+++ b/tests/smart/modules/test_firmware.py
@@ -90,7 +90,6 @@ async def test_update_available_without_cloud(dev: SmartDevice):
     ],
 )
 @pytest.mark.requires_dummy
-@pytest.mark.xdist_group(name="caplog")
 async def test_firmware_update(
     dev: SmartDevice,
     mocker: MockerFixture,

--- a/tests/smart/modules/test_firmware.py
+++ b/tests/smart/modules/test_firmware.py
@@ -90,6 +90,7 @@ async def test_update_available_without_cloud(dev: SmartDevice):
     ],
 )
 @pytest.mark.requires_dummy
+@pytest.mark.xdist_group(name="caplog")
 async def test_firmware_update(
     dev: SmartDevice,
     mocker: MockerFixture,

--- a/tests/smart/modules/test_temperaturecontrol.py
+++ b/tests/smart/modules/test_temperaturecontrol.py
@@ -137,6 +137,7 @@ async def test_thermostat_mode(dev, mode, states, frost_protection):
         ),
     ],
 )
+@pytest.mark.xdist_group(name="caplog")
 async def test_thermostat_mode_warnings(dev, mode, states, msg, caplog):
     """Test thermostat modes that should log a warning."""
     temp_module: TemperatureControl = dev.modules["TemperatureControl"]

--- a/tests/smart/modules/test_temperaturecontrol.py
+++ b/tests/smart/modules/test_temperaturecontrol.py
@@ -137,7 +137,6 @@ async def test_thermostat_mode(dev, mode, states, frost_protection):
         ),
     ],
 )
-@pytest.mark.xdist_group(name="caplog")
 async def test_thermostat_mode_warnings(dev, mode, states, msg, caplog):
     """Test thermostat modes that should log a warning."""
     temp_module: TemperatureControl = dev.modules["TemperatureControl"]

--- a/tests/test_aestransport.py
+++ b/tests/test_aestransport.py
@@ -216,6 +216,7 @@ async def test_send(mocker, status_code, error_code, inner_error_code, expectati
         assert "result" in res
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_unencrypted_response(mocker, caplog):
     host = "127.0.0.1"
     mock_aes_device = MockAesDevice(host, 200, 0, 0, do_not_encrypt_response=True)

--- a/tests/test_aestransport.py
+++ b/tests/test_aestransport.py
@@ -216,7 +216,6 @@ async def test_send(mocker, status_code, error_code, inner_error_code, expectati
         assert "result" in res
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_unencrypted_response(mocker, caplog):
     host = "127.0.0.1"
     mock_aes_device = MockAesDevice(host, 200, 0, 0, do_not_encrypt_response=True)

--- a/tests/test_bulb.py
+++ b/tests/test_bulb.py
@@ -232,7 +232,6 @@ async def test_set_color_temp_transition(dev: IotBulb, mocker):
 
 
 @variable_temp_iot
-@pytest.mark.xdist_group(name="caplog")
 async def test_unknown_temp_range(dev: IotBulb, monkeypatch, caplog):
     monkeypatch.setitem(dev._sys_info, "model", "unknown bulb")
     light = dev.modules.get(Module.Light)

--- a/tests/test_bulb.py
+++ b/tests/test_bulb.py
@@ -232,6 +232,7 @@ async def test_set_color_temp_transition(dev: IotBulb, mocker):
 
 
 @variable_temp_iot
+@pytest.mark.xdist_group(name="caplog")
 async def test_unknown_temp_range(dev: IotBulb, monkeypatch, caplog):
     monkeypatch.setitem(dev._sys_info, "model", "unknown bulb")
     light = dev.modules.get(Module.Light)

--- a/tests/test_childdevice.py
+++ b/tests/test_childdevice.py
@@ -136,7 +136,6 @@ async def test_child_time(dev: Device, freezer: FrozenDateTimeFactory):
         assert child.time != fallback_time
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_child_device_type_unknown(caplog):
     """Test for device type when category is unknown."""
 

--- a/tests/test_childdevice.py
+++ b/tests/test_childdevice.py
@@ -136,6 +136,7 @@ async def test_child_time(dev: Device, freezer: FrozenDateTimeFactory):
         assert child.time != fallback_time
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_child_device_type_unknown(caplog):
     """Test for device type when category is unknown."""
 

--- a/tests/test_device_factory.py
+++ b/tests/test_device_factory.py
@@ -109,7 +109,6 @@ async def test_connect_custom_port(discovery_mock, mocker, custom_port):
     assert dev.port == custom_port or dev.port == default_port
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_connect_logs_connect_time(
     discovery_mock,
     caplog: pytest.LogCaptureFixture,
@@ -193,7 +192,6 @@ async def test_device_types(dev: Device):
     assert dev.device_type == res
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_device_class_from_unknown_family(caplog):
     """Verify that unknown SMART devices yield a warning and fallback to SmartDevice."""
     dummy_name = "SMART.foo"

--- a/tests/test_device_factory.py
+++ b/tests/test_device_factory.py
@@ -109,6 +109,7 @@ async def test_connect_custom_port(discovery_mock, mocker, custom_port):
     assert dev.port == custom_port or dev.port == default_port
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_connect_logs_connect_time(
     discovery_mock,
     caplog: pytest.LogCaptureFixture,
@@ -192,6 +193,7 @@ async def test_device_types(dev: Device):
     assert dev.device_type == res
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_device_class_from_unknown_family(caplog):
     """Verify that unknown SMART devices yield a warning and fallback to SmartDevice."""
     dummy_name = "SMART.foo"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -119,7 +119,6 @@ async def test_type_detection_lightstrip(dev: Device):
     assert d.device_type == DeviceType.LightStrip
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_type_unknown(caplog):
     invalid_info = {"system": {"get_sysinfo": {"type": "nosuchtype"}}}
     assert Discover._get_device_class(invalid_info) is IotPlug
@@ -587,7 +586,6 @@ async def test_do_discover_external_cancel(mocker):
             await dp.wait_for_discovery_to_complete()
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_discovery_redaction(discovery_mock, caplog: pytest.LogCaptureFixture):
     """Test query sensitive info redaction."""
     mac = "12:34:56:78:9A:BC"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -119,6 +119,7 @@ async def test_type_detection_lightstrip(dev: Device):
     assert d.device_type == DeviceType.LightStrip
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_type_unknown(caplog):
     invalid_info = {"system": {"get_sysinfo": {"type": "nosuchtype"}}}
     assert Discover._get_device_class(invalid_info) is IotPlug
@@ -586,6 +587,7 @@ async def test_do_discover_external_cancel(mocker):
             await dp.wait_for_discovery_to_complete()
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_discovery_redaction(discovery_mock, caplog: pytest.LogCaptureFixture):
     """Test query sensitive info redaction."""
     mac = "12:34:56:78:9A:BC"

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -127,7 +127,6 @@ async def test_feature_action(mocker):
     mock_call_action.assert_called()
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_feature_choice_list(dummy_feature, caplog, mocker: MockerFixture):
     """Test the choice feature type."""
     dummy_feature.type = Feature.Type.Choice

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -127,6 +127,7 @@ async def test_feature_action(mocker):
     mock_call_action.assert_called()
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_feature_choice_list(dummy_feature, caplog, mocker: MockerFixture):
     """Test the choice feature type."""
     dummy_feature.type = Feature.Type.Choice

--- a/tests/test_klapprotocol.py
+++ b/tests/test_klapprotocol.py
@@ -184,7 +184,6 @@ async def test_protocol_reconnect(mocker, retry_count, protocol_class, transport
 
 
 @pytest.mark.parametrize("log_level", [logging.WARNING, logging.DEBUG])
-@pytest.mark.xdist_group(name="caplog")
 async def test_protocol_logging(mocker, caplog, log_level):
     caplog.set_level(log_level)
     logging.getLogger("kasa").setLevel(log_level)

--- a/tests/test_klapprotocol.py
+++ b/tests/test_klapprotocol.py
@@ -184,6 +184,7 @@ async def test_protocol_reconnect(mocker, retry_count, protocol_class, transport
 
 
 @pytest.mark.parametrize("log_level", [logging.WARNING, logging.DEBUG])
+@pytest.mark.xdist_group(name="caplog")
 async def test_protocol_logging(mocker, caplog, log_level):
     caplog.set_level(log_level)
     logging.getLogger("kasa").setLevel(log_level)

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -307,6 +307,7 @@ async def test_protocol_handles_cancellation_during_connection(
     ids=("_deprecated_TPLinkSmartHomeProtocol", "IotProtocol-XorTransport"),
 )
 @pytest.mark.parametrize("log_level", [logging.WARNING, logging.DEBUG])
+@pytest.mark.xdist_group(name="caplog")
 async def test_protocol_logging(
     mocker, caplog, log_level, protocol_class, transport_class, encryption_class
 ):
@@ -685,6 +686,7 @@ def test_deprecated_protocol():
 
 
 @device_iot
+@pytest.mark.xdist_group(name="caplog")
 async def test_iot_queries_redaction(dev: IotDevice, caplog: pytest.LogCaptureFixture):
     """Test query sensitive info redaction."""
     if isinstance(dev.protocol._transport, FakeIotTransport):

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -307,7 +307,6 @@ async def test_protocol_handles_cancellation_during_connection(
     ids=("_deprecated_TPLinkSmartHomeProtocol", "IotProtocol-XorTransport"),
 )
 @pytest.mark.parametrize("log_level", [logging.WARNING, logging.DEBUG])
-@pytest.mark.xdist_group(name="caplog")
 async def test_protocol_logging(
     mocker, caplog, log_level, protocol_class, transport_class, encryption_class
 ):
@@ -686,7 +685,6 @@ def test_deprecated_protocol():
 
 
 @device_iot
-@pytest.mark.xdist_group(name="caplog")
 async def test_iot_queries_redaction(dev: IotDevice, caplog: pytest.LogCaptureFixture):
     """Test query sensitive info redaction."""
     if isinstance(dev.protocol._transport, FakeIotTransport):

--- a/tests/test_smartdevice.py
+++ b/tests/test_smartdevice.py
@@ -27,6 +27,7 @@ from .conftest import (
 
 @device_smart
 @pytest.mark.requires_dummy
+@pytest.mark.xdist_group(name="caplog")
 async def test_try_get_response(dev: SmartDevice, caplog):
     mock_response: dict = {
         "get_device_info": SmartErrorCode.PARAMS_ERROR,
@@ -143,6 +144,7 @@ async def test_update_module_queries(dev: SmartDevice, mocker: MockerFixture):
 
 
 @device_smart
+@pytest.mark.xdist_group(name="caplog")
 async def test_update_module_update_delays(
     dev: SmartDevice,
     mocker: MockerFixture,
@@ -203,6 +205,7 @@ async def test_update_module_update_delays(
     ],
 )
 @device_smart
+@pytest.mark.xdist_group(name="caplog")
 async def test_update_module_query_errors(
     dev: SmartDevice,
     mocker: MockerFixture,

--- a/tests/test_smartdevice.py
+++ b/tests/test_smartdevice.py
@@ -27,7 +27,6 @@ from .conftest import (
 
 @device_smart
 @pytest.mark.requires_dummy
-@pytest.mark.xdist_group(name="caplog")
 async def test_try_get_response(dev: SmartDevice, caplog):
     mock_response: dict = {
         "get_device_info": SmartErrorCode.PARAMS_ERROR,
@@ -144,7 +143,6 @@ async def test_update_module_queries(dev: SmartDevice, mocker: MockerFixture):
 
 
 @device_smart
-@pytest.mark.xdist_group(name="caplog")
 async def test_update_module_update_delays(
     dev: SmartDevice,
     mocker: MockerFixture,
@@ -205,7 +203,6 @@ async def test_update_module_update_delays(
     ],
 )
 @device_smart
-@pytest.mark.xdist_group(name="caplog")
 async def test_update_module_query_errors(
     dev: SmartDevice,
     mocker: MockerFixture,

--- a/tests/test_smartprotocol.py
+++ b/tests/test_smartprotocol.py
@@ -54,6 +54,7 @@ async def test_smart_device_errors(dummy_protocol, mocker, error_code):
 
 
 @pytest.mark.parametrize("error_code", [-13333, 13333])
+@pytest.mark.xdist_group(name="caplog")
 async def test_smart_device_unknown_errors(
     dummy_protocol, mocker, error_code, caplog: pytest.LogCaptureFixture
 ):
@@ -417,6 +418,7 @@ async def test_incomplete_list(mocker, caplog):
 
 
 @device_smart
+@pytest.mark.xdist_group(name="caplog")
 async def test_smart_queries_redaction(
     dev: SmartDevice, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/test_smartprotocol.py
+++ b/tests/test_smartprotocol.py
@@ -54,7 +54,6 @@ async def test_smart_device_errors(dummy_protocol, mocker, error_code):
 
 
 @pytest.mark.parametrize("error_code", [-13333, 13333])
-@pytest.mark.xdist_group(name="caplog")
 async def test_smart_device_unknown_errors(
     dummy_protocol, mocker, error_code, caplog: pytest.LogCaptureFixture
 ):
@@ -418,7 +417,6 @@ async def test_incomplete_list(mocker, caplog):
 
 
 @device_smart
-@pytest.mark.xdist_group(name="caplog")
 async def test_smart_queries_redaction(
     dev: SmartDevice, caplog: pytest.LogCaptureFixture
 ):

--- a/tests/test_sslaestransport.py
+++ b/tests/test_sslaestransport.py
@@ -175,7 +175,6 @@ async def test_send(mocker):
     assert "result" in res
 
 
-@pytest.mark.xdist_group(name="caplog")
 async def test_unencrypted_response(mocker, caplog):
     host = "127.0.0.1"
     mock_ssl_aes_device = MockSslAesDevice(host, do_not_encrypt_response=True)

--- a/tests/test_sslaestransport.py
+++ b/tests/test_sslaestransport.py
@@ -175,6 +175,7 @@ async def test_send(mocker):
     assert "result" in res
 
 
+@pytest.mark.xdist_group(name="caplog")
 async def test_unencrypted_response(mocker, caplog):
     host = "127.0.0.1"
     mock_ssl_aes_device = MockSslAesDevice(host, do_not_encrypt_response=True)


### PR DESCRIPTION
Fixes issue causing test failures: https://github.com/python-kasa/python-kasa/actions/runs/11983779130?pr=1303

Experimented with trying to do this centrally in the third commit but it didn't work. Will go with this for now and merge to fix the broken CI pipeline.