### PR TITLE
Fallback to is_low for batterysensor's battery_low

### DIFF
--- a/kasa/smart/modules/batterysensor.py
+++ b/kasa/smart/modules/batterysensor.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
+from ... import KasaException
 from ...feature import Feature
+from ...module import FeatureAttribute
 from ..smartmodule import SmartModule
 
 
@@ -14,18 +18,22 @@ class BatterySensor(SmartModule):
 
     def _initialize_features(self) -> None:
         """Initialize features."""
-        self._add_feature(
-            Feature(
-                self._device,
-                "battery_low",
-                "Battery low",
-                container=self,
-                attribute_getter="battery_low",
-                icon="mdi:alert",
-                type=Feature.Type.BinarySensor,
-                category=Feature.Category.Debug,
+        if (
+            "at_low_battery" in self._device.sys_info
+            or "is_low" in self._device.sys_info
+        ):
+            self._add_feature(
+                Feature(
+                    self._device,
+                    "battery_low",
+                    "Battery low",
+                    container=self,
+                    attribute_getter="battery_low",
+                    icon="mdi:alert",
+                    type=Feature.Type.BinarySensor,
+                    category=Feature.Category.Debug,
+                )
             )
-        )
 
         # Some devices, like T110 contact sensor do not report the battery percentage
         if "battery_percentage" in self._device.sys_info:
@@ -48,13 +56,17 @@ class BatterySensor(SmartModule):
         return {}
 
     @property
-    def battery(self) -> int:
+    def battery(self) -> Annotated[int, FeatureAttribute()]:
         """Return battery level."""
         return self._device.sys_info["battery_percentage"]
 
     @property
-    def battery_low(self) -> bool:
+    def battery_low(self) -> Annotated[bool, FeatureAttribute()]:
         """Return True if battery is low."""
-        return self._device.sys_info.get(
+        is_low = self._device.sys_info.get(
             "at_low_battery", self._device.sys_info.get("is_low")
         )
+        if is_low is None:
+            raise KasaException("Device does not report battery low status")
+
+        return is_low

--- a/kasa/smart/modules/batterysensor.py
+++ b/kasa/smart/modules/batterysensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from ... import KasaException
+from ...exceptions import KasaException
 from ...feature import Feature
 from ...module import FeatureAttribute
 from ..smartmodule import SmartModule

--- a/kasa/smart/modules/batterysensor.py
+++ b/kasa/smart/modules/batterysensor.py
@@ -55,4 +55,6 @@ class BatterySensor(SmartModule):
     @property
     def battery_low(self) -> bool:
         """Return True if battery is low."""
-        return self._device.sys_info["at_low_battery"]
+        return self._device.sys_info.get(
+            "at_low_battery", self._device.sys_info.get("is_low")
+        )


### PR DESCRIPTION
Fallback to `is_low` if `at_low_battery` is not available.

Related to #1418 #1419 and https://github.com/home-assistant/core/issues/133973