### PR TITLE
Add FeatureAttributes to smartcam Alarm

### DIFF
--- a/kasa/interfaces/energy.py
+++ b/kasa/interfaces/energy.py
@@ -28,7 +28,7 @@ class Energy(Module, ABC):
 
     _supported: ModuleFeature = ModuleFeature(0)
 
-    def supports(self, module_feature: ModuleFeature) -> bool:
+    def supports(self, module_feature: Energy.ModuleFeature) -> bool:
         """Return True if module supports the feature."""
         return module_feature in self._supported
 

--- a/kasa/smartcam/modules/alarm.py
+++ b/kasa/smartcam/modules/alarm.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Annotated
+
 from ...feature import Feature
 from ...interfaces import Alarm as AlarmInterface
+from ...module import FeatureAttribute
 from ...smart.smartmodule import allow_update_after
 from ..smartcammodule import SmartCamModule
 
@@ -105,12 +108,12 @@ class Alarm(SmartCamModule, AlarmInterface):
         )
 
     @property
-    def alarm_sound(self) -> str:
+    def alarm_sound(self) -> Annotated[str, FeatureAttribute()]:
         """Return current alarm sound."""
         return self.data["getSirenConfig"]["siren_type"]
 
     @allow_update_after
-    async def set_alarm_sound(self, sound: str) -> dict:
+    async def set_alarm_sound(self, sound: str) -> Annotated[dict, FeatureAttribute()]:
         """Set alarm sound.
 
         See *alarm_sounds* for list of available sounds.
@@ -124,7 +127,7 @@ class Alarm(SmartCamModule, AlarmInterface):
         return self.data["getSirenTypeList"]["siren_type_list"]
 
     @property
-    def alarm_volume(self) -> int:
+    def alarm_volume(self) -> Annotated[int, FeatureAttribute()]:
         """Return alarm volume.
 
         Unlike duration the device expects/returns a string for volume.
@@ -132,18 +135,22 @@ class Alarm(SmartCamModule, AlarmInterface):
         return int(self.data["getSirenConfig"]["volume"])
 
     @allow_update_after
-    async def set_alarm_volume(self, volume: int) -> dict:
+    async def set_alarm_volume(
+        self, volume: int
+    ) -> Annotated[dict, FeatureAttribute()]:
         """Set alarm volume."""
         config = self._validate_and_get_config(volume=volume)
         return await self.call("setSirenConfig", {"siren": config})
 
     @property
-    def alarm_duration(self) -> int:
+    def alarm_duration(self) -> Annotated[int, FeatureAttribute()]:
         """Return alarm duration."""
         return self.data["getSirenConfig"]["duration"]
 
     @allow_update_after
-    async def set_alarm_duration(self, duration: int) -> dict:
+    async def set_alarm_duration(
+        self, duration: int
+    ) -> Annotated[dict, FeatureAttribute()]:
         """Set alarm volume."""
         config = self._validate_and_get_config(duration=duration)
         return await self.call("setSirenConfig", {"siren": config})

--- a/tests/test_common_modules.py
+++ b/tests/test_common_modules.py
@@ -91,6 +91,7 @@ def _get_subclasses(of_class, package):
         if ispkg:
             res = _get_subclasses(of_class, module)
             subclasses.update(res)
+
     return subclasses
 
 

--- a/tests/test_common_modules.py
+++ b/tests/test_common_modules.py
@@ -74,6 +74,7 @@ interfaces = pytest.mark.parametrize("interface", kasa.interfaces.__all__)
 
 
 def _get_subclasses(of_class, package):
+    """Get all the subclasses of a given class."""
     subclasses = set()
     # iter_modules returns ModuleInfo: (module_finder, name, ispkg)
     for _, modname, ispkg in pkgutil.iter_modules(package.__path__):
@@ -86,6 +87,7 @@ def _get_subclasses(of_class, package):
                 and obj is not of_class
             ):
                 subclasses.add(obj)
+
         if ispkg:
             res = _get_subclasses(of_class, module)
             subclasses.update(res)


### PR DESCRIPTION
These were missed off in https://github.com/python-kasa/python-kasa/pull/1479. Testing with [HA PR 136642](https://github.com/home-assistant/core/pull/136642) picked this up.

Adding a test case for this highlighted that the decorators currently lose the `Annotated` annotations which `functools.wraps` fixes.