### PR TITLE
Add KS225(US)_1.0_1.1.1 and L930-5(EU)_1.0_1.2.5

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -118,6 +118,7 @@ Some newer Kasa devices require authentication. These are marked with [^1] in th
 - **KS225**
   - Hardware: 1.0 (US) / Firmware: 1.0.2[^1]
   - Hardware: 1.0 (US) / Firmware: 1.1.0[^1]
+  - Hardware: 1.0 (US) / Firmware: 1.1.1[^1]
 - **KS230**
   - Hardware: 1.0 (US) / Firmware: 1.0.14
   - Hardware: 2.0 (US) / Firmware: 1.0.11
@@ -269,6 +270,7 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
   - Hardware: 1.0 (US) / Firmware: 1.1.0
   - Hardware: 1.0 (US) / Firmware: 1.1.3
 - **L930-5**
+  - Hardware: 1.0 (EU) / Firmware: 1.2.5
   - Hardware: 1.0 (US) / Firmware: 1.1.2
 
 ### Cameras

--- a/tests/fixtures/smart/KS225(US)_1.0_1.1.1.json
+++ b/tests/fixtures/smart/KS225(US)_1.0_1.1.1.json
@@ -259,7 +259,6 @@
                 "signal_level": 3,
                 "ssid": "xxx"
             }
-
         ],
         "start_index": 0,
         "sum": 19,

--- a/tests/fixtures/smart/KS225(US)_1.0_1.1.1.json
+++ b/tests/fixtures/smart/KS225(US)_1.0_1.1.1.json
@@ -104,7 +104,7 @@
             "factory_default": false,
             "ip": "127.0.0.123",
             "is_support_iot_cloud": true,
-            "mac": "xxx",
+            "mac": "3C-52-A1-00-00-00",
             "mgt_encrypt_schm": {
                 "encrypt_type": "KLAP",
                 "http_port": 80,
@@ -153,13 +153,13 @@
         "has_set_location_info": true,
         "hw_id": "00000000000000000000000000000000",
         "hw_ver": "1.0",
-        "ip": "127.0.0.xxx",
+        "ip": "127.0.0.123",
         "lang": "en_US",
         "latitude": 0,
         "longitude": 0,
-        "mac": "xxx",
+        "mac": "3C-52-A1-00-00-00",
         "model": "KS225",
-        "nickname": "xxx",
+        "nickname": "I01BU0tFRF9OQU1FIw==",
         "oem_id": "00000000000000000000000000000000",
         "on_time": 0,
         "overheat_status": "normal",
@@ -167,7 +167,7 @@
         "rssi": -38,
         "signal_level": 3,
         "specs": "",
-        "ssid": "xxx",
+        "ssid": "I01BU0tFRF9TU0lEIw==",
         "time_diff": -300,
         "type": "SMART.KASASWITCH"
     },
@@ -257,7 +257,7 @@
                 "cipher_type": 2,
                 "key_type": "wpa2_psk",
                 "signal_level": 3,
-                "ssid": "xxx"
+                "ssid": "I01BU0tFRF9TU0lEIw=="
             }
         ],
         "start_index": 0,

