### PR TITLE
Update PIR triggered from sensor to binary sensor

### DIFF
--- a/kasa/iot/modules/motion.py
+++ b/kasa/iot/modules/motion.py
@@ -159,7 +159,7 @@ class Motion(IotModule):
                 icon="mdi:motion-sensor",
                 attribute_getter="pir_triggered",
                 attribute_setter=None,
-                type=Feature.Type.Sensor,
+                type=Feature.Type.BinarySensor,
                 category=Feature.Category.Primary,
             )
         )


### PR DESCRIPTION
Binary sensor may better fit this entity since Home Assistant classifies motion into the following device class BinarySensorDeviceClass.MOTION