### PR TITLE
Use log-level debug for smartdevice query error reporting

### DIFF
--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -378,7 +378,7 @@ class SmartDevice(Device):
         """
         msg_part = "on first update" if first_update else "after first update"
 
-        _LOGGER.error(
+        _LOGGER.debug(
             "Error querying %s for modules '%s' %s: %s",
             self.host,
             module_names,
@@ -391,7 +391,7 @@ class SmartDevice(Device):
                 resp = await self.protocol.query({meth: params})
                 responses[meth] = resp[meth]
             except Exception as iex:
-                _LOGGER.error(
+                _LOGGER.debug(
                     "Error querying %s individually for module query '%s' %s: %s",
                     self.host,
                     meth,


### PR DESCRIPTION
We are currently logging query failures to the error logger, which causes log spam if a device is intentionally unavailable.
This PR will change the log-level for connection errors to debug to silence this for common downstream scenarios.
A follow-up PR could be made to report connection errors (i.e., if no module can be queried) by raising an exception for downstream uses.

Related to https://github.com/home-assistant/core/issues/143667