### PR TITLE
Raise errors on single smartcam child requests

### DIFF
--- a/kasa/protocols/smartcamprotocol.py
+++ b/kasa/protocols/smartcamprotocol.py
@@ -244,11 +244,15 @@ class _ChildCameraProtocolWrapper(SmartProtocol):
 
         responses = response["multipleRequest"]["responses"]
         response_dict = {}
+
+        # Raise errors for single calls
+        raise_on_error = len(requests) == 1
+
         for index_id, response in enumerate(responses):
             response_data = response["result"]["response_data"]
             method = methods[index_id]
             self._handle_response_error_code(
-                response_data, method, raise_on_error=False
+                response_data, method, raise_on_error=raise_on_error
             )
             response_dict[method] = response_data.get("result")
 


### PR DESCRIPTION
- This is consistent with `smartprotocol` which raises errors on single calls.
- Will prevent fixtures created via H200 with [inline error codes](https://github.com/python-kasa/python-kasa/blob/master/tests/fixtures/smart/child/S200B(EU)_1.0_1.11.0.json#L88:L89)


