### PR TITLE
Handle network key type

### DIFF
--- a/kasa/cli/wifi.py
+++ b/kasa/cli/wifi.py
@@ -35,7 +35,7 @@ async def scan(dev):
 
 @wifi.command()
 @click.argument("ssid")
-@click.option("--keytype", prompt=True)
+@click.option("--keytype", prompt=True, default="3")
 @click.option("--password", prompt=True, hide_input=True)
 @pass_dev
 async def join(dev: Device, ssid: str, password: str, keytype: str):

--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -679,7 +679,23 @@ class IotDevice(Device):
         async def _join(target: str, payload: dict) -> dict:
             return await self._query_helper(target, "set_stainfo", payload)
 
-        payload = {"ssid": ssid, "password": password, "key_type": int(keytype)}
+        try:
+            keytype = int(keytype)
+        except ValueError:
+            match keytype.lower():
+                case "open":
+                    keytype = 0
+                case "wep":
+                    keytype = 1
+                case "wpa":
+                    keytype = 2
+                case "wpa2":
+                    keytype = 3
+                case "wpa3":
+                    keytype = 4
+                case _:
+                    raise KasaException(f"Unknown network keytype: {keytype}")
+        payload = {"ssid": ssid, "password": password, "key_type": keytype}
         try:
             return await _join("netif", payload)
         except KasaException as ex:


### PR DESCRIPTION
Aims to handle network key type by using a text match that assigns the integer, as reported in #1325, in order to close #1325 

One solution of multiple potential solutions. Adds the default of 3, which corresponds to WPA2, and is set as a default in multiple other locations within the code.

May need more documentation on the levels (0-4) and what they relate to.