### PR TITLE
Cancel in progress CI workflows after new pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
       - 'janitor/**'
   workflow_dispatch:  # to allow manual re-runs
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   UV_VERSION: 0.4.16
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '44 17 * * 3'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze


### PR DESCRIPTION
Currently our CI runs continue after new pushed to pull requests or branches. This PR creates a concurreny group which will cancel in progress workflows after new pushes to pull requests or python-kasa branches. This will improve the performance of the latest CI runs which would otherwise be queued behind previous commit runs.

[github docs](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs)

N.B. the group expression is the same used by HA core.

Run being cancelled after new push:

![image](https://github.com/user-attachments/assets/652882b7-dc34-4075-9345-fe3c930988b9)
