### PR TITLE
dustbin_mode: add 'off' mode for cleaner downstream impl

### DIFF
--- a/kasa/smart/modules/dustbin.py
+++ b/kasa/smart/modules/dustbin.py
@@ -19,6 +19,8 @@ class Mode(IntEnum):
     Balanced = 2
     Max = 3
 
+    Off = -1_000
+
 
 class Dustbin(SmartModule):
     """Implementation of vacuum dustbin."""
@@ -91,6 +93,8 @@ class Dustbin(SmartModule):
     @property
     def mode(self) -> str:
         """Return auto-emptying mode."""
+        if self.auto_collection is False:
+            return Mode.Off.name
         return Mode(self._settings["dust_collection_mode"]).name
 
     async def set_mode(self, mode: str) -> dict:
@@ -101,8 +105,14 @@ class Dustbin(SmartModule):
                 "Invalid auto/emptying mode speed %s, available %s", mode, name_to_value
             )
 
+        if mode == Mode.Off.name:
+            return await self.set_auto_collection(False)
+
+        # Make a copy just in case, even when we are overriding both settings
         settings = self._settings.copy()
+        settings["auto_dust_collection"] = True
         settings["dust_collection_mode"] = name_to_value[mode]
+
         return await self.call("setDustCollectionInfo", settings)
 
     @property

--- a/tests/smart/modules/test_dustbin.py
+++ b/tests/smart/modules/test_dustbin.py
@@ -76,6 +76,7 @@ async def test_dustbin_mode_off(dev: SmartDevice, mocker: MockerFixture):
 
     await dev.update()
     assert dustbin.auto_collection is False
+    assert dustbin.mode is Mode.Off.name
 
 
 @dustbin

--- a/tests/smart/modules/test_dustbin.py
+++ b/tests/smart/modules/test_dustbin.py
@@ -61,6 +61,24 @@ async def test_dustbin_mode(dev: SmartDevice, mocker: MockerFixture):
 
 
 @dustbin
+async def test_dustbin_mode_off(dev: SmartDevice, mocker: MockerFixture):
+    """Test dustbin_mode == Off."""
+    dustbin = next(get_parent_and_child_modules(dev, Module.Dustbin))
+    call = mocker.spy(dustbin, "call")
+
+    auto_collection = dustbin._device.features["dustbin_mode"]
+    await auto_collection.set_value(Mode.Off.name)
+
+    params = dustbin._settings.copy()
+    params["auto_dust_collection"] = False
+
+    call.assert_called_with("setDustCollectionInfo", params)
+
+    await dev.update()
+    assert dustbin.auto_collection is False
+
+
+@dustbin
 async def test_autocollection(dev: SmartDevice, mocker: MockerFixture):
     """Test autocollection switch."""
     dustbin = next(get_parent_and_child_modules(dev, Module.Dustbin))


### PR DESCRIPTION
This PR adds a new artificial "Off" mode for dustbin_mode,
which will allow avoiding the need to expose both a toggle and a select in homeassistant.

This changes the behavior of the existing mode selection, as it is not anymore possible to change the mode without activating the auto collection.

* Mode is Off, if auto collection has been disabled
* When setting mode to "Off", this will disable the auto collection
* When setting mode to anything else than "Off", the auto collection will be automatically enabled.