### PR TITLE
Use repr() for enum values in Feature.__repr__

### DIFF
--- a/kasa/feature.py
+++ b/kasa/feature.py
@@ -295,6 +295,8 @@ class Feature:
         if self.precision_hint is not None and isinstance(value, float):
             value = round(value, self.precision_hint)
 
+        if isinstance(value, Enum):
+            value = repr(value)
         s = f"{self.name} ({self.id}): {value}"
         if self.unit is not None:
             s += f" {self.unit}"


### PR DESCRIPTION
Instead of simply displaying the enum value, use repr to get a nicer output for the cli.
Was: `Error (vacuum_error): 14`
Now: `Error (vacuum_error): <ErrorCode.DustBinRemoved: 14>`