### PR TITLE
Add exception for unsupported provisioning methods

### DIFF
--- a/kasa/__init__.py
+++ b/kasa/__init__.py
@@ -32,6 +32,7 @@ from kasa.exceptions import (
     DeviceError,
     KasaException,
     TimeoutError,
+    UnsupportedAuthenticationError,
     UnsupportedDeviceError,
 )
 from kasa.feature import Feature
@@ -68,6 +69,7 @@ __all__ = [
     "KasaException",
     "AuthenticationError",
     "DeviceError",
+    "UnsupportedAuthenticationError",
     "UnsupportedDeviceError",
     "TimeoutError",
     "Credentials",

--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -29,6 +29,7 @@ from kasa.iot.iotdevice import _extract_sys_info
 from kasa.protocols.iotprotocol import REDACTORS as IOT_REDACTORS
 from kasa.protocols.protocol import redact_data
 
+from ..exceptions import UnsupportedAuthenticationError
 from ..json import dumps as json_dumps
 from .common import echo, error
 
@@ -70,14 +71,16 @@ async def detail(ctx: click.Context) -> DeviceDict:
     async def print_unsupported(unsupported_exception: UnsupportedDeviceError) -> None:
         unsupported.append(unsupported_exception)
         async with sem:
+            echo("== Unsupported device ==")
+            echo(f"\t{unsupported_exception}")
+            echo()
+
             if unsupported_exception.discovery_result:
-                echo("== Unsupported device ==")
                 _echo_discovery_info(unsupported_exception.discovery_result)
                 echo()
-            else:
-                echo("== Unsupported device ==")
-                echo(f"\t{unsupported_exception}")
-                echo()
+                if isinstance(unsupported_exception, UnsupportedAuthenticationError):
+                    echo("\t[red bold]Provisioned using unsupported 'tss'.[/red bold]")
+                    echo("\tTo fix, reset and provision manually.")
 
     from .device import state
 

--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -94,6 +94,8 @@ async def detail(ctx: click.Context) -> DeviceDict:
         async with sem:
             try:
                 await dev.update()
+            except UnsupportedAuthenticationError as ex:
+                await print_unsupported(ex)
             except AuthenticationError:
                 if TYPE_CHECKING:
                     assert dev._discovery_info
@@ -166,6 +168,8 @@ async def list(ctx: click.Context) -> DeviceDict:
         async with sem:
             try:
                 await dev.update()
+            except UnsupportedAuthenticationError as ex:
+                await print_unsupported(ex)
             except AuthenticationError:
                 echo(f"{infostr} - Authentication failed")
             except TimeoutError:

--- a/kasa/cli/discover.py
+++ b/kasa/cli/discover.py
@@ -79,7 +79,11 @@ async def detail(ctx: click.Context) -> DeviceDict:
                 _echo_discovery_info(unsupported_exception.discovery_result)
                 echo()
                 if isinstance(unsupported_exception, UnsupportedAuthenticationError):
-                    echo("\t[red bold]Provisioned using unsupported 'tss'.[/red bold]")
+                    obd_src = unsupported_exception.discovery_result.get("obd_src")
+                    echo(
+                        f"\t[red bold]Provisioned using unsupported"
+                        f" '{obd_src}'.[/red bold]"
+                    )
                     echo("\tTo fix, reset and provision manually.")
 
     from .device import state

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -123,6 +123,7 @@ from kasa.deviceconfig import (
 from kasa.exceptions import (
     KasaException,
     TimeoutError,
+    UnsupportedAuthenticationError,
     UnsupportedDeviceError,
 )
 from kasa.iot.iotdevice import IotDevice, _extract_sys_info
@@ -810,6 +811,13 @@ class Discover:
         discovery_result: DiscoveryResult,
     ) -> DeviceConnectionParameters:
         """Get connection parameters from the discovery result."""
+        # Raise specific exception for unsupported authentication source
+        if getattr(discovery_result, "obd_src", None) == "tss":
+            raise UnsupportedAuthenticationError(
+                f"Device at {discovery_result.ip} uses unsupported onboarding 'tss'.",
+                discovery_result=discovery_result.to_dict(),
+                host=discovery_result.ip,
+            )
         type_ = discovery_result.device_type
         if (encrypt_schm := discovery_result.mgt_encrypt_schm) is None:
             raise UnsupportedDeviceError(
@@ -890,7 +898,7 @@ class Discover:
             conn_params = Discover._get_connection_parameters(discovery_result)
             config.connection_type = conn_params
         except KasaException as ex:
-            if isinstance(ex, UnsupportedDeviceError):
+            if isinstance(ex, UnsupportedDeviceError | UnsupportedAuthenticationError):
                 raise
             raise UnsupportedDeviceError(
                 f"Unsupported device {config.host} of type {type_} "

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -285,6 +285,16 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         task: asyncio.Task = asyncio.create_task(coro)
         self.callback_tasks.append(task)
 
+    async def _on_discovered_wrapper(self, device: Device) -> None:
+        """Wrap on_discovered to handle UnsupportedAuthenticationError."""
+        assert self.on_discovered is not None  # noqa: S101
+        try:
+            await self.on_discovered(device)
+        except UnsupportedAuthenticationError as ex:
+            self.unsupported_device_exceptions[device.host] = ex
+            if self.on_unsupported is not None:
+                await self.on_unsupported(ex)
+
     async def wait_for_discovery_to_complete(self) -> None:
         """Wait for the discovery task to complete."""
         # Give some time for connection_made event to be received
@@ -394,7 +404,7 @@ class _DiscoverProtocol(asyncio.DatagramProtocol):
         self.discovered_devices[ip] = device
 
         if self.on_discovered is not None:
-            self._run_callback_task(self.on_discovered(device))
+            self._run_callback_task(self._on_discovered_wrapper(device))
 
         self._handle_discovered_event()
 
@@ -811,17 +821,6 @@ class Discover:
         discovery_result: DiscoveryResult,
     ) -> DeviceConnectionParameters:
         """Get connection parameters from the discovery result."""
-        # Raise a specific exception for unknown onboarding sources, which have
-        # valid encryption schemes but use credentials we cannot obtain.
-        _KNOWN_OBD_SRCS = {"tplink", "matter", "apple"}
-        obd_src = discovery_result.obd_src
-        if obd_src and obd_src not in _KNOWN_OBD_SRCS:
-            raise UnsupportedAuthenticationError(
-                f"Device at {discovery_result.ip} uses unsupported onboarding"
-                f" '{obd_src}'.",
-                discovery_result=discovery_result.to_dict(),
-                host=discovery_result.ip,
-            )
         type_ = discovery_result.device_type
         if (encrypt_schm := discovery_result.mgt_encrypt_schm) is None:
             raise UnsupportedDeviceError(
@@ -902,7 +901,7 @@ class Discover:
             conn_params = Discover._get_connection_parameters(discovery_result)
             config.connection_type = conn_params
         except KasaException as ex:
-            if isinstance(ex, UnsupportedDeviceError | UnsupportedAuthenticationError):
+            if isinstance(ex, UnsupportedDeviceError):
                 raise
             raise UnsupportedDeviceError(
                 f"Unsupported device {config.host} of type {type_} "

--- a/kasa/discover.py
+++ b/kasa/discover.py
@@ -811,10 +811,14 @@ class Discover:
         discovery_result: DiscoveryResult,
     ) -> DeviceConnectionParameters:
         """Get connection parameters from the discovery result."""
-        # Raise specific exception for unsupported authentication source
-        if getattr(discovery_result, "obd_src", None) == "tss":
+        # Raise a specific exception for unknown onboarding sources, which have
+        # valid encryption schemes but use credentials we cannot obtain.
+        _KNOWN_OBD_SRCS = {"tplink", "matter", "apple"}
+        obd_src = discovery_result.obd_src
+        if obd_src and obd_src not in _KNOWN_OBD_SRCS:
             raise UnsupportedAuthenticationError(
-                f"Device at {discovery_result.ip} uses unsupported onboarding 'tss'.",
+                f"Device at {discovery_result.ip} uses unsupported onboarding"
+                f" '{obd_src}'.",
                 discovery_result=discovery_result.to_dict(),
                 host=discovery_result.ip,
             )

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -200,3 +200,11 @@ SMART_AUTHENTICATION_ERRORS = [
     SmartErrorCode.TRANSPORT_UNKNOWN_CREDENTIALS_ERROR,
     SmartErrorCode.HOMEKIT_LOGIN_FAIL,
 ]
+
+
+class UnsupportedAuthenticationError(UnsupportedDeviceError, AuthenticationError):
+    """Raised when authentication fails with unsupported provisioning method.
+
+    This can be used to display a more helpful message to the user when their devices
+    have been provisioned using the tplink simple setup (tss).
+    """

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -202,14 +202,13 @@ SMART_AUTHENTICATION_ERRORS = [
 ]
 
 
-#: Onboarding sources we can authenticate with. Devices provisioned via other
-#: sources have valid encryption but use credentials we cannot access.
+#: Onboarding sources that are known to work
 SUPPORTED_OBD_SRCS = {"tplink", "matter", "apple"}
 
 
 class UnsupportedAuthenticationError(UnsupportedDeviceError, AuthenticationError):
     """Raised when authentication fails with unsupported provisioning method.
 
-    This can be used to display a more helpful message to the user when their devices
-    have been provisioned using the tplink simple setup (tss).
+    This can be used to display a more helpful message in when we know it is
+    not necessarily an issue with the inputted credentials.
     """

--- a/kasa/exceptions.py
+++ b/kasa/exceptions.py
@@ -202,6 +202,11 @@ SMART_AUTHENTICATION_ERRORS = [
 ]
 
 
+#: Onboarding sources we can authenticate with. Devices provisioned via other
+#: sources have valid encryption but use credentials we cannot access.
+SUPPORTED_OBD_SRCS = {"tplink", "matter", "apple"}
+
+
 class UnsupportedAuthenticationError(UnsupportedDeviceError, AuthenticationError):
     """Raised when authentication fails with unsupported provisioning method.
 

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -13,7 +13,14 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 from ..device import Device, DeviceInfo, WifiNetwork
 from ..device_type import DeviceType
 from ..deviceconfig import DeviceConfig
-from ..exceptions import AuthenticationError, DeviceError, KasaException, SmartErrorCode
+from ..exceptions import (
+    SUPPORTED_OBD_SRCS,
+    AuthenticationError,
+    DeviceError,
+    KasaException,
+    SmartErrorCode,
+    UnsupportedAuthenticationError,
+)
 from ..feature import Feature
 from ..module import Module
 from ..modulemapping import ModuleMapping, ModuleName
@@ -263,6 +270,20 @@ class SmartDevice(Device):
         if self.credentials is None and self.credentials_hash is None:
             raise AuthenticationError("Tapo plug requires authentication.")
 
+        try:
+            await self._update(update_children)
+        except AuthenticationError as ex:
+            obd_src = self._discovery_info and self._discovery_info.get("obd_src")
+            if obd_src and obd_src not in SUPPORTED_OBD_SRCS:
+                raise UnsupportedAuthenticationError(
+                    f"Device at {self.host} uses unsupported onboarding '{obd_src}'.",
+                    discovery_result=self._discovery_info,
+                    host=self.host,
+                ) from ex
+            raise
+
+    async def _update(self, update_children: bool = True) -> None:
+        """Update implementation."""
         first_update = self._last_update_time is None
         now = time.monotonic()
         self._last_update_time = now

--- a/tests/discovery_fixtures.py
+++ b/tests/discovery_fixtures.py
@@ -399,3 +399,21 @@ def unsupported_device_info(request, mocker):
     mocker.patch("kasa.discover._DiscoverProtocol.do_discover", mock_discover)
 
     return discovery_data
+
+
+def test_unsupported_authentication_exception_for_tss():
+    from kasa.discover import Discover, DiscoveryResult
+    from kasa.exceptions import UnsupportedAuthenticationError
+
+    # Create a mock discovery result with obd_src='tss'
+    dr = DiscoveryResult(
+        device_type="SomeType",
+        device_model="SomeModel",
+        device_id="SomeID",
+        ip="127.0.0.2",
+        mac="00:11:22:33:44:55",
+        obd_src="tss",
+    )
+    with pytest.raises(UnsupportedAuthenticationError) as excinfo:
+        Discover._get_connection_parameters(dr)
+    assert "obd_src='tss'" in str(excinfo.value)

--- a/tests/discovery_fixtures.py
+++ b/tests/discovery_fixtures.py
@@ -399,21 +399,3 @@ def unsupported_device_info(request, mocker):
     mocker.patch("kasa.discover._DiscoverProtocol.do_discover", mock_discover)
 
     return discovery_data
-
-
-def test_unsupported_authentication_exception_for_tss():
-    from kasa.discover import Discover, DiscoveryResult
-    from kasa.exceptions import UnsupportedAuthenticationError
-
-    # Create a mock discovery result with obd_src='tss'
-    dr = DiscoveryResult(
-        device_type="SomeType",
-        device_model="SomeModel",
-        device_id="SomeID",
-        ip="127.0.0.2",
-        mac="00:11:22:33:44:55",
-        obd_src="tss",
-    )
-    with pytest.raises(UnsupportedAuthenticationError) as excinfo:
-        Discover._get_connection_parameters(dr)
-    assert "obd_src='tss'" in str(excinfo.value)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -441,11 +441,8 @@ async def test_unsupported_authentication_exception_for_tss(mocker):
         ),
     )
 
-    # Connection parameters succeed — no short-circuit on obd_src
     assert Discover._get_connection_parameters(dr) is not None
 
-    # When on_discovered propagates UnsupportedAuthenticationError (raised by update()),
-    # the wrapper routes it to on_unsupported
     unsupported_calls = []
 
     async def on_discovered(dev):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -418,6 +418,24 @@ async def test_device_update_from_new_discovery_info(discovery_mock):
             assert device.modules
 
 
+def test_unsupported_authentication_exception_for_tss():
+    """Test that unknown obd_src raises UnsupportedAuthenticationError."""
+    from kasa.discover import Discover, DiscoveryResult
+    from kasa.exceptions import UnsupportedAuthenticationError
+
+    dr = DiscoveryResult(
+        device_type="SomeType",
+        device_model="SomeModel",
+        device_id="SomeID",
+        ip="127.0.0.2",
+        mac="00:11:22:33:44:55",
+        obd_src="tss",
+    )
+    with pytest.raises(UnsupportedAuthenticationError) as excinfo:
+        Discover._get_connection_parameters(dr)
+    assert "unsupported onboarding 'tss'" in str(excinfo.value)
+
+
 async def test_discover_single_http_client(discovery_mock, mocker):
     """Make sure that discover_single returns an initialized SmartDevice instance."""
     host = "127.0.0.1"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -418,22 +418,59 @@ async def test_device_update_from_new_discovery_info(discovery_mock):
             assert device.modules
 
 
-def test_unsupported_authentication_exception_for_tss():
-    """Test that unknown obd_src raises UnsupportedAuthenticationError."""
-    from kasa.discover import Discover, DiscoveryResult
+async def test_unsupported_authentication_exception_for_tss(mocker):
+    """Test that unknown obd_src raises UnsupportedAuthenticationError after auth fails."""
+    from kasa.discover import (
+        Discover,
+        DiscoveryResult,
+        EncryptionScheme,
+        _DiscoverProtocol,
+    )
     from kasa.exceptions import UnsupportedAuthenticationError
 
+    # tss devices have valid connection params but unknown credentials
     dr = DiscoveryResult(
-        device_type="SomeType",
-        device_model="SomeModel",
+        device_type="SMART.TAPOPLUG",
+        device_model="P316M(US)",
         device_id="SomeID",
         ip="127.0.0.2",
         mac="00:11:22:33:44:55",
         obd_src="tss",
+        mgt_encrypt_schm=EncryptionScheme(
+            encrypt_type="KLAP", lv=2, is_support_https=False
+        ),
     )
-    with pytest.raises(UnsupportedAuthenticationError) as excinfo:
-        Discover._get_connection_parameters(dr)
-    assert "unsupported onboarding 'tss'" in str(excinfo.value)
+
+    # Connection parameters succeed — no short-circuit on obd_src
+    assert Discover._get_connection_parameters(dr) is not None
+
+    # When on_discovered propagates UnsupportedAuthenticationError (raised by update()),
+    # the wrapper routes it to on_unsupported
+    unsupported_calls = []
+
+    async def on_discovered(dev):
+        raise UnsupportedAuthenticationError(
+            "Device at 127.0.0.2 uses unsupported onboarding 'tss'.",
+            discovery_result=dr.to_dict(),
+            host="127.0.0.2",
+        )
+
+    async def on_unsupported(ex):
+        unsupported_calls.append(ex)
+
+    protocol = _DiscoverProtocol(
+        target="127.0.0.2",
+        on_discovered=on_discovered,
+        on_unsupported=on_unsupported,
+    )
+    device = mocker.MagicMock()
+    device.host = "127.0.0.2"
+
+    await protocol._on_discovered_wrapper(device)
+
+    assert len(unsupported_calls) == 1
+    assert isinstance(unsupported_calls[0], UnsupportedAuthenticationError)
+    assert "unsupported onboarding 'tss'" in str(unsupported_calls[0])
 
 
 async def test_discover_single_http_client(discovery_mock, mocker):


### PR DESCRIPTION
We frequently receive reports from users who have issues with credentials.
One of the most common cases, besides the mobile app users' uppercasing the first letter, is due to the provisioning through "tplink simple setup" (tss) where the newly provisioned devices do not accept the regular credentials.

This PR adds a new exception that can be caught to display user a more detailed message about what they can do to fix the issue.

This has not been tested yet, so drafting for now.

Fixes #1573