### PR TITLE
Handle missing mgt_encryption_schm in discovery

### DIFF
--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -230,10 +230,12 @@ def _echo_discovery_info(discovery_info) -> None:
     _conditional_echo("Supports IOT Cloud", dr.is_support_iot_cloud)
     _conditional_echo("OBD Src", dr.owner)
     _conditional_echo("Factory Default", dr.factory_default)
-    _conditional_echo("Encrypt Type", dr.mgt_encrypt_schm.encrypt_type)
     _conditional_echo("Encrypt Type", dr.encrypt_type)
-    _conditional_echo("Supports HTTPS", dr.mgt_encrypt_schm.is_support_https)
-    _conditional_echo("HTTP Port", dr.mgt_encrypt_schm.http_port)
+    if mgt_encrypt_schm := dr.mgt_encrypt_schm:
+        _conditional_echo("Encrypt Type", mgt_encrypt_schm.encrypt_type)
+        _conditional_echo("Supports HTTPS", mgt_encrypt_schm.is_support_https)
+        _conditional_echo("HTTP Port", mgt_encrypt_schm.http_port)
+        _conditional_echo("Login version", mgt_encrypt_schm.lv)
     _conditional_echo("Encrypt info", pf(dr.encrypt_info) if dr.encrypt_info else None)
     _conditional_echo("Decrypted", pf(dr.decrypted_data) if dr.decrypted_data else None)
 

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -156,6 +156,9 @@ NEW_DISCOVERY_REDACTORS: dict[str, Callable[[Any], Any] | None] = {
     "device_id": lambda x: "REDACTED_" + x[9::],
     "owner": lambda x: "REDACTED_" + x[9::],
     "mac": mask_mac,
+    "master_device_id": lambda x: "REDACTED_" + x[9::],
+    "group_id": lambda x: "REDACTED_" + x[9::],
+    "group_name": lambda x: "I01BU0tFRF9TU0lEIw==",
 }
 
 
@@ -643,7 +646,11 @@ class Discover:
         """Find SmartDevice subclass for device described by passed data."""
         if "result" in info:
             discovery_result = DiscoveryResult.from_dict(info["result"])
-            https = discovery_result.mgt_encrypt_schm.is_support_https
+            https = (
+                discovery_result.mgt_encrypt_schm.is_support_https
+                if discovery_result.mgt_encrypt_schm
+                else False
+            )
             dev_class = get_device_class_from_family(
                 discovery_result.device_type, https=https
             )
@@ -747,7 +754,13 @@ class Discover:
                 )
 
         type_ = discovery_result.device_type
-        encrypt_schm = discovery_result.mgt_encrypt_schm
+        if (encrypt_schm := discovery_result.mgt_encrypt_schm) is None:
+            raise UnsupportedDeviceError(
+                f"Unsupported device {config.host} of type {type_} "
+                "with no mgt_encrypt_schm",
+                discovery_result=discovery_result.to_dict(),
+                host=config.host,
+            )
 
         try:
             if not (encrypt_type := encrypt_schm.encrypt_type) and (
@@ -765,13 +778,13 @@ class Discover:
             config.connection_type = DeviceConnectionParameters.from_values(
                 type_,
                 encrypt_type,
-                discovery_result.mgt_encrypt_schm.lv,
-                discovery_result.mgt_encrypt_schm.is_support_https,
+                encrypt_schm.lv,
+                encrypt_schm.is_support_https,
             )
         except KasaException as ex:
             raise UnsupportedDeviceError(
                 f"Unsupported device {config.host} of type {type_} "
-                + f"with encrypt_type {discovery_result.mgt_encrypt_schm.encrypt_type}",
+                + f"with encrypt_type {encrypt_schm.encrypt_type}",
                 discovery_result=discovery_result.to_dict(),
                 host=config.host,
             ) from ex
@@ -854,7 +867,7 @@ class DiscoveryResult(_DiscoveryBaseMixin):
     device_id: str
     ip: str
     mac: str
-    mgt_encrypt_schm: EncryptionScheme
+    mgt_encrypt_schm: EncryptionScheme | None = None
     device_name: str | None = None
     encrypt_info: EncryptionInfo | None = None
     encrypt_type: list[str] | None = None

--- a/tests/discovery_fixtures.py
+++ b/tests/discovery_fixtures.py
@@ -22,6 +22,29 @@ class DiscoveryResponse(TypedDict):
     error_code: int
 
 
+UNSUPPORTED_HOMEWIFISYSTEM = {
+    "error_code": 0,
+    "result": {
+        "channel_2g": "10",
+        "channel_5g": "44",
+        "device_id": "REDACTED_51f72a752213a6c45203530",
+        "device_model": "X20",
+        "device_type": "HOMEWIFISYSTEM",
+        "factory_default": False,
+        "group_id": "REDACTED_07d902da02fa9beab8a64",
+        "group_name": "I01BU0tFRF9TU0lEIw==",  # '#MASKED_SSID#'
+        "hardware_version": "3.0",
+        "ip": "192.168.1.192",
+        "mac": "24:2F:D0:00:00:00",
+        "master_device_id": "REDACTED_51f72a752213a6c45203530",
+        "need_account_digest": True,
+        "owner": "REDACTED_341c020d7e8bda184e56a90",
+        "role": "master",
+        "tmp_port": [20001],
+    },
+}
+
+
 def _make_unsupported(
     device_family,
     encrypt_type,
@@ -75,13 +98,14 @@ UNSUPPORTED_DEVICES = {
     "unable_to_parse": _make_unsupported(
         "SMART.TAPOBULB",
         "FOO",
-        omit_keys={"mgt_encrypt_schm": None},
+        omit_keys={"device_id": None},
     ),
     "invalidinstance": _make_unsupported(
         "IOT.SMARTPLUGSWITCH",
         "KLAP",
         https=True,
     ),
+    "homewifi": UNSUPPORTED_HOMEWIFISYSTEM,
 }
 
 


### PR DESCRIPTION
This should reduce confusion around tplink homewifi systems that have a discovery response without this data.

[HA Issue comment](https://github.com/home-assistant/core/issues/123651#issuecomment-2293719325)
[Kasa Homebridge Plugin](https://github.com/ZeliardM/homebridge-kasa-python/issues/4#issuecomment-2492635938)
