### PR TITLE
Do not error when accessing smart device_type before update

### DIFF
--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -765,8 +765,9 @@ class SmartDevice(Device):
         if self._device_type is not DeviceType.Unknown:
             return self._device_type
 
-        if not self._components or not (
-            type_str := self._info.get("type", self._info.get("device_type"))
+        if (
+            not (type_str := self._info.get("type", self._info.get("device_type")))
+            or not self._components
         ):
             # no update or discovery info
             return self._device_type

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -765,10 +765,10 @@ class SmartDevice(Device):
         if self._device_type is not DeviceType.Unknown:
             return self._device_type
 
-        # Fallback to device_type (from disco info)
-        type_str = self._info.get("type", self._info.get("device_type"))
-
-        if not type_str:  # no update or discovery info
+        if not self._components or not (
+            type_str := self._info.get("type", self._info.get("device_type"))
+        ):
+            # no update or discovery info
             return self._device_type
 
         self._device_type = self._get_device_type_from_components(

--- a/tests/discovery_fixtures.py
+++ b/tests/discovery_fixtures.py
@@ -130,6 +130,8 @@ new_discovery = parametrize_discovery(
     "new discovery", data_root_filter="discovery_result"
 )
 
+smart_discovery = parametrize_discovery("smart discovery", protocol_filter={"SMART"})
+
 
 @pytest.fixture(
     params=filter_fixtures("discoverable", protocol_filter={"SMART", "IOT"}),

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -18,9 +18,11 @@ from kasa.smart import SmartDevice
 from kasa.smart.modules.energy import Energy
 from kasa.smart.smartmodule import SmartModule
 from tests.conftest import (
+    DISCOVERY_MOCK_IP,
     device_smart,
     get_device_for_fixture_protocol,
     get_parent_and_child_modules,
+    smart_discovery,
 )
 from tests.device_fixtures import variable_temp_smart
 
@@ -49,6 +51,17 @@ async def test_update_no_device_info(dev: SmartDevice, mocker: MockerFixture):
     mocker.patch.object(dev.protocol, "query", return_value=mock_response)
     with pytest.raises(KasaException, match=msg):
         await dev.update()
+
+
+@smart_discovery
+async def test_repr_no_update(discovery_mock):
+    dev = SmartDevice(DISCOVERY_MOCK_IP)
+    assert repr(dev) == f"<DeviceType.Unknown at {DISCOVERY_MOCK_IP} - update() needed>"
+    dev.update_from_discover_info(discovery_mock.discovery_data["result"])
+    assert (
+        repr(dev)
+        == f"<DeviceType.Unknown at {DISCOVERY_MOCK_IP} - None (None) - update() needed>"
+    )
 
 
 @device_smart


### PR DESCRIPTION
Fixes exception raised accessing `device_type` before `update()` in [Homebridge kasa plug in](https://github.com/ZeliardM/homebridge-kasa-python/issues/4)
