### PR TITLE
Update ruff to 0.9

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - "--indent=4"
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.4
+  rev: v0.9.3
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/devtools/parse_pcap_klap.py
+++ b/devtools/parse_pcap_klap.py
@@ -286,8 +286,7 @@ def main(
                     operator.local_seed = message
                     response = None
                     print(
-                        f"got handshake1 in {packet_number}, "
-                        f"looking for the response"
+                        f"got handshake1 in {packet_number}, looking for the response"
                     )
                     while (
                         True

--- a/kasa/cli/hub.py
+++ b/kasa/cli/hub.py
@@ -66,8 +66,8 @@ async def hub_pair(dev: SmartDevice, timeout: int):
 
     for child in pair_res:
         echo(
-            f'Paired {child["name"]} ({child["device_model"]}, '
-            f'{pretty_category(child["category"])}) with id {child["device_id"]}'
+            f"Paired {child['name']} ({child['device_model']}, "
+            f"{pretty_category(child['category'])}) with id {child['device_id']}"
         )
 
 

--- a/kasa/cli/lazygroup.py
+++ b/kasa/cli/lazygroup.py
@@ -66,7 +66,6 @@ class LazyGroup(click.Group):
         # check the result to make debugging easier
         if not isinstance(cmd_object, click.BaseCommand):
             raise ValueError(
-                f"Lazy loading of {cmd_name} failed by returning "
-                "a non-command object"
+                f"Lazy loading of {cmd_name} failed by returning a non-command object"
             )
         return cmd_object

--- a/kasa/iot/iotdimmer.py
+++ b/kasa/iot/iotdimmer.py
@@ -115,9 +115,7 @@ class IotDimmer(IotPlug):
             raise KasaException("Device is not dimmable.")
 
         if not isinstance(brightness, int):
-            raise ValueError(
-                "Brightness must be integer, " "not of %s.", type(brightness)
-            )
+            raise ValueError("Brightness must be integer, not of %s.", type(brightness))
 
         if not 0 <= brightness <= 100:
             raise ValueError(

--- a/kasa/iot/modules/lightpreset.py
+++ b/kasa/iot/modules/lightpreset.py
@@ -54,7 +54,7 @@ class LightPreset(IotModule, LightPresetInterface):
     async def _post_update_hook(self) -> None:
         """Update the internal presets."""
         self._presets = {
-            f"Light preset {index+1}": IotLightPreset.from_dict(vals)
+            f"Light preset {index + 1}": IotLightPreset.from_dict(vals)
             for index, vals in enumerate(self.data["preferred_state"])
             # Devices may list some light effects along with normal presets but these
             # are handled by the LightEffect module so exclude preferred states with id

--- a/kasa/protocols/iotprotocol.py
+++ b/kasa/protocols/iotprotocol.py
@@ -30,7 +30,7 @@ def _mask_children(children: list[dict[str, Any]]) -> list[dict[str, Any]]:
     def mask_child(child: dict[str, Any], index: int) -> dict[str, Any]:
         result = {
             **child,
-            "id": f"SCRUBBED_CHILD_DEVICE_ID_{index+1}",
+            "id": f"SCRUBBED_CHILD_DEVICE_ID_{index + 1}",
         }
         # Will leave empty aliases as blank
         if child.get("alias"):

--- a/kasa/protocols/smartprotocol.py
+++ b/kasa/protocols/smartprotocol.py
@@ -236,7 +236,7 @@ class SmartProtocol(BaseProtocol):
 
             smart_params = {"requests": requests_step}
             smart_request = self.get_smart_request(smart_method, smart_params)
-            batch_name = f"multi-request-batch-{batch_num+1}-of-{int(end/step)+1}"
+            batch_name = f"multi-request-batch-{batch_num + 1}-of-{int(end / step) + 1}"
             if debug_enabled:
                 _LOGGER.debug(
                     "%s %s >> %s",

--- a/kasa/transports/xortransport.py
+++ b/kasa/transports/xortransport.py
@@ -142,18 +142,16 @@ class XorTransport(BaseTransport):
             await self.reset()
             if ex.errno in _NO_RETRY_ERRORS:
                 raise KasaException(
-                    f"Unable to connect to the device:"
-                    f" {self._host}:{self._port}: {ex}"
+                    f"Unable to connect to the device: {self._host}:{self._port}: {ex}"
                 ) from ex
             else:
                 raise _RetryableError(
-                    f"Unable to connect to the device:"
-                    f" {self._host}:{self._port}: {ex}"
+                    f"Unable to connect to the device: {self._host}:{self._port}: {ex}"
                 ) from ex
         except Exception as ex:
             await self.reset()
             raise _RetryableError(
-                f"Unable to connect to the device:" f" {self._host}:{self._port}: {ex}"
+                f"Unable to connect to the device: {self._host}:{self._port}: {ex}"
             ) from ex
         except BaseException:
             # Likely something cancelled the task so we need to close the connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev-dependencies = [
   "mypy~=1.0",
   "pytest-xdist>=3.6.1",
   "pytest-socket>=0.7.0",
-  "ruff==0.7.4",
+  "ruff>=0.9.0",
 ]
 
 
@@ -146,8 +146,6 @@ select = [
 ignore = [
   "D105",  # Missing docstring in magic method
   "D107",  # Missing docstring in `__init__`
-  "ANN101",  # Missing type annotation for `self`
-  "ANN102",  # Missing type annotation for `cls` in classmethod
   "ANN003",  # Missing type annotation for `**kwargs`
   "ANN401",  # allow any
 ]

--- a/tests/fakeprotocol_smartcam.py
+++ b/tests/fakeprotocol_smartcam.py
@@ -218,9 +218,9 @@ class FakeSmartCamTransport(BaseTransport):
 
     @staticmethod
     def _get_second_key(request_dict: dict[str, Any]) -> str:
-        assert (
-            len(request_dict) == 2
-        ), f"Unexpected dict {request_dict}, should be length 2"
+        assert len(request_dict) == 2, (
+            f"Unexpected dict {request_dict}, should be length 2"
+        )
         it = iter(request_dict)
         next(it, None)
         return next(it)

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -223,9 +223,9 @@ async def test_update_module_update_delays(
                     now if mod_delay == 0 else now - (seconds % mod_delay)
                 )
 
-                assert (
-                    module._last_update_time == expected_update_time
-                ), f"Expected update time {expected_update_time} after {seconds} seconds for {module.name} with delay {mod_delay} got {module._last_update_time}"
+                assert module._last_update_time == expected_update_time, (
+                    f"Expected update time {expected_update_time} after {seconds} seconds for {module.name} with delay {mod_delay} got {module._last_update_time}"
+                )
 
 
 async def _get_child_responses(child_requests: list[dict[str, Any]], child_protocol):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -653,8 +653,7 @@ async def test_light_preset(dev: Device, runner: CliRunner):
 
     if len(light_preset.preset_states_list) == 0:
         pytest.skip(
-            "Some fixtures do not have presets and"
-            " the api doesn'tsupport creating them"
+            "Some fixtures do not have presets and the api doesn'tsupport creating them"
         )
     # Start off with a known state
     first_name = light_preset.preset_list[1]

--- a/tests/transports/test_aestransport.py
+++ b/tests/transports/test_aestransport.py
@@ -56,7 +56,7 @@ def test_encrypt():
 
 
 status_parameters = pytest.mark.parametrize(
-    "status_code, error_code, inner_error_code, expectation",
+    ("status_code", "error_code", "inner_error_code", "expectation"),
     [
         (200, 0, 0, does_not_raise()),
         (400, 0, 0, pytest.raises(KasaException)),

--- a/tests/transports/test_sslaestransport.py
+++ b/tests/transports/test_sslaestransport.py
@@ -273,7 +273,7 @@ async def test_unencrypted_passthrough_errors(mocker, caplog, want_default):
         aiohttp.ClientSession, "post", side_effect=mock_ssl_aes_device.post
     )
 
-    msg = f"{host} responded with an unexpected " f"status code 401 to handshake1"
+    msg = f"{host} responded with an unexpected status code 401 to handshake1"
     with pytest.raises(KasaException, match=msg):
         await transport.send(json_dumps(request))
 
@@ -288,7 +288,7 @@ async def test_unencrypted_passthrough_errors(mocker, caplog, want_default):
         aiohttp.ClientSession, "post", side_effect=mock_ssl_aes_device.post
     )
 
-    msg = f"{host} responded with an unexpected " f"status code 401 to login"
+    msg = f"{host} responded with an unexpected status code 401 to login"
     with pytest.raises(KasaException, match=msg):
         await transport.send(json_dumps(request))
 
@@ -303,7 +303,7 @@ async def test_unencrypted_passthrough_errors(mocker, caplog, want_default):
         aiohttp.ClientSession, "post", side_effect=mock_ssl_aes_device.post
     )
 
-    msg = f"{host} responded with an unexpected " f"status code 401 to unencrypted send"
+    msg = f"{host} responded with an unexpected status code 401 to unencrypted send"
     with pytest.raises(KasaException, match=msg):
         await transport.send(json_dumps(request))
 

--- a/uv.lock
+++ b/uv.lock
@@ -1170,7 +1170,7 @@ dev = [
     { name = "pytest-sugar" },
     { name = "pytest-timeout", specifier = "~=2.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
-    { name = "ruff", specifier = "==0.7.4" },
+    { name = "ruff", specifier = ">=0.9.0" },
     { name = "toml" },
     { name = "voluptuous" },
     { name = "xdoctest", specifier = ">=1.2.0" },
@@ -1241,27 +1241,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.7.4"
+version = "0.9.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/8b/bc4e0dfa1245b07cf14300e10319b98e958a53ff074c1dd86b35253a8c2a/ruff-0.7.4.tar.gz", hash = "sha256:cd12e35031f5af6b9b93715d8c4f40360070b2041f81273d0527683d5708fce2", size = 3275547 }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7f/60fda2eec81f23f8aa7cbbfdf6ec2ca11eb11c273827933fb2541c2ce9d8/ruff-0.9.3.tar.gz", hash = "sha256:8293f89985a090ebc3ed1064df31f3b4b56320cdfcec8b60d3295bddb955c22a", size = 3586740 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/4b/f5094719e254829766b807dadb766841124daba75a37da83e292ae5ad12f/ruff-0.7.4-py3-none-linux_armv6l.whl", hash = "sha256:a4919925e7684a3f18e18243cd6bea7cfb8e968a6eaa8437971f681b7ec51478", size = 10447512 },
-    { url = "https://files.pythonhosted.org/packages/9e/1d/3d2d2c9f601cf6044799c5349ff5267467224cefed9b35edf5f1f36486e9/ruff-0.7.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:cfb365c135b830778dda8c04fb7d4280ed0b984e1aec27f574445231e20d6c63", size = 10235436 },
-    { url = "https://files.pythonhosted.org/packages/62/83/42a6ec6216ded30b354b13e0e9327ef75a3c147751aaf10443756cb690e9/ruff-0.7.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:63a569b36bc66fbadec5beaa539dd81e0527cb258b94e29e0531ce41bacc1f20", size = 9888936 },
-    { url = "https://files.pythonhosted.org/packages/4d/26/e1e54893b13046a6ad05ee9b89ee6f71542ba250f72b4c7a7d17c3dbf73d/ruff-0.7.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d06218747d361d06fd2fdac734e7fa92df36df93035db3dc2ad7aa9852cb109", size = 10697353 },
-    { url = "https://files.pythonhosted.org/packages/21/24/98d2e109c4efc02bfef144ec6ea2c3e1217e7ce0cfddda8361d268dfd499/ruff-0.7.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e0cea28d0944f74ebc33e9f934238f15c758841f9f5edd180b5315c203293452", size = 10228078 },
-    { url = "https://files.pythonhosted.org/packages/ad/b7/964c75be9bc2945fc3172241b371197bb6d948cc69e28bc4518448c368f3/ruff-0.7.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80094ecd4793c68b2571b128f91754d60f692d64bc0d7272ec9197fdd09bf9ea", size = 11264823 },
-    { url = "https://files.pythonhosted.org/packages/12/8d/20abdbf705969914ce40988fe71a554a918deaab62c38ec07483e77866f6/ruff-0.7.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:997512325c6620d1c4c2b15db49ef59543ef9cd0f4aa8065ec2ae5103cedc7e7", size = 11951855 },
-    { url = "https://files.pythonhosted.org/packages/b8/fc/6519ce58c57b4edafcdf40920b7273dfbba64fc6ebcaae7b88e4dc1bf0a8/ruff-0.7.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00b4cf3a6b5fad6d1a66e7574d78956bbd09abfd6c8a997798f01f5da3d46a05", size = 11516580 },
-    { url = "https://files.pythonhosted.org/packages/37/1a/5ec1844e993e376a86eb2456496831ed91b4398c434d8244f89094758940/ruff-0.7.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7dbdc7d8274e1422722933d1edddfdc65b4336abf0b16dfcb9dedd6e6a517d06", size = 12692057 },
-    { url = "https://files.pythonhosted.org/packages/50/90/76867152b0d3c05df29a74bb028413e90f704f0f6701c4801174ba47f959/ruff-0.7.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e92dfb5f00eaedb1501b2f906ccabfd67b2355bdf117fea9719fc99ac2145bc", size = 11085137 },
-    { url = "https://files.pythonhosted.org/packages/c8/eb/0a7cb6059ac3555243bd026bb21785bbc812f7bbfa95a36c101bd72b47ae/ruff-0.7.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:3bd726099f277d735dc38900b6a8d6cf070f80828877941983a57bca1cd92172", size = 10681243 },
-    { url = "https://files.pythonhosted.org/packages/5e/76/2270719dbee0fd35780b05c08a07b7a726c3da9f67d9ae89ef21fc18e2e5/ruff-0.7.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:2e32829c429dd081ee5ba39aef436603e5b22335c3d3fff013cd585806a6486a", size = 10319187 },
-    { url = "https://files.pythonhosted.org/packages/9f/e5/39100f72f8ba70bec1bd329efc880dea8b6c1765ea1cb9d0c1c5f18b8d7f/ruff-0.7.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:662a63b4971807623f6f90c1fb664613f67cc182dc4d991471c23c541fee62dd", size = 10803715 },
-    { url = "https://files.pythonhosted.org/packages/a5/89/40e904784f305fb56850063f70a998a64ebba68796d823dde67e89a24691/ruff-0.7.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:876f5e09eaae3eb76814c1d3b68879891d6fde4824c015d48e7a7da4cf066a3a", size = 11162912 },
-    { url = "https://files.pythonhosted.org/packages/8d/1b/dd77503b3875c51e3dbc053fd8367b845ab8b01c9ca6d0c237082732856c/ruff-0.7.4-py3-none-win32.whl", hash = "sha256:75c53f54904be42dd52a548728a5b572344b50d9b2873d13a3f8c5e3b91f5cac", size = 8702767 },
-    { url = "https://files.pythonhosted.org/packages/63/76/253ddc3e89e70165bba952ecca424b980b8d3c2598ceb4fc47904f424953/ruff-0.7.4-py3-none-win_amd64.whl", hash = "sha256:745775c7b39f914238ed1f1b0bebed0b9155a17cd8bc0b08d3c87e4703b990d6", size = 9497534 },
-    { url = "https://files.pythonhosted.org/packages/aa/70/f8724f31abc0b329ca98b33d73c14020168babcf71b0cba3cded5d9d0e66/ruff-0.7.4-py3-none-win_arm64.whl", hash = "sha256:11bff065102c3ae9d3ea4dc9ecdfe5a5171349cdd0787c1fc64761212fc9cf1f", size = 8851590 },
+    { url = "https://files.pythonhosted.org/packages/f9/77/4fb790596d5d52c87fd55b7160c557c400e90f6116a56d82d76e95d9374a/ruff-0.9.3-py3-none-linux_armv6l.whl", hash = "sha256:7f39b879064c7d9670197d91124a75d118d00b0990586549949aae80cdc16624", size = 11656815 },
+    { url = "https://files.pythonhosted.org/packages/a2/a8/3338ecb97573eafe74505f28431df3842c1933c5f8eae615427c1de32858/ruff-0.9.3-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a187171e7c09efa4b4cc30ee5d0d55a8d6c5311b3e1b74ac5cb96cc89bafc43c", size = 11594821 },
+    { url = "https://files.pythonhosted.org/packages/8e/89/320223c3421962762531a6b2dd58579b858ca9916fb2674874df5e97d628/ruff-0.9.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c59ab92f8e92d6725b7ded9d4a31be3ef42688a115c6d3da9457a5bda140e2b4", size = 11040475 },
+    { url = "https://files.pythonhosted.org/packages/b2/bd/1d775eac5e51409535804a3a888a9623e87a8f4b53e2491580858a083692/ruff-0.9.3-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2dc153c25e715be41bb228bc651c1e9b1a88d5c6e5ed0194fa0dfea02b026439", size = 11856207 },
+    { url = "https://files.pythonhosted.org/packages/7f/c6/3e14e09be29587393d188454064a4aa85174910d16644051a80444e4fd88/ruff-0.9.3-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:646909a1e25e0dc28fbc529eab8eb7bb583079628e8cbe738192853dbbe43af5", size = 11420460 },
+    { url = "https://files.pythonhosted.org/packages/ef/42/b7ca38ffd568ae9b128a2fa76353e9a9a3c80ef19746408d4ce99217ecc1/ruff-0.9.3-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5a5a46e09355695fbdbb30ed9889d6cf1c61b77b700a9fafc21b41f097bfbba4", size = 12605472 },
+    { url = "https://files.pythonhosted.org/packages/a6/a1/3167023f23e3530fde899497ccfe239e4523854cb874458ac082992d206c/ruff-0.9.3-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c4bb09d2bbb394e3730d0918c00276e79b2de70ec2a5231cd4ebb51a57df9ba1", size = 13243123 },
+    { url = "https://files.pythonhosted.org/packages/d0/b4/3c600758e320f5bf7de16858502e849f4216cb0151f819fa0d1154874802/ruff-0.9.3-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:96a87ec31dc1044d8c2da2ebbed1c456d9b561e7d087734336518181b26b3aa5", size = 12744650 },
+    { url = "https://files.pythonhosted.org/packages/be/38/266fbcbb3d0088862c9bafa8b1b99486691d2945a90b9a7316336a0d9a1b/ruff-0.9.3-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb7554aca6f842645022fe2d301c264e6925baa708b392867b7a62645304df4", size = 14458585 },
+    { url = "https://files.pythonhosted.org/packages/63/a6/47fd0e96990ee9b7a4abda62de26d291bd3f7647218d05b7d6d38af47c30/ruff-0.9.3-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cabc332b7075a914ecea912cd1f3d4370489c8018f2c945a30bcc934e3bc06a6", size = 12419624 },
+    { url = "https://files.pythonhosted.org/packages/84/5d/de0b7652e09f7dda49e1a3825a164a65f4998175b6486603c7601279baad/ruff-0.9.3-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:33866c3cc2a575cbd546f2cd02bdd466fed65118e4365ee538a3deffd6fcb730", size = 11843238 },
+    { url = "https://files.pythonhosted.org/packages/9e/be/3f341ceb1c62b565ec1fb6fd2139cc40b60ae6eff4b6fb8f94b1bb37c7a9/ruff-0.9.3-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:006e5de2621304c8810bcd2ee101587712fa93b4f955ed0985907a36c427e0c2", size = 11484012 },
+    { url = "https://files.pythonhosted.org/packages/a3/c8/ff8acbd33addc7e797e702cf00bfde352ab469723720c5607b964491d5cf/ruff-0.9.3-py3-none-musllinux_1_2_i686.whl", hash = "sha256:ba6eea4459dbd6b1be4e6bfc766079fb9b8dd2e5a35aff6baee4d9b1514ea519", size = 12038494 },
+    { url = "https://files.pythonhosted.org/packages/73/b1/8d9a2c0efbbabe848b55f877bc10c5001a37ab10aca13c711431673414e5/ruff-0.9.3-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:90230a6b8055ad47d3325e9ee8f8a9ae7e273078a66401ac66df68943ced029b", size = 12473639 },
+    { url = "https://files.pythonhosted.org/packages/cb/44/a673647105b1ba6da9824a928634fe23186ab19f9d526d7bdf278cd27bc3/ruff-0.9.3-py3-none-win32.whl", hash = "sha256:eabe5eb2c19a42f4808c03b82bd313fc84d4e395133fb3fc1b1516170a31213c", size = 9834353 },
+    { url = "https://files.pythonhosted.org/packages/c3/01/65cadb59bf8d4fbe33d1a750103e6883d9ef302f60c28b73b773092fbde5/ruff-0.9.3-py3-none-win_amd64.whl", hash = "sha256:040ceb7f20791dfa0e78b4230ee9dce23da3b64dd5848e40e3bf3ab76468dcf4", size = 10821444 },
+    { url = "https://files.pythonhosted.org/packages/69/cb/b3fe58a136a27d981911cba2f18e4b29f15010623b79f0f2510fd0d31fd3/ruff-0.9.3-py3-none-win_arm64.whl", hash = "sha256:800d773f6d4d33b0a3c60e2c6ae8f4c202ea2de056365acfa519aa48acf28e0b", size = 10038168 },
 ]
 
 [[package]]


### PR DESCRIPTION
Ruff 0.9 contains a number of formatter changes for the 2025 style guide. This PR updates to ruff>=0.9.0 and applies the formatter fixes.

https://astral.sh/blog/ruff-v0.9.0

This will reduce the diffs in the [0.10.0 release PR](https://github.com/python-kasa/python-kasa/pull/1473) and keep all the resulting code changes linked to this specific change.