### PR TITLE
Fallback smart device alias to model when nickname is empty

### DIFF
--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -49,7 +49,7 @@ DEVICE_TYPE_TO_LABEL = {
     DeviceType.StripSocket: "Power Strip",
     DeviceType.Dimmer: "Wall Switch",
     DeviceType.WallSwitch: "Wall Switch",
-    DeviceType.Fan: "Wall Switch",
+    DeviceType.Fan: "Fan",
     DeviceType.Bulb: "Bulb",
     DeviceType.LightStrip: "Light Strip",
     DeviceType.Camera: "Camera",
@@ -57,7 +57,7 @@ DEVICE_TYPE_TO_LABEL = {
     DeviceType.Chime: "Chime",
     DeviceType.Vacuum: "Vacuum",
     DeviceType.Hub: "Hub",
-    DeviceType.Sensor: "Hub-Connected Device",
+    DeviceType.Sensor: "Sensor",
     DeviceType.Thermostat: "Hub-Connected Thermostat",
 }
 
@@ -617,7 +617,7 @@ class SmartDevice(Device):
         if self._info and (nickname := self._info.get("nickname")):
             return base64.b64decode(nickname).decode()
         elif label := DEVICE_TYPE_TO_LABEL.get(self._device_type):
-            return label
+            return f"Unnamed {label} ({self.model} {self.device_id})"
         else:
             return None
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -617,7 +617,7 @@ class SmartDevice(Device):
         if self._info and (nickname := self._info.get("nickname")):
             return base64.b64decode(nickname).decode()
         elif label := DEVICE_TYPE_TO_LABEL.get(self._device_type):
-            return f"Unnamed {label} ({self.model} {self.device_id})"
+            return f"{label} ({self.model} {self.device_id})"
         else:
             return None
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -598,6 +598,8 @@ class SmartDevice(Device):
         """Returns the device alias or nickname."""
         if self._info and (nickname := self._info.get("nickname")):
             return base64.b64decode(nickname).decode()
+        elif self._info and (model := self._info.get("model")):
+            return model
         else:
             return None
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -43,6 +43,24 @@ NON_HUB_PARENT_ONLY_MODULES = [DeviceModule, Time, Firmware, Cloud]
 
 ComponentsRaw: TypeAlias = dict[str, list[dict[str, int | str]]]
 
+DEVICE_TYPE_TO_LABEL = {
+    DeviceType.Plug: "Plug",
+    DeviceType.Strip: "Power Strip",
+    DeviceType.StripSocket: "Power Strip",
+    DeviceType.Dimmer: "Wall Switch",
+    DeviceType.WallSwitch: "Wall Switch",
+    DeviceType.Fan: "Wall Switch",
+    DeviceType.Bulb: "Bulb",
+    DeviceType.LightStrip: "Light Strip",
+    DeviceType.Camera: "Camera",
+    DeviceType.Doorbell: "Doorbell",
+    DeviceType.Chime: "Chime",
+    DeviceType.Vacuum: "Vacuum",
+    DeviceType.Hub: "Hub",
+    DeviceType.Sensor: "Hub-Connected Device",
+    DeviceType.Thermostat: "Hub-Connected Thermostat",
+}
+
 
 # Device must go last as the other interfaces also inherit Device
 # and python needs a consistent method resolution order.
@@ -598,8 +616,8 @@ class SmartDevice(Device):
         """Returns the device alias or nickname."""
         if self._info and (nickname := self._info.get("nickname")):
             return base64.b64decode(nickname).decode()
-        elif self._info and (model := self._info.get("model")):
-            return model
+        elif label := DEVICE_TYPE_TO_LABEL.get(self._device_type):
+            return label
         else:
             return None
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -617,7 +617,7 @@ class SmartDevice(Device):
         if self._info and (nickname := self._info.get("nickname")):
             return base64.b64decode(nickname).decode()
         elif label := DEVICE_TYPE_TO_LABEL.get(self._device_type):
-            return f"{label} ({self.model} {self.device_id})"
+            return f"{label} ({self.device_id})"
         else:
             return None
 

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -94,7 +94,7 @@ async def test_device_type_no_update(discovery_mock, caplog: pytest.LogCaptureFi
     assert dev.device_type is DeviceType.Plug
     assert (
         repr(dev)
-        == f"<DeviceType.Plug at {DISCOVERY_MOCK_IP} - Plug ({short_model} {disco_id}) ({short_model}) - update() needed>"
+        == f"<DeviceType.Plug at {DISCOVERY_MOCK_IP} - Plug ({disco_id}) ({short_model}) - update() needed>"
     )
     assert "Unknown device type, falling back to plug" in caplog.text
 

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -76,6 +76,10 @@ async def test_device_type_no_update(discovery_mock, caplog: pytest.LogCaptureFi
 
     discovery_result = copy.deepcopy(discovery_mock.discovery_data["result"])
 
+    print("TESTERINO", discovery_result)
+
+    disco_id = discovery_result["device_id"]
+
     disco_model = discovery_result["device_model"]
     short_model, _, _ = disco_model.partition("(")
     dev.update_from_discover_info(discovery_result)
@@ -90,7 +94,7 @@ async def test_device_type_no_update(discovery_mock, caplog: pytest.LogCaptureFi
     assert dev.device_type is DeviceType.Plug
     assert (
         repr(dev)
-        == f"<DeviceType.Plug at {DISCOVERY_MOCK_IP} - Plug ({short_model}) - update() needed>"
+        == f"<DeviceType.Plug at {DISCOVERY_MOCK_IP} - Plug ({short_model} {disco_id}) ({short_model}) - update() needed>"
     )
     assert "Unknown device type, falling back to plug" in caplog.text
 

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -90,7 +90,7 @@ async def test_device_type_no_update(discovery_mock, caplog: pytest.LogCaptureFi
     assert dev.device_type is DeviceType.Plug
     assert (
         repr(dev)
-        == f"<DeviceType.Plug at {DISCOVERY_MOCK_IP} - None ({short_model}) - update() needed>"
+        == f"<DeviceType.Plug at {DISCOVERY_MOCK_IP} - Plug ({short_model}) - update() needed>"
     )
     assert "Unknown device type, falling back to plug" in caplog.text
 


### PR DESCRIPTION
Fallback smart device alias to `model` if `nickname` is empty.

This will apply to any device, not just the P304M smart strip. If we prefer to have this exception just for the P304M I can add ` and model == "P304M"` in the elif on line 601.

The end result:
![image](https://github.com/user-attachments/assets/861631bd-ddbd-4681-bd10-3a96e3aa1474)

Notice that the name will be `P304M P304M`, however this can easily be edited in the UI:
![image](https://github.com/user-attachments/assets/286c5898-5a74-4ea4-8de8-8a7c68d806fd)

Entity ids look great:
![image](https://github.com/user-attachments/assets/fa372b97-8299-422c-91bf-639860c0d000)

Let me know if this solution is good or you would like to tweak it :)

EDIT: I see tests need fixing, I'll wait on your decision between having this fallback globally or only for P304M before fixing them.