### PR TITLE
Add shutdown (summer mode) to thermostatstate

### DIFF
--- a/kasa/interfaces/thermostat.py
+++ b/kasa/interfaces/thermostat.py
@@ -16,6 +16,7 @@ class ThermostatState(Enum):
     Calibrating = "progress_calibration"
     Idle = "idle"
     Off = "off"
+    Shutdown = "shutdown"
     Unknown = "unknown"
 
 


### PR DESCRIPTION
According to https://github.com/home-assistant/core/issues/151870, thermostats report "shutdown" when they are set into the summer mode.
