### PR TITLE
Pass raw components to SmartChildDevice init

### DIFF
--- a/kasa/smart/smartchilddevice.py
+++ b/kasa/smart/smartchilddevice.py
@@ -9,7 +9,7 @@ from typing import Any
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
 from ..protocols.smartprotocol import SmartProtocol, _ChildProtocolWrapper
-from .smartdevice import SmartDevice
+from .smartdevice import ComponentsRaw, SmartDevice
 from .smartmodule import SmartModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,7 +37,7 @@ class SmartChildDevice(SmartDevice):
         self,
         parent: SmartDevice,
         info: dict,
-        component_info: dict,
+        component_info_raw: ComponentsRaw,
         *,
         config: DeviceConfig | None = None,
         protocol: SmartProtocol | None = None,
@@ -47,7 +47,8 @@ class SmartChildDevice(SmartDevice):
         super().__init__(parent.host, config=parent.config, protocol=_protocol)
         self._parent = parent
         self._update_internal_state(info)
-        self._components = component_info
+        self._components_raw = component_info_raw
+        self._components = self._parse_components(self._components_raw)
 
     async def update(self, update_children: bool = True) -> None:
         """Update child module info.
@@ -84,7 +85,7 @@ class SmartChildDevice(SmartDevice):
         cls,
         parent: SmartDevice,
         child_info: dict,
-        child_components: dict,
+        child_components_raw: dict,
         protocol: SmartProtocol | None = None,
         *,
         last_update: dict | None = None,
@@ -97,7 +98,7 @@ class SmartChildDevice(SmartDevice):
         derived from the parent.
         """
         child: SmartChildDevice = cls(
-            parent, child_info, child_components, protocol=protocol
+            parent, child_info, child_components_raw, protocol=protocol
         )
         if last_update:
             child._last_update = last_update

--- a/kasa/smart/smartchilddevice.py
+++ b/kasa/smart/smartchilddevice.py
@@ -85,7 +85,7 @@ class SmartChildDevice(SmartDevice):
         cls,
         parent: SmartDevice,
         child_info: dict,
-        child_components_raw: dict,
+        child_components_raw: ComponentsRaw,
         protocol: SmartProtocol | None = None,
         *,
         last_update: dict | None = None,

--- a/kasa/smartcam/smartcamdevice.py
+++ b/kasa/smartcam/smartcamdevice.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from ..device import _DeviceInfo
 from ..device_type import DeviceType
 from ..module import Module
 from ..protocols.smartcamprotocol import _ChildCameraProtocolWrapper
 from ..smart import SmartChildDevice, SmartDevice
+from ..smart.smartdevice import ComponentsRaw
 from .modules import ChildDevice, DeviceModule
 from .smartcammodule import SmartCamModule
 
@@ -78,7 +79,7 @@ class SmartCamDevice(SmartDevice):
                 self._children[child_id]._update_internal_state(info)
 
     async def _initialize_smart_child(
-        self, info: dict, child_components: dict
+        self, info: dict, child_components_raw: ComponentsRaw
     ) -> SmartDevice:
         """Initialize a smart child device attached to a smartcam device."""
         child_id = info["device_id"]
@@ -93,7 +94,7 @@ class SmartCamDevice(SmartDevice):
         return await SmartChildDevice.create(
             parent=self,
             child_info=info,
-            child_components=child_components,
+            child_components_raw=child_components_raw,
             protocol=child_protocol,
             last_update=initial_response,
         )
@@ -108,17 +109,8 @@ class SmartCamDevice(SmartDevice):
         self.internal_state.update(resp)
 
         smart_children_components = {
-            child["device_id"]: {
-                comp["id"]: int(comp["ver_code"]) for comp in component_list
-            }
+            child["device_id"]: child
             for child in resp["getChildDeviceComponentList"]["child_component_list"]
-            if (component_list := child.get("component_list"))
-            # Child camera devices will have a different component schema so only
-            # extract smart values.
-            and (first_comp := next(iter(component_list), None))
-            and isinstance(first_comp, dict)
-            and "id" in first_comp
-            and "ver_code" in first_comp
         }
         children = {}
         for info in resp["getChildDeviceList"]["child_device_list"]:
@@ -172,6 +164,13 @@ class SmartCamDevice(SmartDevice):
 
         return res
 
+    @staticmethod
+    def _parse_components(components_raw: ComponentsRaw) -> dict[str, int]:
+        return {
+            str(comp["name"]): int(comp["version"])
+            for comp in components_raw["app_component_list"]
+        }
+
     async def _negotiate(self) -> None:
         """Perform initialization.
 
@@ -186,12 +185,10 @@ class SmartCamDevice(SmartDevice):
         self._last_update.update(resp)
         self._update_internal_info(resp)
 
-        self._components = {
-            comp["name"]: int(comp["version"])
-            for comp in resp["getAppComponentList"]["app_component"][
-                "app_component_list"
-            ]
-        }
+        self._components_raw = cast(
+            ComponentsRaw, resp["getAppComponentList"]["app_component"]
+        )
+        self._components = self._parse_components(self._components_raw)
 
         if "childControl" in self._components and not self.children:
             await self._initialize_children()

--- a/tests/test_childdevice.py
+++ b/tests/test_childdevice.py
@@ -145,7 +145,9 @@ async def test_child_device_type_unknown(caplog):
             super().__init__(
                 SmartDevice("127.0.0.1"),
                 {"device_id": "1", "category": "foobar"},
-                {"device", 1},
+                {
+                    "component_list": [{"id": "device", "ver_code": 1}],
+                },
             )
 
     assert DummyDevice().device_type is DeviceType.Unknown

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -86,7 +86,11 @@ async def test_device_class_ctors(device_class_name_obj):
     if issubclass(klass, SmartChildDevice):
         parent = SmartDevice(host, config=config)
         dev = klass(
-            parent, {"dummy": "info", "device_id": "dummy"}, {"dummy": "components"}
+            parent,
+            {"dummy": "info", "device_id": "dummy"},
+            {
+                "component_list": [{"id": "device", "ver_code": 1}],
+            },
         )
     else:
         dev = klass(host, config=config)
@@ -106,7 +110,11 @@ async def test_device_class_repr(device_class_name_obj):
     if issubclass(klass, SmartChildDevice):
         parent = SmartDevice(host, config=config)
         dev = klass(
-            parent, {"dummy": "info", "device_id": "dummy"}, {"dummy": "components"}
+            parent,
+            {"dummy": "info", "device_id": "dummy"},
+            {
+                "component_list": [{"id": "device", "ver_code": 1}],
+            },
         )
     else:
         dev = klass(host, config=config)


### PR DESCRIPTION
Cleans up and consolidates up the processing of raw component query responses.

Will simplify the code paths for creating smartcam child devices when supported.

Also addresses the [question raised](https://github.com/python-kasa/python-kasa/pull/1338#discussion_r1870911802) in the PR for consistent use of `DeviceInfo`
