### PR TITLE
Fix thermostat idle reporting on low battery

### DIFF
--- a/kasa/smart/modules/temperaturecontrol.py
+++ b/kasa/smart/modules/temperaturecontrol.py
@@ -93,12 +93,14 @@ class TemperatureControl(SmartModule):
 
         states = self.states
 
+        # Discard known non-mode states
+        states.discard("low_battery")
+
         # If the states is empty, the device is idling
         if not states:
             return ThermostatState.Idle
 
-        # Discard known extra states, and report on unknown extra states
-        states.discard("low_battery")
+        # Report on unknown extra states
         if len(states) > 1:
             _LOGGER.warning("Got multiple states: %s", states)
 

--- a/tests/smart/modules/test_temperaturecontrol.py
+++ b/tests/smart/modules/test_temperaturecontrol.py
@@ -154,3 +154,13 @@ async def test_thermostat_heating_with_low_battery(dev):
     temp_module: TemperatureControl = dev.modules["TemperatureControl"]
     temp_module.data["trv_states"] = ["low_battery", "heating"]
     assert temp_module.mode is ThermostatState.Heating
+
+
+@thermostats_smart
+async def test_thermostat_idle_with_low_battery(dev, caplog):
+    """Test that mode is reported correctly with extra states."""
+    temp_module: TemperatureControl = dev.modules["TemperatureControl"]
+    temp_module.data["trv_states"] = ["low_battery"]
+    with caplog.at_level(logging.WARNING):
+        assert temp_module.mode is ThermostatState.Idle
+    assert not caplog.records


### PR DESCRIPTION
As reported in https://github.com/home-assistant/core/issues/155234, the `low_battery` state needs to be discarded before checking for an empty list of states to avoid incorrect reporting when the battery is low and there is no specific state set.

