### PR TITLE
Force single for some smartcam requests

### DIFF
--- a/kasa/protocols/smartprotocol.py
+++ b/kasa/protocols/smartprotocol.py
@@ -69,6 +69,13 @@ REDACTORS: dict[str, Callable[[Any], Any] | None] = {
     "map_data": lambda x: "#SCRUBBED_MAPDATA#" if x else "",
 }
 
+# Queries that are known not to work properly when sent as a
+# multiRequest. They will not return the `method` key.
+DO_NOT_SEND_AS_MULTI_REQUEST = {
+    "getConnectStatus",
+    "scanApList",
+}
+
 
 class SmartProtocol(BaseProtocol):
     """Class for the new TPLink SMART protocol."""
@@ -89,6 +96,7 @@ class SmartProtocol(BaseProtocol):
             self._transport._config.batch_size or self.DEFAULT_MULTI_REQUEST_BATCH_SIZE
         )
         self._redact_data = True
+        self._method_missing_logged = False
 
     def get_smart_request(self, method: str, params: dict | None = None) -> str:
         """Get a request message as a string."""
@@ -178,6 +186,7 @@ class SmartProtocol(BaseProtocol):
         multi_requests = [
             {"method": method, "params": params} if params else {"method": method}
             for method, params in requests.items()
+            if method not in DO_NOT_SEND_AS_MULTI_REQUEST
         ]
 
         end = len(multi_requests)
@@ -246,7 +255,20 @@ class SmartProtocol(BaseProtocol):
 
             responses = response_step["result"]["responses"]
             for response in responses:
-                method = response["method"]
+                # some smartcam devices calls do not populate the method key
+                # these should be defined in DO_NOT_SEND_AS_MULTI_REQUEST.
+                if not (method := response.get("method")):
+                    if not self._method_missing_logged:
+                        # Avoid spamming the logs
+                        self._method_missing_logged = True
+                        _LOGGER.error(
+                            "No method key in response for %s, skipping: %s",
+                            self._host,
+                            response_step,
+                        )
+                    # These will end up being queried individually
+                    continue
+
                 self._handle_response_error_code(
                     response, method, raise_on_error=raise_on_error
                 )
@@ -255,7 +277,9 @@ class SmartProtocol(BaseProtocol):
                     result, method, retry_count=retry_count
                 )
                 multi_result[method] = result
-        # Multi requests don't continue after errors so requery any missing
+
+        # Multi requests don't continue after errors so requery any missing.
+        # Will also query individually any DO_NOT_SEND_AS_MULTI_REQUEST.
         for method, params in requests.items():
             if method not in multi_result:
                 resp = await self._transport.send(

--- a/kasa/protocols/smartprotocol.py
+++ b/kasa/protocols/smartprotocol.py
@@ -71,7 +71,7 @@ REDACTORS: dict[str, Callable[[Any], Any] | None] = {
 
 # Queries that are known not to work properly when sent as a
 # multiRequest. They will not return the `method` key.
-DO_NOT_SEND_AS_MULTI_REQUEST = {
+FORCE_SINGLE_REQUEST = {
     "getConnectStatus",
     "scanApList",
 }
@@ -186,7 +186,7 @@ class SmartProtocol(BaseProtocol):
         multi_requests = [
             {"method": method, "params": params} if params else {"method": method}
             for method, params in requests.items()
-            if method not in DO_NOT_SEND_AS_MULTI_REQUEST
+            if method not in FORCE_SINGLE_REQUEST
         ]
 
         end = len(multi_requests)

--- a/tests/fakeprotocol_smartcam.py
+++ b/tests/fakeprotocol_smartcam.py
@@ -34,6 +34,7 @@ class FakeSmartCamTransport(BaseTransport):
         list_return_size=10,
         is_child=False,
         verbatim=False,
+        components_not_included=False,
     ):
         super().__init__(
             config=DeviceConfig(
@@ -59,12 +60,16 @@ class FakeSmartCamTransport(BaseTransport):
         # self.child_protocols = self._get_child_protocols()
         self.list_return_size = list_return_size
 
-        self.components = {
-            comp["name"]: comp["version"]
-            for comp in self.info["getAppComponentList"]["app_component"][
-                "app_component_list"
-            ]
-        }
+        # Setting this flag allows tests to create dummy transports without
+        # full fixture info for testing specific cases like list handling etc
+        self.components_not_included = (components_not_included,)
+        if not components_not_included:
+            self.components = {
+                comp["name"]: comp["version"]
+                for comp in self.info["getAppComponentList"]["app_component"][
+                    "app_component_list"
+                ]
+            }
 
     @property
     def default_port(self):


### PR DESCRIPTION
Required for `onboarding` requests included in https://github.com/python-kasa/python-kasa/pull/1373 which do not return the `method` key and need to be sent as single requests.
