### PR TITLE
Return raw discovery result in cli discover raw

### DIFF
--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -80,12 +80,22 @@ async def detail(ctx):
 
 
 @discover.command()
+@click.option(
+    "--redact/--no-redact",
+    default=False,
+    is_flag=True,
+    type=bool,
+    help="Set flag to redact sensitive data from raw output.",
+)
 @click.pass_context
-async def raw(ctx):
+async def raw(ctx, redact: bool):
     """Return raw discovery data returned from devices."""
 
     def print_raw(discovered: JsonDiscovered):
-        output = {"ip": discovered.ip, "discovery_result": discovered.raw}
+        raw = discovered.raw
+        if redact:
+            raw = discovered.redactor(raw)
+        output = {"ip": discovered.ip, "discovery_result": raw}
         echo(json_dumps(output, indent=True))
 
     return await _discover(ctx, print_raw=print_raw, do_echo=False)

--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -64,7 +64,9 @@ async def detail(ctx):
                 await ctx.parent.invoke(state)
             echo()
 
-    discovered = await _discover(ctx, print_discovered, print_unsupported)
+    discovered = await _discover(
+        ctx, print_discovered=print_discovered, print_unsupported=print_unsupported
+    )
     if ctx.parent.parent.params["host"]:
         return discovered
 

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -786,7 +786,9 @@ class Discover:
                 Discover._decrypt_discovery_data(discovery_result)
             except Exception:
                 _LOGGER.exception(
-                    "Unable to decrypt discovery data %s: %s", config.host, data
+                    "Unable to decrypt discovery data %s: %s",
+                    config.host,
+                    redact_data(info, NEW_DISCOVERY_REDACTORS),
                 )
 
         type_ = discovery_result.device_type

--- a/kasa/json.py
+++ b/kasa/json.py
@@ -8,18 +8,24 @@ from typing import Any
 try:
     import orjson
 
-    def dumps(obj: Any, *, default: Callable | None = None) -> str:
+    def dumps(
+        obj: Any, *, default: Callable | None = None, indent: bool = False
+    ) -> str:
         """Dump JSON."""
-        return orjson.dumps(obj).decode()
+        return orjson.dumps(
+            obj, option=orjson.OPT_INDENT_2 if indent else None
+        ).decode()
 
     loads = orjson.loads
 except ImportError:
     import json
 
-    def dumps(obj: Any, *, default: Callable | None = None) -> str:
+    def dumps(
+        obj: Any, *, default: Callable | None = None, indent: bool = False
+    ) -> str:
         """Dump JSON."""
         # Separators specified for consistency with orjson
-        return json.dumps(obj, separators=(",", ":"))
+        return json.dumps(obj, separators=(",", ":"), indent=2 if indent else None)
 
     loads = json.loads
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -731,6 +731,7 @@ async def test_without_device_type(dev, mocker, runner):
         timeout=5,
         discovery_timeout=7,
         on_unsupported=ANY,
+        on_json_discovered=ANY,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -130,7 +130,9 @@ async def test_list_devices(discovery_mock, runner):
 async def test_discover_raw(discovery_mock, runner, mocker):
     """Test that device update is called on main."""
     wrapped = redact_data
-    with patch("kasa.discover.redact_data", side_effect=wrapped) as redact_spy:
+    with patch(
+        "kasa.protocols.protocol.redact_data", side_effect=wrapped
+    ) as redact_spy:
         res = await runner.invoke(
             cli,
             ["--username", "foo", "--password", "bar", "discover", "raw"],
@@ -139,8 +141,8 @@ async def test_discover_raw(discovery_mock, runner, mocker):
         assert res.exit_code == 0
 
         expected = {
-            "ip": "127.0.0.123",
-            "discovery_result": discovery_mock.discovery_data,
+            "discovery_response": discovery_mock.discovery_data,
+            "meta": {"ip": "127.0.0.123", "port": 20002},
         }
         assert res.output == json_dumps(expected, indent=True) + "\n"
 
@@ -152,11 +154,6 @@ async def test_discover_raw(discovery_mock, runner, mocker):
             catch_exceptions=False,
         )
         assert res.exit_code == 0
-
-        expected = {
-            "ip": "127.0.0.123",
-            "discovery_result": discovery_mock.discovery_data,
-        }
 
         redact_spy.assert_called()
 
@@ -766,7 +763,7 @@ async def test_without_device_type(dev, mocker, runner):
         timeout=5,
         discovery_timeout=7,
         on_unsupported=ANY,
-        on_json_discovered=ANY,
+        on_discovered_raw=ANY,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -142,7 +142,7 @@ async def test_discover_raw(discovery_mock, runner, mocker):
 
         expected = {
             "discovery_response": discovery_mock.discovery_data,
-            "meta": {"ip": "127.0.0.123", "port": 20002},
+            "meta": {"ip": "127.0.0.123", "port": discovery_mock.discovery_port},
         }
         assert res.output == json_dumps(expected, indent=True) + "\n"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -128,34 +128,33 @@ async def test_list_devices(discovery_mock, runner):
 
 
 async def test_discover_raw(discovery_mock, runner, mocker):
-    """Test that device update is called on main."""
-    wrapped = redact_data
-    with patch(
-        "kasa.protocols.protocol.redact_data", side_effect=wrapped
-    ) as redact_spy:
-        res = await runner.invoke(
-            cli,
-            ["--username", "foo", "--password", "bar", "discover", "raw"],
-            catch_exceptions=False,
-        )
-        assert res.exit_code == 0
+    """Test the discover raw command."""
+    redact_spy = mocker.patch(
+        "kasa.protocols.protocol.redact_data", side_effect=redact_data
+    )
+    res = await runner.invoke(
+        cli,
+        ["--username", "foo", "--password", "bar", "discover", "raw"],
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 0
 
-        expected = {
-            "discovery_response": discovery_mock.discovery_data,
-            "meta": {"ip": "127.0.0.123", "port": discovery_mock.discovery_port},
-        }
-        assert res.output == json_dumps(expected, indent=True) + "\n"
+    expected = {
+        "discovery_response": discovery_mock.discovery_data,
+        "meta": {"ip": "127.0.0.123", "port": discovery_mock.discovery_port},
+    }
+    assert res.output == json_dumps(expected, indent=True) + "\n"
 
-        redact_spy.assert_not_called()
+    redact_spy.assert_not_called()
 
-        res = await runner.invoke(
-            cli,
-            ["--username", "foo", "--password", "bar", "discover", "raw", "--redact"],
-            catch_exceptions=False,
-        )
-        assert res.exit_code == 0
+    res = await runner.invoke(
+        cli,
+        ["--username", "foo", "--password", "bar", "discover", "raw", "--redact"],
+        catch_exceptions=False,
+    )
+    assert res.exit_code == 0
 
-        redact_spy.assert_called()
+    redact_spy.assert_called()
 
 
 @new_discovery


### PR DESCRIPTION
Adds `on_discovered_raw` callback to `Discover` and adds a cli command `discover raw` which returns the raw json before serializing to a `DiscoveryResult` and attempting to create a device class.