### PR TITLE
cli: print model, https, and lv for discover list

### DIFF
--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -132,6 +132,10 @@ async def list(ctx):
                 await dev.update()
             except AuthenticationError:
                 echo(f"{infostr} - Authentication failed")
+            except TimeoutError:
+                echo(f"{infostr} - Timed out")
+            except Exception as ex:
+                echo(f"{infostr} - Error: {ex}")
             else:
                 echo(f"{infostr} {dev.alias}")
 

--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -85,8 +85,9 @@ async def list(ctx):
     async def print_discovered(dev: Device):
         cparams = dev.config.connection_type
         infostr = (
-            f"{dev.host:<15} {cparams.device_family.value:<20} "
-            f"{cparams.encryption_type.value:<7}"
+            f"{dev.host:<15} {dev.model:<9} {cparams.device_family.value:<20} "
+            f"{cparams.encryption_type.value:<7} {cparams.https:<5} "
+            f"{cparams.login_version or '-':<3}"
         )
         async with sem:
             try:
@@ -100,7 +101,10 @@ async def list(ctx):
         if host := unsupported_exception.host:
             echo(f"{host:<15} UNSUPPORTED DEVICE")
 
-    echo(f"{'HOST':<15} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} {'ALIAS'}")
+    echo(
+        f"{'HOST':<15} {'MODEL':<9} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} "
+        f"{'HTTPS':<5} {'LV':<3} {'ALIAS'}"
+    )
     return await _discover(ctx, print_discovered, print_unsupported, do_echo=False)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,8 +122,15 @@ async def test_list_devices(discovery_mock, runner):
         catch_exceptions=False,
     )
     assert res.exit_code == 0
-    header = f"{'HOST':<15} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} {'ALIAS'}"
-    row = f"{discovery_mock.ip:<15} {discovery_mock.device_type:<20} {discovery_mock.encrypt_type:<7}"
+    header = (
+        f"{'HOST':<15} {'MODEL':<9} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} "
+        f"{'HTTPS':<5} {'LV':<3} {'ALIAS'}"
+    )
+    row = (
+        f"{discovery_mock.ip:<15} {discovery_mock.model:<9} {discovery_mock.device_type:<20} "
+        f"{discovery_mock.encrypt_type:<7} {discovery_mock.https:<5} "
+        f"{discovery_mock.login_version or '-':<3}"
+    )
     assert header in res.output
     assert row in res.output
 
@@ -158,14 +165,26 @@ async def test_discover_raw(discovery_mock, runner, mocker):
     redact_spy.assert_called()
 
 
+@pytest.mark.parametrize(
+    ("exception", "expected"),
+    [
+        pytest.param(
+            AuthenticationError("Failed to authenticate"),
+            "Authentication failed",
+            id="auth",
+        ),
+        pytest.param(TimeoutError(), "Timed out", id="timeout"),
+        pytest.param(Exception("Foobar"), "Error: Foobar", id="other-error"),
+    ],
+)
 @new_discovery
-async def test_list_auth_failed(discovery_mock, mocker, runner):
+async def test_list_update_failed(discovery_mock, mocker, runner, exception, expected):
     """Test that device update is called on main."""
     device_class = Discover._get_device_class(discovery_mock.discovery_data)
     mocker.patch.object(
         device_class,
         "update",
-        side_effect=AuthenticationError("Failed to authenticate"),
+        side_effect=exception,
     )
     res = await runner.invoke(
         cli,
@@ -173,10 +192,17 @@ async def test_list_auth_failed(discovery_mock, mocker, runner):
         catch_exceptions=False,
     )
     assert res.exit_code == 0
-    header = f"{'HOST':<15} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} {'ALIAS'}"
-    row = f"{discovery_mock.ip:<15} {discovery_mock.device_type:<20} {discovery_mock.encrypt_type:<7} - Authentication failed"
-    assert header in res.output
-    assert row in res.output
+    header = (
+        f"{'HOST':<15} {'MODEL':<9} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} "
+        f"{'HTTPS':<5} {'LV':<3} {'ALIAS'}"
+    )
+    row = (
+        f"{discovery_mock.ip:<15} {discovery_mock.model:<9} {discovery_mock.device_type:<20} "
+        f"{discovery_mock.encrypt_type:<7} {discovery_mock.https:<5} "
+        f"{discovery_mock.login_version or '-':<3} - {expected}"
+    )
+    assert header in res.output.replace("\n", "")
+    assert row in res.output.replace("\n", "")
 
 
 async def test_list_unsupported(unsupported_device_info, runner):
@@ -187,7 +213,10 @@ async def test_list_unsupported(unsupported_device_info, runner):
         catch_exceptions=False,
     )
     assert res.exit_code == 0
-    header = f"{'HOST':<15} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} {'ALIAS'}"
+    header = (
+        f"{'HOST':<15} {'MODEL':<9} {'DEVICE FAMILY':<20} {'ENCRYPT':<7} "
+        f"{'HTTPS':<5} {'LV':<3} {'ALIAS'}"
+    )
     row = f"{'127.0.0.1':<15} UNSUPPORTED DEVICE"
     assert header in res.output
     assert row in res.output


### PR DESCRIPTION
```
kasa --target 192.168.xx.xx discover list

HOST            MODEL     DEVICE FAMILY        ENCRYPT HTTPS LV  ALIAS
192.168.xxx.xxx KP115(EU) IOT.SMARTPLUGSWITCH  XOR     0     -   Fridge
192.168.xxx.xxx L900-5    SMART.TAPOBULB       KLAP    0     2   L900
192.168.xxx.xxx P115      SMART.TAPOPLUG       AES     0     2   Nightdesk
192.168.xxx.xxx TC65      SMART.IPCAMERA       AES     1     2   Tapo_TC65_B593

```

Also handles `TimeoutError` and `Exception` during `update()`