--- a/tests/fixtures/smart/KS225(US)_1.0_1.1.1.json
+++ b/tests/fixtures/smart/KS225(US)_1.0_1.1.1.json
@@ -1,0 +1,305 @@
+{
+    "component_nego": {
+        "component_list": [
+            {
+                "id": "device",
+                "ver_code": 2
+            },
+            {
+                "id": "firmware",
+                "ver_code": 2
+            },
+            {
+                "id": "quick_setup",
+                "ver_code": 3
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "time",
+                "ver_code": 1
+            },
+            {
+                "id": "wireless",
+                "ver_code": 1
+            },
+            {
+                "id": "schedule",
+                "ver_code": 2
+            },
+            {
+                "id": "countdown",
+                "ver_code": 2
+            },
+            {
+                "id": "antitheft",
+                "ver_code": 1
+            },
+            {
+                "id": "account",
+                "ver_code": 1
+            },
+            {
+                "id": "synchronize",
+                "ver_code": 1
+            },
+            {
+                "id": "sunrise_sunset",
+                "ver_code": 1
+            },
+            {
+                "id": "led",
+                "ver_code": 1
+            },
+            {
+                "id": "cloud_connect",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "device_local_time",
+                "ver_code": 1
+            },
+            {
+                "id": "default_states",
+                "ver_code": 1
+            },
+            {
+                "id": "brightness",
+                "ver_code": 1
+            },
+            {
+                "id": "preset",
+                "ver_code": 1
+            },
+            {
+                "id": "on_off_gradually",
+                "ver_code": 2
+            },
+            {
+                "id": "dimmer_calibration",
+                "ver_code": 1
+            },
+            {
+                "id": "overheat_protection",
+                "ver_code": 1
+            },
+            {
+                "id": "matter",
+                "ver_code": 2
+            }
+        ]
+    },
+    "discovery_result": {
+        "error_code": 0,
+        "result": {
+            "device_id": "00000000000000000000000000000000",
+            "device_model": "KS225(US)",
+            "device_type": "SMART.KASASWITCH",
+            "factory_default": false,
+            "ip": "127.0.0.123",
+            "is_support_iot_cloud": true,
+            "mac": "xxx",
+            "mgt_encrypt_schm": {
+                "encrypt_type": "KLAP",
+                "http_port": 80,
+                "is_support_https": false,
+                "lv": 2
+            },
+            "obd_src": "matter",
+            "owner": "00000000000000000000000000000000",
+            "protocol_version": 1
+        }
+    },
+    "get_antitheft_rules": {
+        "antitheft_rule_max_count": 1,
+        "enable": false,
+        "rule_list": []
+    },
+    "get_auto_update_info": {
+        "enable": true,
+        "random_range": 120,
+        "time": 180
+    },
+    "get_connect_cloud_state": {
+        "status": 0
+    },
+    "get_countdown_rules": {
+        "countdown_rule_max_count": 1,
+        "enable": false,
+        "rule_list": []
+    },
+    "get_device_info": {
+        "avatar": "switch_s500d",
+        "brightness": 25,
+        "default_states": {
+            "re_power_type": "always_off",
+            "re_power_type_capability": [
+                "last_states",
+                "always_on",
+                "always_off"
+            ],
+            "type": "last_states"
+        },
+        "device_id": "0000000000000000000000000000000000000000",
+        "device_on": false,
+        "fw_id": "00000000000000000000000000000000",
+        "fw_ver": "1.1.1 Build 240626 Rel.175125",
+        "has_set_location_info": true,
+        "hw_id": "00000000000000000000000000000000",
+        "hw_ver": "1.0",
+        "ip": "127.0.0.xxx",
+        "lang": "en_US",
+        "latitude": 0,
+        "longitude": 0,
+        "mac": "xxx",
+        "model": "KS225",
+        "nickname": "xxx",
+        "oem_id": "00000000000000000000000000000000",
+        "on_time": 0,
+        "overheat_status": "normal",
+        "region": "America/Toronto",
+        "rssi": -38,
+        "signal_level": 3,
+        "specs": "",
+        "ssid": "xxx",
+        "time_diff": -300,
+        "type": "SMART.KASASWITCH"
+    },
+    "get_device_time": {
+        "region": "America/Toronto",
+        "time_diff": -300,
+        "timestamp": 1739199350
+    },
+    "get_device_usage": {
+        "time_usage": {
+            "past30": 2189,
+            "past7": 705,
+            "today": 0
+        }
+    },
+    "get_fw_download_state": {
+        "auto_upgrade": false,
+        "download_progress": 0,
+        "reboot_time": 5,
+        "status": 0,
+        "upgrade_time": 5
+    },
+    "get_inherit_info": null,
+    "get_latest_fw": {
+        "fw_size": 0,
+        "fw_ver": "1.1.1 Build 240626 Rel.175125",
+        "hw_id": "",
+        "need_to_upgrade": false,
+        "oem_id": "",
+        "release_date": "",
+        "release_note": "",
+        "type": 0
+    },
+    "get_led_info": {
+        "bri_config": {
+            "bri_type": "overall",
+            "overall_bri": 50
+        },
+        "led_rule": "always",
+        "led_status": true,
+        "night_mode": {
+            "end_time": 423,
+            "night_mode_type": "sunrise_sunset",
+            "start_time": 1036,
+            "sunrise_offset": 0,
+            "sunset_offset": 0
+        }
+    },
+    "get_matter_setup_info": {
+        "setup_code": "00000000000",
+        "setup_payload": "00:000000-000000000000"
+    },
+    "get_next_event": {},
+    "get_on_off_gradually_info": {
+        "off_state": {
+            "duration": 3,
+            "enable": true,
+            "max_duration": 60
+        },
+        "on_state": {
+            "duration": 3,
+            "enable": true,
+            "max_duration": 60
+        }
+    },
+    "get_preset_rules": {
+        "brightness": [
+            100,
+            75,
+            50,
+            25,
+            1
+        ]
+    },
+    "get_schedule_rules": {
+        "enable": false,
+        "rule_list": [],
+        "schedule_rule_max_count": 32,
+        "start_index": 0,
+        "sum": 0
+    },
+    "get_wireless_scan_info": {
+        "ap_list": [
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 3,
+                "ssid": "xxx"
+            }
+
+        ],
+        "start_index": 0,
+        "sum": 19,
+        "wep_supported": false
+    },
+    "qs_component_nego": {
+        "component_list": [
+            {
+                "id": "quick_setup",
+                "ver_code": 3
+            },
+            {
+                "id": "sunrise_sunset",
+                "ver_code": 1
+            },
+            {
+                "id": "ble_whole_setup",
+                "ver_code": 1
+            },
+            {
+                "id": "matter",
+                "ver_code": 2
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "firmware",
+                "ver_code": 2
+            }
+        ],
+        "extra_info": {
+            "device_model": "KS225",
+            "device_type": "SMART.KASASWITCH",
+            "is_klap": true
+        }
+    }
+}

