### PR TITLE
Add LB100(US)_1.0_1.8.11 fixture file

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Plugs**: EP10, EP25[^1], HS100[^2], HS103, HS105, HS110, KP100, KP105, KP115, KP125, KP125M[^1], KP401
 - **Power Strips**: EP40, EP40M[^1], HS107, HS300, KP200, KP303, KP400
 - **Wall Switches**: ES20M, HS200[^2], HS210, HS220[^2], KP405, KS200, KS200M, KS205[^1], KS220, KS220M, KS225[^1], KS230, KS240[^1]
-- **Bulbs**: KL110, KL120, KL125, KL130, KL135, KL50, KL60, LB110
+- **Bulbs**: KL110, KL120, KL125, KL130, KL135, KL50, KL60, LB100, LB110
 - **Light Strips**: KL400L5, KL420L5, KL430
 - **Hubs**: KH100[^1]
 - **Hub-Connected Devices[^3]**: KE100[^1]

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -149,6 +149,8 @@ Some newer Kasa devices require authentication. These are marked with [^1] in th
 - **KL60**
   - Hardware: 1.0 (UN) / Firmware: 1.1.4
   - Hardware: 1.0 (US) / Firmware: 1.1.13
+- **LB100**
+  - Hardware: 1.0 (US) / Firmware: 1.8.11
 - **LB110**
   - Hardware: 1.0 (US) / Firmware: 1.8.11
 

--- a/tests/fixtures/iot/LB100(US)_1.0_1.8.11.json
+++ b/tests/fixtures/iot/LB100(US)_1.0_1.8.11.json
@@ -1,0 +1,135 @@
+{
+    "smartlife.iot.common.cloud": {
+        "get_info": {
+            "binded": 1,
+            "cld_connection": 1,
+            "err_code": 0,
+            "fwDlPage": "",
+            "fwNotifyType": 0,
+            "illegalType": 0,
+            "server": "n-devs.tplinkcloud.com",
+            "stopConnect": 0,
+            "tcspInfo": "",
+            "tcspStatus": 1,
+            "username": "user@example.com"
+        },
+        "get_intl_fw_list": {
+            "err_code": 0,
+            "fw_list": []
+        }
+    },
+    "smartlife.iot.common.emeter": {
+        "get_realtime": {
+            "err_code": 0,
+            "power_mw": 4400
+        }
+    },
+    "smartlife.iot.common.schedule": {
+        "get_next_action": {
+            "err_code": 0,
+            "type": -1
+        },
+        "get_rules": {
+            "enable": 1,
+            "err_code": 0,
+            "rule_list": [],
+            "version": 2
+        }
+    },
+    "smartlife.iot.smartbulb.lightingservice": {
+        "get_default_behavior": {
+            "err_code": 0,
+            "hard_on": {
+                "mode": "last_status"
+            },
+            "soft_on": {
+                "mode": "last_status"
+            }
+        },
+        "get_light_details": {
+            "color_rendering_index": 80,
+            "err_code": 0,
+            "incandescent_equivalent": 50,
+            "lamp_beam_angle": 270,
+            "max_lumens": 600,
+            "max_voltage": 120,
+            "min_voltage": 110,
+            "wattage": 7
+        },
+        "get_light_state": {
+            "brightness": 50,
+            "color_temp": 2700,
+            "err_code": 0,
+            "hue": 0,
+            "mode": "normal",
+            "on_off": 1,
+            "saturation": 0
+        }
+    },
+    "system": {
+        "get_sysinfo": {
+            "active_mode": "none",
+            "alias": "#MASKED_NAME#",
+            "ctrl_protocols": {
+                "name": "Linkie",
+                "version": "1.0"
+            },
+            "description": "Smart Wi-Fi LED Bulb with Dimmable Light",
+            "dev_state": "normal",
+            "deviceId": "0000000000000000000000000000000000000000",
+            "disco_ver": "1.0",
+            "err_code": 0,
+            "heapsize": 291960,
+            "hwId": "00000000000000000000000000000000",
+            "hw_ver": "1.0",
+            "is_color": 0,
+            "is_dimmable": 1,
+            "is_factory": false,
+            "is_variable_color_temp": 0,
+            "light_state": {
+                "brightness": 50,
+                "color_temp": 2700,
+                "hue": 0,
+                "mode": "normal",
+                "on_off": 1,
+                "saturation": 0
+            },
+            "mic_mac": "50C7BF000000",
+            "mic_type": "IOT.SMARTBULB",
+            "model": "LB100(US)",
+            "oemId": "00000000000000000000000000000000",
+            "preferred_state": [
+                {
+                    "brightness": 100,
+                    "color_temp": 2700,
+                    "hue": 0,
+                    "index": 0,
+                    "saturation": 0
+                },
+                {
+                    "brightness": 75,
+                    "color_temp": 2700,
+                    "hue": 0,
+                    "index": 1,
+                    "saturation": 0
+                },
+                {
+                    "brightness": 25,
+                    "color_temp": 2700,
+                    "hue": 0,
+                    "index": 2,
+                    "saturation": 0
+                },
+                {
+                    "brightness": 1,
+                    "color_temp": 2700,
+                    "hue": 0,
+                    "index": 3,
+                    "saturation": 0
+                }
+            ],
+            "rssi": -46,
+            "sw_ver": "1.8.11 Build 191113 Rel.105336"
+        }
+    }
+}


### PR DESCRIPTION
The LB100 was already in the device_fixtures.py for tests, but was not listed in the supported devices nor did it have a fixture file.