### PR TITLE
Add required sphinx.configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,6 +2,10 @@ version: 2
 
 formats: all
 
+sphinx:
+  configuration: docs/source/conf.py
+
+
 build:
   os: ubuntu-22.04
   tools:


### PR DESCRIPTION
Fixes CI build, this key will become mandatory very soon: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/