### PR TITLE
Improve exception messages on credential mismatches

### DIFF
--- a/kasa/transports/klaptransport.py
+++ b/kasa/transports/klaptransport.py
@@ -214,8 +214,8 @@ class KlapTransport(BaseTransport):
 
             if default_credentials_seed_auth_hash == server_hash:
                 _LOGGER.debug(
-                    "Server response doesn't match our expected hash on ip %s, "
-                    "but an authentication with %s default credentials matched",
+                    "Device response did not match our expected hash on ip %s,"
+                    "but an authentication with %s default credentials worked",
                     self._host,
                     key,
                 )
@@ -235,13 +235,16 @@ class KlapTransport(BaseTransport):
 
             if blank_seed_auth_hash == server_hash:
                 _LOGGER.debug(
-                    "Server response doesn't match our expected hash on ip %s, "
-                    "but an authentication with blank credentials matched",
+                    "Device response did not match our expected hash on ip %s, "
+                    "but an authentication with blank credentials worked",
                     self._host,
                 )
                 return local_seed, remote_seed, self._blank_auth_hash  # type: ignore
 
-        msg = f"Server response doesn't match our challenge on ip {self._host}"
+        msg = (
+            f"Device response did not match our challenge on ip {self._host}, "
+            f"check that your e-mail and password (both case-sensitive) are correct. "
+        )
         _LOGGER.debug(msg)
         raise AuthenticationError(msg)
 

--- a/kasa/transports/sslaestransport.py
+++ b/kasa/transports/sslaestransport.py
@@ -603,7 +603,10 @@ class SslAesTransport(BaseTransport):
             _LOGGER.debug("Credentials match")
             return local_nonce, server_nonce, pwd_hash
 
-        msg = f"Server response doesn't match our challenge on ip {self._host}"
+        msg = (
+            f"Device response did not match our challenge on ip {self._host}, "
+            f"check that your e-mail and password (both case-sensitive) are correct. "
+        )
         _LOGGER.debug(msg)
 
         raise AuthenticationError(msg)


### PR DESCRIPTION
This PR makes the exception message on authentication hash mismatches clearer.
I renamed "server" to "device" as that makes more sense for errors that are shown to users.

Related comments:
* https://github.com/home-assistant/core/issues/133164#issuecomment-2567042655
* https://github.com/python-kasa/python-kasa/issues/1351#issuecomment-2569849407


Thanks to @TheHairforce and @ZeliardM for helping spot the issue, I will create a separate PR to update the exception messages to help users encountering the challenge hash mismatch.