### PR TITLE
Do not return empty string for custom light effect name

### DIFF
--- a/kasa/interfaces/lighteffect.py
+++ b/kasa/interfaces/lighteffect.py
@@ -51,6 +51,7 @@ class LightEffect(Module, ABC):
     """Interface to represent a light effect module."""
 
     LIGHT_EFFECTS_OFF = "Off"
+    LIGHT_EFFECTS_UNNAMED_CUSTOM = "Custom"
 
     def _initialize_features(self) -> None:
         """Initialize features."""
@@ -77,7 +78,7 @@ class LightEffect(Module, ABC):
     @property
     @abstractmethod
     def effect(self) -> str:
-        """Return effect state or name."""
+        """Return effect name."""
 
     @property
     @abstractmethod

--- a/kasa/iot/modules/lighteffect.py
+++ b/kasa/iot/modules/lighteffect.py
@@ -12,20 +12,11 @@ class LightEffect(IotModule, LightEffectInterface):
 
     @property
     def effect(self) -> str:
-        """Return effect state.
-
-        Example:
-            {'brightness': 50,
-             'custom': 0,
-             'enable': 0,
-             'id': '',
-             'name': ''}
-        """
+        """Return effect name."""
         eff = self.data["lighting_effect_state"]
         name = eff["name"]
         if eff["enable"]:
-            return name
-
+            return name or self.LIGHT_EFFECTS_UNNAMED_CUSTOM
         return self.LIGHT_EFFECTS_OFF
 
     @property

--- a/kasa/smart/modules/lightstripeffect.py
+++ b/kasa/smart/modules/lightstripeffect.py
@@ -37,20 +37,14 @@ class LightStripEffect(SmartModule, SmartLightEffect):
 
     @property
     def effect(self) -> str:
-        """Return effect state.
-
-        Example:
-            {'brightness': 50,
-             'custom': 0,
-             'enable': 0,
-             'id': '',
-             'name': ''}
-        """
+        """Return effect name."""
         eff = self.data["lighting_effect"]
         name = eff["name"]
         # When devices are unpaired effect name is softAP which is not in our list
         if eff["enable"] and name in self._effect_list:
             return name
+        if eff["enable"] and eff["custom"]:
+            return name or self.LIGHT_EFFECTS_UNNAMED_CUSTOM
         return self.LIGHT_EFFECTS_OFF
 
     @property


### PR DESCRIPTION
Fixes [HA Issue 134568](https://github.com/home-assistant/core/issues/134568)

Issue caused when a custom effect has an empty string for a name. Causes the HA `__validate_color_mode` to treat as no effect active:

```py
if not effect or effect == EFFECT_OFF:
    # No effect is active, the light must set color mode to one of the supported
    # color modes
    if color_mode in supported_color_modes:
        return
```

but the integration tests for `!= LightEffect.LIGHT_EFFECTS_OFF` when deciding on the color mode:

```
if effect_module.effect != LightEffect.LIGHT_EFFECTS_OFF:
    self._attr_effect = effect_module.effect
    self._attr_color_mode = ColorMode.BRIGHTNESS
else:
```

As the effect is in fact on, we should not return empty string for effect name.
