### PR TITLE
Fix lens mask required component and state

### DIFF
--- a/kasa/smartcam/modules/camera.py
+++ b/kasa/smartcam/modules/camera.py
@@ -50,7 +50,7 @@ class Camera(SmartCamModule):
     def is_on(self) -> bool:
         """Return the device on state."""
         if lens_mask := self._device.modules.get(Module.LensMask):
-            return lens_mask.state
+            return not lens_mask.enabled
         return True
 
     async def set_state(self, on: bool) -> Annotated[dict, FeatureAttribute()]:
@@ -60,7 +60,7 @@ class Camera(SmartCamModule):
         """
         if lens_mask := self._device.modules.get(Module.LensMask):
             # Turning off enables the privacy mask which is why value is reversed.
-            return await lens_mask.set_state(not on)
+            return await lens_mask.set_enabled(not on)
         return {}
 
     def _get_credentials(self) -> Credentials | None:

--- a/kasa/smartcam/modules/camera.py
+++ b/kasa/smartcam/modules/camera.py
@@ -39,6 +39,7 @@ class Camera(SmartCamModule):
                     self._device,
                     id="state",
                     name="State",
+                    container=self,
                     attribute_getter="is_on",
                     attribute_setter="set_state",
                     type=Feature.Type.Switch,

--- a/kasa/smartcam/modules/lensmask.py
+++ b/kasa/smartcam/modules/lensmask.py
@@ -12,18 +12,20 @@ _LOGGER = logging.getLogger(__name__)
 class LensMask(SmartCamModule):
     """Implementation of lens mask module."""
 
+    REQUIRED_COMPONENT = "lensMask"
+
     QUERY_GETTER_NAME = "getLensMaskConfig"
     QUERY_MODULE_NAME = "lens_mask"
     QUERY_SECTION_NAMES = "lens_mask_info"
 
     @property
-    def state(self) -> bool:
+    def enabled(self) -> bool:
         """Return the lens mask state."""
-        return self.data["lens_mask_info"]["enabled"] == "off"
+        return self.data["lens_mask_info"]["enabled"] == "on"
 
-    async def set_state(self, state: bool) -> dict:
+    async def set_enabled(self, enable: bool) -> dict:
         """Set the lens mask state."""
-        params = {"enabled": "on" if state else "off"}
+        params = {"enabled": "on" if enable else "off"}
         return await self._device._query_setter_helper(
             "setLensMaskConfig", self.QUERY_MODULE_NAME, "lens_mask_info", params
         )


### PR DESCRIPTION
Fixes a few issues with the lens mask since migrating it into its own module:

 - The module didn't provide itself as the container and hence the feature was accessing the same properties on the device.
 - `enabled` getter on the module incorrect but not picked up due to the previous issue.
 - No `REQUIRED_COMPONENT` set to ensure the module only created if available.

Also changes attribute names to `enabled` from `state` to avoid confusion with device states.