### PR TITLE
EST invalid IANA timezone

### DIFF
--- a/kasa/iot/iottimezone.py
+++ b/kasa/iot/iottimezone.py
@@ -90,7 +90,7 @@ TIMEZONE_INDEX = {
     15: "Canada/Saskatchewan",
     16: "America/Bogota",
     17: "Etc/GMT+5",
-    18: "EST",
+    18: "America/Toronto",
     19: "America/Indiana/Indianapolis",
     20: "America/Caracas",
     21: "America/Asuncion",


### PR DESCRIPTION
With 'EST' `kasa discover` on Debian consistently failed with
```Raised error: 'No time zone found with key EST'```

I couldn't confirm "EST" was a valid IANA timezone, where America/Toronto definitely is... but it's "Eastern Time" not "Eastern Standard Time" which I think is what folks would expect in any case.