### PR TITLE
Add error code 7 for clean module

### DIFF
--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -38,6 +38,7 @@ class ErrorCode(IntEnum):
     MainBrushStuck = 3
     WheelBlocked = 4
     Trapped = 6
+    TrappedCliff = 7
     DustBinRemoved = 14
     UnableToMove = 15
     LidarBlocked = 16


### PR DESCRIPTION
Unsure about the naming, but this can apparently happen when the cliff sensors indicate the device cannot move.