### PR TITLE
Raise UnsupportedDeviceError for unsupported legacy device types

### DIFF
--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -142,7 +142,14 @@ def get_device_class_from_sys_info(sysinfo: dict[str, Any]) -> type[IotDevice]:
         # Disabled until properly implemented
         # DeviceType.Camera: IotCamera,
     }
-    return TYPE_TO_CLASS[IotDevice._get_device_type_from_sys_info(sysinfo)]
+    device_type = IotDevice._get_device_type_from_sys_info(sysinfo)
+    cls = TYPE_TO_CLASS.get(device_type)
+    if cls is None:
+        raise UnsupportedDeviceError(
+            f"Unsupported device type {device_type} for sysinfo: {sysinfo}",
+            host=sysinfo.get("ip"),
+        )
+    return cls
 
 
 def get_device_class_from_family(

--- a/tests/discovery_fixtures.py
+++ b/tests/discovery_fixtures.py
@@ -92,6 +92,7 @@ UNSUPPORTED_DEVICES = {
     "wrong_encryption_iot": _make_unsupported("IOT.SMARTPLUGSWITCH", "AES"),
     "wrong_encryption_smart": _make_unsupported("SMART.TAPOBULB", "IOT"),
     "unknown_encryption": _make_unsupported("IOT.SMARTPLUGSWITCH", "FOO"),
+    "incomplete_iotcamera": _make_unsupported("IOT.IPCAMERA", "XOR"),
     "missing_encrypt_type": _make_unsupported(
         "SMART.TAPOBULB",
         "FOO",


### PR DESCRIPTION
Some code paths leads into trying to initialize the device class for a type that does not exist in our device type to class map.

The test might not be correct, as this was also raising even before adding the new raise, needs to be verified.

This aims to fix https://github.com/home-assistant/core/issues/138866