### PR TITLE
Allow update of camera modules after setting values

### DIFF
--- a/kasa/smartcam/modules/alarm.py
+++ b/kasa/smartcam/modules/alarm.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...feature import Feature
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 DURATION_MIN = 0
@@ -110,6 +111,7 @@ class Alarm(SmartCamModule):
         """Return current alarm sound."""
         return self.data["getSirenConfig"]["siren_type"]
 
+    @allow_update_after
     async def set_alarm_sound(self, sound: str) -> dict:
         """Set alarm sound.
 
@@ -134,6 +136,7 @@ class Alarm(SmartCamModule):
         """
         return int(self.data["getSirenConfig"]["volume"])
 
+    @allow_update_after
     async def set_alarm_volume(self, volume: int) -> dict:
         """Set alarm volume."""
         if volume < VOLUME_MIN or volume > VOLUME_MAX:
@@ -145,6 +148,7 @@ class Alarm(SmartCamModule):
         """Return alarm duration."""
         return self.data["getSirenConfig"]["duration"]
 
+    @allow_update_after
     async def set_alarm_duration(self, duration: int) -> dict:
         """Set alarm volume."""
         if duration < DURATION_MIN or duration > DURATION_MAX:

--- a/kasa/smartcam/modules/babycrydetection.py
+++ b/kasa/smartcam/modules/babycrydetection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from ...feature import Feature
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class BabyCryDetection(SmartCamModule):
         """Return the baby cry detection enabled state."""
         return self.data["bcd"]["enabled"] == "on"
 
+    @allow_update_after
     async def set_enabled(self, enable: bool) -> dict:
         """Set the baby cry detection enabled state."""
         params = {"enabled": "on" if enable else "off"}

--- a/kasa/smartcam/modules/camera.py
+++ b/kasa/smartcam/modules/camera.py
@@ -99,6 +99,9 @@ class Camera(SmartCamModule):
         :return: rtsp url with escaped credentials or None if no credentials or
             camera is off.
         """
+        if self._device._is_hub_child:
+            return None
+
         streams = {
             StreamResolution.HD: "stream1",
             StreamResolution.SD: "stream2",
@@ -119,6 +122,9 @@ class Camera(SmartCamModule):
 
     def onvif_url(self) -> str | None:
         """Return the onvif url."""
+        if self._device._is_hub_child:
+            return None
+
         return f"http://{self._device.host}:{ONVIF_PORT}/onvif/device_service"
 
     async def _check_supported(self) -> bool:

--- a/kasa/smartcam/modules/led.py
+++ b/kasa/smartcam/modules/led.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ...interfaces.led import Led as LedInterface
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 
@@ -19,6 +20,7 @@ class Led(SmartCamModule, LedInterface):
         """Return current led status."""
         return self.data["config"]["enabled"] == "on"
 
+    @allow_update_after
     async def set_led(self, enable: bool) -> dict:
         """Set led.
 

--- a/kasa/smartcam/modules/lensmask.py
+++ b/kasa/smartcam/modules/lensmask.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ class LensMask(SmartCamModule):
         """Return the lens mask state."""
         return self.data["lens_mask_info"]["enabled"] == "on"
 
+    @allow_update_after
     async def set_enabled(self, enable: bool) -> dict:
         """Set the lens mask state."""
         params = {"enabled": "on" if enable else "off"}

--- a/kasa/smartcam/modules/motiondetection.py
+++ b/kasa/smartcam/modules/motiondetection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from ...feature import Feature
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class MotionDetection(SmartCamModule):
         """Return the motion detection enabled state."""
         return self.data["motion_det"]["enabled"] == "on"
 
+    @allow_update_after
     async def set_enabled(self, enable: bool) -> dict:
         """Set the motion detection enabled state."""
         params = {"enabled": "on" if enable else "off"}

--- a/kasa/smartcam/modules/persondetection.py
+++ b/kasa/smartcam/modules/persondetection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from ...feature import Feature
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class PersonDetection(SmartCamModule):
         """Return the person detection enabled state."""
         return self.data["detection"]["enabled"] == "on"
 
+    @allow_update_after
     async def set_enabled(self, enable: bool) -> dict:
         """Set the person detection enabled state."""
         params = {"enabled": "on" if enable else "off"}

--- a/kasa/smartcam/modules/tamperdetection.py
+++ b/kasa/smartcam/modules/tamperdetection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from ...feature import Feature
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +40,7 @@ class TamperDetection(SmartCamModule):
         """Return the tamper detection enabled state."""
         return self.data["tamper_det"]["enabled"] == "on"
 
+    @allow_update_after
     async def set_enabled(self, enable: bool) -> dict:
         """Set the tamper detection enabled state."""
         params = {"enabled": "on" if enable else "off"}

--- a/kasa/smartcam/modules/time.py
+++ b/kasa/smartcam/modules/time.py
@@ -9,6 +9,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from ...cachedzoneinfo import CachedZoneInfo
 from ...feature import Feature
 from ...interfaces import Time as TimeInterface
+from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
 
@@ -73,6 +74,7 @@ class Time(SmartCamModule, TimeInterface):
         """Return device's current datetime."""
         return self._time
 
+    @allow_update_after
     async def set_time(self, dt: datetime) -> dict:
         """Set device time."""
         if not dt.tzinfo:


### PR DESCRIPTION
Hub-attached child camera modules will delay updates 24 hours. This PR adds the `allow_update_after` decorator to the module setters to allow updates after invoking them.

Also ensures that `stream_rtsp_url` and `onvif_url` returns `None` for hub-attached cameras as they don't support streaming.
