### PR TITLE
Backoff after xor timeout and improve error reporting

### DIFF
--- a/kasa/protocols/iotprotocol.py
+++ b/kasa/protocols/iotprotocol.py
@@ -98,12 +98,26 @@ class IotProtocol(BaseProtocol):
                 )
                 raise auex
             except _RetryableError as ex:
+                if retry == 0:
+                    _LOGGER.debug(
+                        "Device %s got a retryable error, will retry %s times: %s",
+                        self._host,
+                        retry_count,
+                        ex,
+                    )
                 await self._transport.reset()
                 if retry >= retry_count:
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)
                     raise ex
                 continue
             except TimeoutError as ex:
+                if retry == 0:
+                    _LOGGER.debug(
+                        "Device %s got a timeout error, will retry %s times: %s",
+                        self._host,
+                        retry_count,
+                        ex,
+                    )
                 await self._transport.reset()
                 if retry >= retry_count:
                     _LOGGER.debug("Giving up on %s after %s retries", self._host, retry)

--- a/kasa/transports/xortransport.py
+++ b/kasa/transports/xortransport.py
@@ -23,6 +23,7 @@ from collections.abc import Generator
 
 from kasa.deviceconfig import DeviceConfig
 from kasa.exceptions import KasaException, _RetryableError
+from kasa.exceptions import TimeoutError as KasaTimeoutError
 from kasa.json import loads as json_loads
 
 from .basetransport import BaseTransport
@@ -128,7 +129,7 @@ class XorTransport(BaseTransport):
             await self._connect(self._timeout)
         except TimeoutError as ex:
             await self.reset()
-            raise _RetryableError(
+            raise KasaTimeoutError(
                 f"Timeout after {self._timeout} seconds connecting to the device:"
                 f" {self._host}:{self._port}: {ex}"
             ) from ex
@@ -167,7 +168,7 @@ class XorTransport(BaseTransport):
                 return await self._execute_send(request)
         except TimeoutError as ex:
             await self.reset()
-            raise _RetryableError(
+            raise KasaTimeoutError(
                 f"Timeout after {self._timeout} seconds sending request to the device"
                 f" {self._host}:{self._port}: {ex}"
             ) from ex

--- a/kasa/transports/xortransport.py
+++ b/kasa/transports/xortransport.py
@@ -126,6 +126,12 @@ class XorTransport(BaseTransport):
         # This is especially import when there are multiple tplink devices being polled.
         try:
             await self._connect(self._timeout)
+        except TimeoutError as ex:
+            await self.reset()
+            raise _RetryableError(
+                f"Timeout after {self._timeout} seconds connecting to the device:"
+                f" {self._host}:{self._port}: {ex}"
+            ) from ex
         except ConnectionRefusedError as ex:
             await self.reset()
             raise KasaException(
@@ -159,6 +165,12 @@ class XorTransport(BaseTransport):
             assert self.writer is not None  # noqa: S101
             async with asyncio_timeout(self._timeout):
                 return await self._execute_send(request)
+        except TimeoutError as ex:
+            await self.reset()
+            raise _RetryableError(
+                f"Timeout after {self._timeout} seconds sending request to the device"
+                f" {self._host}:{self._port}: {ex}"
+            ) from ex
         except Exception as ex:
             await self.reset()
             raise _RetryableError(

--- a/tests/protocols/test_iotprotocol.py
+++ b/tests/protocols/test_iotprotocol.py
@@ -16,7 +16,7 @@ import pytest
 from kasa.credentials import Credentials
 from kasa.device import Device
 from kasa.deviceconfig import DeviceConfig
-from kasa.exceptions import KasaException, _RetryableError
+from kasa.exceptions import KasaException, TimeoutError
 from kasa.iot import IotDevice
 from kasa.protocols.iotprotocol import IotProtocol, _deprecated_TPLinkSmartHomeProtocol
 from kasa.protocols.protocol import (
@@ -444,7 +444,7 @@ async def test_protocol_handles_timeout_failure_during_write(
     protocol = protocol_class(transport=transport_class(config=config))
     mocker.patch("asyncio.open_connection", side_effect=aio_mock_writer)
     with pytest.raises(
-        _RetryableError,
+        TimeoutError,
         match="Timeout after 5 seconds sending request to the device 127.0.0.1:9999: Simulated timeout",
     ):
         await protocol.query({})
@@ -490,7 +490,7 @@ async def test_protocol_handles_timeout_failure_during_connection(
 
     mocker.patch("asyncio.open_connection", side_effect=aio_mock_writer)
     with pytest.raises(
-        _RetryableError,
+        TimeoutError,
         match="Timeout after 5 seconds connecting to the device: 127.0.0.1:9999: Simulated timeout",
     ):
         await protocol.query({})


### PR DESCRIPTION
`asyncio.TimeoutError` doesn't provide a useful error string so we need to provide something better
```
>>> str(asyncio.TimeoutError())
''
``` 

related issue https://github.com/home-assistant/core/issues/128677