### PR TITLE
Convert carpet_clean_mode to carpet_boost switch

### DIFF
--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from enum import IntEnum, StrEnum
+from enum import IntEnum
 from typing import Annotated, Literal
 
 from ...feature import Feature
@@ -56,13 +56,6 @@ class FanSpeed(IntEnum):
     Turbo = 3
     Max = 4
     Ultra = 5
-
-
-class CarpetCleanMode(StrEnum):
-    """Carpet clean mode."""
-
-    Normal = "normal"
-    Boost = "boost"
 
 
 class AreaUnit(IntEnum):
@@ -184,15 +177,14 @@ class Clean(SmartModule):
         self._add_feature(
             Feature(
                 self._device,
-                id="carpet_clean_mode",
-                name="Carpet clean mode",
+                id="carpet_boost",
+                name="Carpet boost",
                 container=self,
-                attribute_getter="carpet_clean_mode",
-                attribute_setter="set_carpet_clean_mode",
+                attribute_getter="carpet_boost",
+                attribute_setter="set_carpet_boost",
                 icon="mdi:rug",
-                choices_getter=lambda: list(CarpetCleanMode.__members__),
                 category=Feature.Category.Config,
-                type=Feature.Type.Choice,
+                type=Feature.Type.Switch,
             )
         )
         self._add_feature(
@@ -380,22 +372,14 @@ class Clean(SmartModule):
             return Status.UnknownInternal
 
     @property
-    def carpet_clean_mode(self) -> Annotated[str, FeatureAttribute()]:
-        """Return carpet clean mode."""
-        return CarpetCleanMode(self.data["getCarpetClean"]["carpet_clean_prefer"]).name
+    def carpet_boost(self) -> bool:
+        """Return carpet boost mode."""
+        return self.data["getCarpetClean"]["carpet_clean_prefer"] == "boost"
 
-    async def set_carpet_clean_mode(
-        self, mode: str
-    ) -> Annotated[dict, FeatureAttribute()]:
+    async def set_carpet_boost(self, on: bool) -> dict:
         """Set carpet clean mode."""
-        name_to_value = {x.name: x.value for x in CarpetCleanMode}
-        if mode not in name_to_value:
-            raise ValueError(
-                "Invalid carpet clean mode %s, available %s", mode, name_to_value
-            )
-        return await self.call(
-            "setCarpetClean", {"carpet_clean_prefer": name_to_value[mode]}
-        )
+        mode = "boost" if on else "normal"
+        return await self.call("setCarpetClean", {"carpet_clean_prefer": mode})
 
     @property
     def area_unit(self) -> AreaUnit:

--- a/tests/smart/modules/test_clean.py
+++ b/tests/smart/modules/test_clean.py
@@ -21,7 +21,7 @@ clean = parametrize("clean module", component_filter="clean", protocol_filter={"
         ("vacuum_status", "status", Status),
         ("vacuum_error", "error", ErrorCode),
         ("vacuum_fan_speed", "fan_speed_preset", str),
-        ("carpet_clean_mode", "carpet_clean_mode", str),
+        ("carpet_boost", "carpet_boost", bool),
         ("battery_level", "battery", int),
     ],
 )
@@ -71,11 +71,11 @@ async def test_features(dev: SmartDevice, feature: str, prop_name: str, type: ty
             id="vacuum_fan_speed",
         ),
         pytest.param(
-            "carpet_clean_mode",
-            "Boost",
+            "carpet_boost",
+            True,
             "setCarpetClean",
             {"carpet_clean_prefer": "boost"},
-            id="carpet_clean_mode",
+            id="carpet_boost",
         ),
         pytest.param(
             "clean_count",
@@ -217,13 +217,6 @@ async def test_unknown_status(
             ValueError,
             "Invalid fan speed",
             id="vacuum_fan_speed",
-        ),
-        pytest.param(
-            "carpet_clean_mode",
-            "invalid mode",
-            ValueError,
-            "Invalid carpet clean mode",
-            id="carpet_clean_mode",
         ),
     ],
 )


### PR DESCRIPTION
Convert `carpet_clean_mode` into a switch called `carpet_boost`, as it makes no sense to have an enum for this.