### PR TITLE
Add support for Tapo hub-attached switch devices

### DIFF
--- a/kasa/smart/smartchilddevice.py
+++ b/kasa/smart/smartchilddevice.py
@@ -24,6 +24,7 @@ class SmartChildDevice(SmartDevice):
 
     CHILD_DEVICE_TYPE_MAP = {
         "plug.powerstrip.sub-plug": DeviceType.Plug,
+        "subg.plugswitch.switch": DeviceType.WallSwitch,
         "subg.trigger.contact-sensor": DeviceType.Sensor,
         "subg.trigger.temp-hmdt-sensor": DeviceType.Sensor,
         "subg.trigger.water-leak-sensor": DeviceType.Sensor,


### PR DESCRIPTION
Required for https://github.com/python-kasa/python-kasa/pull/1419 and https://github.com/python-kasa/python-kasa/pull/1418

Fixes [HA issue 133973](https://github.com/home-assistant/core/issues/133973)
