### PR TITLE
Treat smartcam 500 errors after handshake as retryable

### DIFF
--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -113,25 +113,23 @@ class HttpClient:
                 ssl=ssl,
             )
             async with resp:
-                if resp.status == 200:
-                    response_data = await resp.read()
-                    if return_json:
+                response_data = await resp.read()
+
+            if resp.status == 200:
+                if return_json:
+                    response_data = json_loads(response_data.decode())
+            else:
+                _LOGGER.debug(
+                    "Device %s received status code %s with response %s",
+                    self._config.host,
+                    resp.status,
+                    str(response_data),
+                )
+                if response_data and return_json:
+                    try:
                         response_data = json_loads(response_data.decode())
-                else:
-                    response_data = await resp.read()
-                    _LOGGER.debug(
-                        "Device %s received status code %s with response %s",
-                        self._config.host,
-                        resp.status,
-                        str(response_data),
-                    )
-                    if response_data and return_json:
-                        try:
-                            response_data = json_loads(response_data.decode())
-                        except Exception:
-                            _LOGGER.debug(
-                                "Device %s response could not be parsed as json"
-                            )
+                    except Exception:
+                        _LOGGER.debug("Device %s response could not be parsed as json")
 
         except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as ex:
             if not self._wait_between_requests:

--- a/kasa/httpclient.py
+++ b/kasa/httpclient.py
@@ -117,6 +117,21 @@ class HttpClient:
                     response_data = await resp.read()
                     if return_json:
                         response_data = json_loads(response_data.decode())
+                else:
+                    response_data = await resp.read()
+                    _LOGGER.debug(
+                        "Device %s received status code %s with response %s",
+                        self._config.host,
+                        resp.status,
+                        str(response_data),
+                    )
+                    if response_data and return_json:
+                        try:
+                            response_data = json_loads(response_data.decode())
+                        except Exception:
+                            _LOGGER.debug(
+                                "Device %s response could not be parsed as json"
+                            )
 
         except (aiohttp.ServerDisconnectedError, aiohttp.ClientOSError) as ex:
             if not self._wait_between_requests:

--- a/kasa/transports/sslaestransport.py
+++ b/kasa/transports/sslaestransport.py
@@ -240,16 +240,15 @@ class SslAesTransport(BaseTransport):
                 f"Device {self._host} replied with status 500 after handshake, "
                 f"response: "
             )
+            decrypted = None
             if isinstance(resp_dict, dict) and (
                 response := resp_dict.get("result", {}).get("response")
             ):
-                decrypted = None
                 with suppress(Exception):
                     decrypted = self._encryption_session.decrypt(response.encode())
-                if decrypted:
-                    msg += decrypted
-                else:
-                    msg += str(resp_dict)
+
+            if decrypted:
+                msg += decrypted
             else:
                 msg += str(resp_dict)
 

--- a/kasa/transports/sslaestransport.py
+++ b/kasa/transports/sslaestransport.py
@@ -8,6 +8,7 @@ import hashlib
 import logging
 import secrets
 import ssl
+from contextlib import suppress
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Any, cast
 
@@ -229,6 +230,32 @@ class SslAesTransport(BaseTransport):
             ssl=await self._get_ssl_context(),
         )
 
+        if TYPE_CHECKING:
+            assert self._encryption_session is not None
+
+        # Devices can respond with 500 if another session is created from
+        # the same host. Decryption may not succeed after that
+        if status_code == 500:
+            msg = (
+                f"Device {self._host} replied with status 500 after handshake, "
+                f"response: "
+            )
+            if isinstance(resp_dict, dict) and (
+                response := resp_dict.get("result", {}).get("response")
+            ):
+                decrypted = None
+                with suppress(Exception):
+                    decrypted = self._encryption_session.decrypt(response.encode())
+                if decrypted:
+                    msg += decrypted
+                else:
+                    msg += str(resp_dict)
+            else:
+                msg += str(resp_dict)
+
+            _LOGGER.debug(msg)
+            raise _RetryableError(msg)
+
         if status_code != 200:
             raise KasaException(
                 f"{self._host} responded with an unexpected "
@@ -241,7 +268,6 @@ class SslAesTransport(BaseTransport):
 
         if TYPE_CHECKING:
             resp_dict = cast(dict[str, Any], resp_dict)
-            assert self._encryption_session is not None
 
         if "result" in resp_dict and "response" in resp_dict["result"]:
             raw_response: str = resp_dict["result"]["response"]


### PR DESCRIPTION
`smartcam` devices can respond with 500 if another session is created from the same host.

A retry should reauthenticate succesfully.

Example response:

```json
{"error_code": -1, "msg": "Check tapo tag failed"}
```

N.B. decryption doesn't always succeed in this instance
