### PR TITLE
Use Device instead of SmartDevice where feasible

### DIFF
--- a/kasa/cli/hub.py
+++ b/kasa/cli/hub.py
@@ -4,7 +4,7 @@ import asyncio
 
 import asyncclick as click
 
-from kasa import DeviceType, Module, SmartDevice
+from kasa import Device, DeviceType, Module
 from kasa.smart import SmartChildDevice
 
 from .common import (
@@ -21,7 +21,7 @@ def pretty_category(cat: str):
 
 @click.group()
 @pass_dev
-async def hub(dev: SmartDevice):
+async def hub(dev: Device):
     """Commands controlling hub child device pairing."""
     if dev.device_type is not DeviceType.Hub:
         error(f"{dev} is not a hub.")
@@ -32,7 +32,7 @@ async def hub(dev: SmartDevice):
 
 @hub.command(name="list")
 @pass_dev
-async def hub_list(dev: SmartDevice):
+async def hub_list(dev: Device):
     """List hub paired child devices."""
     for c in dev.children:
         echo(f"{c.device_id}: {c}")
@@ -40,7 +40,7 @@ async def hub_list(dev: SmartDevice):
 
 @hub.command(name="supported")
 @pass_dev
-async def hub_supported(dev: SmartDevice):
+async def hub_supported(dev: Device):
     """List supported hub child device categories."""
     cs = dev.modules[Module.ChildSetup]
 
@@ -51,7 +51,7 @@ async def hub_supported(dev: SmartDevice):
 @hub.command(name="pair")
 @click.option("--timeout", default=10)
 @pass_dev
-async def hub_pair(dev: SmartDevice, timeout: int):
+async def hub_pair(dev: Device, timeout: int):
     """Pair all pairable device.
 
     This will pair any child devices currently in pairing mode.

--- a/tests/fakeprotocol_iot.py
+++ b/tests/fakeprotocol_iot.py
@@ -190,7 +190,6 @@ AMBIENT_MODULE = {
     },
 }
 
-
 MOTION_MODULE = {
     "get_adc_value": {"value": 50, "err_code": 0},
     "get_config": {

--- a/tests/smart/modules/test_childsetup.py
+++ b/tests/smart/modules/test_childsetup.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 from pytest_mock import MockerFixture
 
-from kasa import Feature, Module, SmartDevice
+from kasa import Device, Feature, Module
 
 from ...device_fixtures import parametrize
 
@@ -15,7 +15,7 @@ childsetup = parametrize(
 
 
 @childsetup
-async def test_childsetup_features(dev: SmartDevice):
+async def test_childsetup_features(dev: Device):
     """Test the exposed features."""
     cs = dev.modules.get(Module.ChildSetup)
     assert cs
@@ -27,7 +27,7 @@ async def test_childsetup_features(dev: SmartDevice):
 
 @childsetup
 async def test_childsetup_pair(
-    dev: SmartDevice, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    dev: Device, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ):
     """Test device pairing."""
     caplog.set_level(logging.INFO)
@@ -51,7 +51,7 @@ async def test_childsetup_pair(
 
 @childsetup
 async def test_childsetup_unpair(
-    dev: SmartDevice, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    dev: Device, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ):
     """Test unpair."""
     mock_query_helper = mocker.spy(dev, "_query_helper")

--- a/tests/smart/modules/test_powerprotection.py
+++ b/tests/smart/modules/test_powerprotection.py
@@ -1,7 +1,7 @@
 import pytest
 from pytest_mock import MockerFixture
 
-from kasa import Module, SmartDevice
+from kasa import Device, Module
 
 from ...device_fixtures import get_parent_and_child_modules, parametrize
 
@@ -35,7 +35,7 @@ async def test_features(dev, feature, prop_name, type):
 
 
 @powerprotection
-async def test_set_enable(dev: SmartDevice, mocker: MockerFixture):
+async def test_set_enable(dev: Device, mocker: MockerFixture):
     """Test enable."""
     powerprot = next(get_parent_and_child_modules(dev, Module.PowerProtection))
     assert powerprot
@@ -88,7 +88,7 @@ async def test_set_enable(dev: SmartDevice, mocker: MockerFixture):
 
 
 @powerprotection
-async def test_set_threshold(dev: SmartDevice, mocker: MockerFixture):
+async def test_set_threshold(dev: Device, mocker: MockerFixture):
     """Test enable."""
     powerprot = next(get_parent_and_child_modules(dev, Module.PowerProtection))
     assert powerprot

--- a/tests/smartcam/modules/test_childsetup.py
+++ b/tests/smartcam/modules/test_childsetup.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 from pytest_mock import MockerFixture
 
-from kasa import Feature, Module, SmartDevice
+from kasa import Device, Feature, Module
 
 from ...device_fixtures import parametrize
 
@@ -15,7 +15,7 @@ childsetup = parametrize(
 
 
 @childsetup
-async def test_childsetup_features(dev: SmartDevice):
+async def test_childsetup_features(dev: Device):
     """Test the exposed features."""
     cs = dev.modules[Module.ChildSetup]
 
@@ -26,7 +26,7 @@ async def test_childsetup_features(dev: SmartDevice):
 
 @childsetup
 async def test_childsetup_pair(
-    dev: SmartDevice, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    dev: Device, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ):
     """Test device pairing."""
     caplog.set_level(logging.INFO)
@@ -69,7 +69,7 @@ async def test_childsetup_pair(
 
 @childsetup
 async def test_childsetup_unpair(
-    dev: SmartDevice, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
+    dev: Device, mocker: MockerFixture, caplog: pytest.LogCaptureFixture
 ):
     """Test unpair."""
     mock_query_helper = mocker.spy(dev, "_query_helper")


### PR DESCRIPTION
This PR is just some clean up that I found while working on my other PR's and you asked me to move it all to its own PR. These changes were to clean up the use of the old generic SmartDevice Class in some CLI files to the new standard Device Class. There is also the removal of an extra space in the fakeprotocol_iot.py that I found to maintain consistency with the rest of the file. Other changes are welcome if you have found anything along your way that doesn't really fit into another PR.