### PR TITLE
Vacuum Robot: Map list and selection

### DIFF
--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -454,10 +454,8 @@ class Clean(SmartModule):
             for map_data in map_info.get("map_list", []):
                 if map_data.get("map_id") == current_map_id:
                     return self._get_map_name(map_data)
-                
-        return "No map"
 
-    
+        return "No map"
 
     @property
     def available_maps(self) -> list[str]:

--- a/tests/fixtures/smart/RV30 Max(US)_1.0_1.2.0.json
+++ b/tests/fixtures/smart/RV30 Max(US)_1.0_1.2.0.json
@@ -647,7 +647,7 @@
         "map_hash": "A5D8FA4487CC40312EF58D8123F0A4CC",
         "map_id": 1734727686,
         "map_locked": 0,
-        "map_name": "I01BU0tFRF9OQU1FIw==",
+        "map_name": "TGl2aW5nIFJvb20=",
         "origin_coor": [
             -33,
             -108,
@@ -691,7 +691,7 @@
                 "is_saved": true,
                 "map_id": 1734727686,
                 "map_locked": 0,
-                "map_name": "I01BU0tFRF9OQU1FIw==",
+                "map_name": "TGl2aW5nIFJvb20=",
                 "rotate_angle": 270,
                 "update_time": 1737387285
             },
@@ -701,7 +701,7 @@
                 "is_saved": true,
                 "map_id": 1734742958,
                 "map_locked": 0,
-                "map_name": "I01BU0tFRF9OQU1FIw==",
+                "map_name": "S2l0Y2hlbg==",
                 "rotate_angle": 0,
                 "update_time": 1737304392
             },
@@ -711,7 +711,7 @@
                 "is_saved": true,
                 "map_id": 1736541042,
                 "map_locked": 0,
-                "map_name": "I01BU0tFRF9OQU1FIw==",
+                "map_name": "QmVkcm9vbQ==",
                 "rotate_angle": 270,
                 "update_time": 1737216718
             }


### PR DESCRIPTION
This PR aims to add support for map selection on Tapo robot vacuums. By having the choice feature "Selected Map" it is possible to list maps, view currently selected map and select a map.