### PR TITLE
Rename `current_consumption` to `power`

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -85,7 +85,7 @@ state
 rssi
 on_since
 reboot
-current_consumption
+power
 consumption_today
 consumption_this_month
 consumption_total
@@ -604,7 +604,7 @@ class Device(ABC):
         "emeter_realtime": (Module.Energy, ["status"]),
         "emeter_today": (Module.Energy, ["consumption_today"]),
         "emeter_this_month": (Module.Energy, ["consumption_this_month"]),
-        "current_consumption": (Module.Energy, ["current_consumption"]),
+        "current_consumption": (Module.Energy, ["power"]),
         "get_emeter_daily": (Module.Energy, ["get_daily_stats"]),
         "get_emeter_monthly": (Module.Energy, ["get_monthly_stats"]),
         # Other attributes

--- a/kasa/interfaces/energy.py
+++ b/kasa/interfaces/energy.py
@@ -38,11 +38,11 @@ class Energy(Module, ABC):
         self._add_feature(
             Feature(
                 device,
-                name="Current consumption",
-                attribute_getter="current_consumption",
+                name="Power",
+                attribute_getter="power",
                 container=self,
                 unit_getter=lambda: "W",
-                id="current_consumption",
+                id="power",
                 precision_hint=1,
                 category=Feature.Category.Primary,
                 type=Feature.Type.Sensor,
@@ -64,11 +64,11 @@ class Energy(Module, ABC):
         self._add_feature(
             Feature(
                 device,
-                id="consumption_this_month",
                 name="This month's consumption",
                 attribute_getter="consumption_this_month",
                 container=self,
                 unit_getter=lambda: "kWh",
+                id="consumption_this_month",
                 precision_hint=3,
                 category=Feature.Category.Info,
                 type=Feature.Type.Sensor,
@@ -123,8 +123,8 @@ class Energy(Module, ABC):
 
     @property
     @abstractmethod
-    def current_consumption(self) -> float | None:
-        """Get the current power consumption in Watt."""
+    def power(self) -> float | None:
+        """Get the current power draw in Watts."""
 
     @property
     @abstractmethod
@@ -182,6 +182,7 @@ class Energy(Module, ABC):
         "erase_emeter_stats": "erase_stats",
         "get_daystat": "get_daily_stats",
         "get_monthstat": "get_monthly_stats",
+        "current_consumption": "power",
     }
 
     if not TYPE_CHECKING:

--- a/kasa/iot/iotstrip.py
+++ b/kasa/iot/iotstrip.py
@@ -201,10 +201,10 @@ class StripEmeter(IotModule, Energy):
         return {}
 
     @property
-    def current_consumption(self) -> float | None:
+    def power(self) -> float | None:
         """Get the current power consumption in watts."""
         return sum(
-            v if (v := plug.modules[Module.Energy].current_consumption) else 0.0
+            v if (v := plug.modules[Module.Energy].power) else 0.0
             for plug in self._device.children
         )
 

--- a/kasa/iot/modules/emeter.py
+++ b/kasa/iot/modules/emeter.py
@@ -51,8 +51,8 @@ class Emeter(Usage, EnergyInterface):
         return data.get(current_month, 0.0)
 
     @property
-    def current_consumption(self) -> float | None:
-        """Get the current power consumption in Watt."""
+    def power(self) -> float | None:
+        """Get the current power draw in Watts."""
         return self.status.power
 
     @property

--- a/kasa/smart/modules/energy.py
+++ b/kasa/smart/modules/energy.py
@@ -67,9 +67,20 @@ class Energy(SmartModule, EnergyInterface):
         return []
 
     @property
-    def current_consumption(self) -> float | None:
-        """Current power in watts."""
-        return self._current_consumption
+    @raise_if_update_error
+    def power(self) -> float | None:
+        """Current power draw in Watts."""
+        if (power := self.energy.get("current_power")) is not None or (
+            power := self.data.get("get_emeter_data", {}).get("power_mw")
+        ) is not None:
+            return power / 1_000
+        # Fallback if get_energy_usage does not provide current_power,
+        # which can happen on some newer devices (e.g. P304M).
+        elif (
+            power := self.data.get("get_current_power", {}).get("current_power")
+        ) is not None:
+            return power
+        return None
 
     @property
     def energy(self) -> dict:

--- a/kasa/smart/modules/energy.py
+++ b/kasa/smart/modules/energy.py
@@ -126,15 +126,17 @@ class Energy(SmartModule, EnergyInterface):
     @raise_if_update_error
     def current(self) -> float | None:
         """Return the current in A."""
-        ma = self.data.get("get_emeter_data", {}).get("current_ma")
-        return ma / 1000 if ma else None
+        if (ma := self.data.get("get_emeter_data", {}).get("current_ma")) is not None:
+            return ma / 1_000
+        return None
 
     @property
     @raise_if_update_error
     def voltage(self) -> float | None:
         """Get the current voltage in V."""
-        mv = self.data.get("get_emeter_data", {}).get("voltage_mv")
-        return mv / 1000 if mv else None
+        if (mv := self.data.get("get_emeter_data", {}).get("voltage_mv")) is not None:
+            return mv / 1_000
+        return None
 
     async def _deprecated_get_realtime(self) -> EmeterStatus:
         """Retrieve current energy readings."""

--- a/tests/iot/modules/test_emeter.py
+++ b/tests/iot/modules/test_emeter.py
@@ -133,9 +133,9 @@ async def test_erase_emeter_stats(dev):
 
 
 @has_emeter_iot
-async def test_current_consumption(dev):
+async def test_power(dev):
     emeter = dev.modules[Module.Energy]
-    x = emeter.current_consumption
+    x = emeter.power
     assert isinstance(x, float)
     assert x >= 0.0
 

--- a/tests/test_strip.py
+++ b/tests/test_strip.py
@@ -159,4 +159,4 @@ async def test_children_energy(dev: Device):
         energy = plug.modules[Module.Energy]
         assert "voltage" in energy._module_features
         assert "current" in energy._module_features
-        assert "current_consumption" in energy._module_features
+        assert "power" in energy._module_features


### PR DESCRIPTION
- Note: This is a breaking change.
- Fix: Rename `current_consumption` to `power` in energy modules, to deconflict and clarify.
- Fix: Report `0` instead of `None` for current when current is zero.
- Fix: Report `0` instead of `None` for voltage when voltage is zero (not that this was possible to see).