--- a/tests/fixtures/smart/L930-5(EU)_1.0_1.2.5.json
+++ b/tests/fixtures/smart/L930-5(EU)_1.0_1.2.5.json
@@ -1,0 +1,528 @@
+{
+    "component_nego": {
+        "component_list": [
+            {
+                "id": "device",
+                "ver_code": 2
+            },
+            {
+                "id": "light_strip",
+                "ver_code": 1
+            },
+            {
+                "id": "light_strip_lighting_effect",
+                "ver_code": 2
+            },
+            {
+                "id": "firmware",
+                "ver_code": 2
+            },
+            {
+                "id": "quick_setup",
+                "ver_code": 3
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "time",
+                "ver_code": 1
+            },
+            {
+                "id": "wireless",
+                "ver_code": 1
+            },
+            {
+                "id": "schedule",
+                "ver_code": 2
+            },
+            {
+                "id": "countdown",
+                "ver_code": 2
+            },
+            {
+                "id": "antitheft",
+                "ver_code": 1
+            },
+            {
+                "id": "account",
+                "ver_code": 1
+            },
+            {
+                "id": "synchronize",
+                "ver_code": 1
+            },
+            {
+                "id": "sunrise_sunset",
+                "ver_code": 1
+            },
+            {
+                "id": "brightness",
+                "ver_code": 1
+            },
+            {
+                "id": "cloud_connect",
+                "ver_code": 1
+            },
+            {
+                "id": "color_temperature",
+                "ver_code": 1
+            },
+            {
+                "id": "default_states",
+                "ver_code": 1
+            },
+            {
+                "id": "preset",
+                "ver_code": 3
+            },
+            {
+                "id": "color",
+                "ver_code": 1
+            },
+            {
+                "id": "on_off_gradually",
+                "ver_code": 1
+            },
+            {
+                "id": "device_local_time",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "music_rhythm",
+                "ver_code": 3
+            },
+            {
+                "id": "music_rhythm_v2",
+                "ver_code": 4
+            },
+            {
+                "id": "bulb_quick_control",
+                "ver_code": 1
+            },
+            {
+                "id": "localSmart",
+                "ver_code": 1
+            },
+            {
+                "id": "homekit",
+                "ver_code": 2
+            },
+            {
+                "id": "segment",
+                "ver_code": 1
+            },
+            {
+                "id": "segment_effect",
+                "ver_code": 1
+            },
+            {
+                "id": "auto_light",
+                "ver_code": 1
+            }
+        ]
+    },
+    "discovery_result": {
+        "error_code": 0,
+        "result": {
+            "device_id": "00000000000000000000000000000000",
+            "device_model": "L930-5(EU)",
+            "device_type": "SMART.TAPOBULB",
+            "factory_default": false,
+            "ip": "127.0.0.123",
+            "is_support_iot_cloud": true,
+            "mac": "78-8C-B5-00-00-00",
+            "mgt_encrypt_schm": {
+                "encrypt_type": "KLAP",
+                "http_port": 80,
+                "is_support_https": false,
+                "lv": 2
+            },
+            "obd_src": "apple",
+            "owner": "00000000000000000000000000000000",
+            "protocol_version": 1
+        }
+    },
+    "get_antitheft_rules": {
+        "antitheft_rule_max_count": 1,
+        "enable": false,
+        "rule_list": []
+    },
+    "get_auto_light_info": {
+        "enable": false,
+        "mode": "light_track"
+    },
+    "get_auto_update_info": {
+        "enable": true,
+        "random_range": 120,
+        "time": 180
+    },
+    "get_connect_cloud_state": {
+        "status": 0
+    },
+    "get_countdown_rules": {
+        "countdown_rule_max_count": 1,
+        "enable": false,
+        "rule_list": []
+    },
+    "get_device_info": {
+        "avatar": "light_strip",
+        "brightness": 100,
+        "color_temp": 0,
+        "color_temp_range": [
+            2500,
+            6500
+        ],
+        "default_states": {
+            "state": {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 255,
+                "saturation": 68
+            },
+            "type": "last_states"
+        },
+        "device_id": "0000000000000000000000000000000000000000",
+        "device_on": true,
+        "fw_id": "00000000000000000000000000000000",
+        "fw_ver": "1.2.5 Build 240727 Rel.102843",
+        "has_set_location_info": false,
+        "hue": 255,
+        "hw_id": "00000000000000000000000000000000",
+        "hw_ver": "1.0",
+        "ip": "127.0.0.123",
+        "lang": "en_US",
+        "latitude": 0,
+        "lighting_effect": {
+            "brightness": 50,
+            "custom": 0,
+            "display_colors": [],
+            "enable": 0,
+            "id": "",
+            "name": "station"
+        },
+        "longitude": 0,
+        "mac": "78-8C-B5-00-00-00",
+        "model": "L930",
+        "music_rhythm_enable": false,
+        "music_rhythm_mode": "single_lamp",
+        "nickname": "I01BU0tFRF9OQU1FIw==",
+        "oem_id": "00000000000000000000000000000000",
+        "overheated": false,
+        "region": "Europe/London",
+        "rssi": -73,
+        "saturation": 68,
+        "segment_effect": {
+            "brightness": 0,
+            "custom": 0,
+            "display_colors": [],
+            "enable": 0,
+            "id": "",
+            "name": "station"
+        },
+        "signal_level": 1,
+        "specs": "",
+        "ssid": "I01BU0tFRF9TU0lEIw==",
+        "time_diff": 0,
+        "type": "SMART.TAPOBULB"
+    },
+    "get_device_segment": {
+        "segment": 50
+    },
+    "get_device_time": {
+        "region": "Europe/London",
+        "time_diff": 0,
+        "timestamp": 1739740342
+    },
+    "get_device_usage": {
+        "power_usage": {
+            "past30": 3515,
+            "past7": 314,
+            "today": 229
+        },
+        "saved_power": {
+            "past30": 31361,
+            "past7": 1442,
+            "today": 1043
+        },
+        "time_usage": {
+            "past30": 34876,
+            "past7": 1756,
+            "today": 1272
+        }
+    },
+    "get_fw_download_state": {
+        "auto_upgrade": false,
+        "download_progress": 0,
+        "reboot_time": 5,
+        "status": 0,
+        "upgrade_time": 5
+    },
+    "get_homekit_info": {
+        "mfi_setup_code": "000-00-000",
+        "mfi_setup_id": "0000",
+        "mfi_token_token": "000000000000000000000000000/000000000000000000/000000+00000000/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000+000000000000000000000000000000000000000000000000/0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000+00000000000000000000=",
+        "mfi_token_uuid": "00000000-0000-0000-0000-000000000000"
+    },
+    "get_inherit_info": null,
+    "get_latest_fw": {
+        "fw_size": 0,
+        "fw_ver": "1.2.5 Build 240727 Rel.102843",
+        "hw_id": "",
+        "need_to_upgrade": false,
+        "oem_id": "",
+        "release_date": "",
+        "release_note": "",
+        "type": 0
+    },
+    "get_lighting_effect": {
+        "brightness": 50,
+        "custom": 0,
+        "direction": 1,
+        "display_colors": [],
+        "duration": 0,
+        "enable": 0,
+        "expansion_strategy": 2,
+        "id": "",
+        "name": "station",
+        "repeat_times": 1,
+        "segment_length": 1,
+        "sequence": [
+            [
+                300,
+                100,
+                50
+            ],
+            [
+                240,
+                100,
+                50
+            ],
+            [
+                180,
+                100,
+                50
+            ],
+            [
+                120,
+                100,
+                50
+            ],
+            [
+                60,
+                100,
+                50
+            ],
+            [
+                0,
+                100,
+                50
+            ],
+            [
+                0,
+                0,
+                50
+            ],
+            [
+                0,
+                0,
+                50
+            ],
+            [
+                0,
+                0,
+                50
+            ],
+            [
+                0,
+                0,
+                50
+            ],
+            [
+                0,
+                0,
+                50
+            ],
+            [
+                0,
+                0,
+                50
+            ]
+        ],
+        "spread": 16,
+        "transition": 400,
+        "type": "sequence"
+    },
+    "get_next_event": {},
+    "get_on_off_gradually_info": {
+        "enable": false
+    },
+    "get_preset_rules": {
+        "start_index": 0,
+        "states": [
+            {
+                "brightness": 50,
+                "color_temp": 4500,
+                "hue": 0,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 240,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 0,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 120,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 277,
+                "saturation": 86
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 60,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 300,
+                "saturation": 100
+            }
+        ],
+        "sum": 7
+    },
+    "get_schedule_rules": {
+        "enable": false,
+        "rule_list": [],
+        "schedule_rule_max_count": 32,
+        "start_index": 0,
+        "sum": 0
+    },
+    "get_segment_effect_rule": {
+        "brightness": 0,
+        "custom": 0,
+        "display_colors": [],
+        "enable": 0,
+        "id": "",
+        "name": "station"
+    },
+    "get_wireless_scan_info": {
+        "ap_list": [
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 0,
+                "key_type": "none",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            }
+        ],
+        "start_index": 0,
+        "sum": 8,
+        "wep_supported": false
+    },
+    "qs_component_nego": {
+        "component_list": [
+            {
+                "id": "quick_setup",
+                "ver_code": 3
+            },
+            {
+                "id": "sunrise_sunset",
+                "ver_code": 1
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "firmware",
+                "ver_code": 2
+            }
+        ],
+        "extra_info": {
+            "device_model": "L930",
+            "device_type": "SMART.TAPOBULB",
+            "is_klap": true
+        }
+    }
+}


### PR DESCRIPTION
Added fixture files, one device was added directly into HomeKit, and one device was added through Matter from the obd_src. I'm not sure if that makes a difference for you, but the devices are working correctly through my plug-in with the latest python-kasa 0.10.2.