### PR TITLE
Add hold state to thermostatstate

### DIFF
--- a/kasa/interfaces/thermostat.py
+++ b/kasa/interfaces/thermostat.py
@@ -15,6 +15,7 @@ class ThermostatState(Enum):
     Heating = "heating"
     Calibrating = "progress_calibration"
     Idle = "idle"
+    Hold = "hold_on"
     Off = "off"
     Shutdown = "shutdown"
     Unknown = "unknown"


### PR DESCRIPTION
This adds `hold_on` to the known states to allow downstreams handle the hold mode (idle, but heating if the temperature gets lower than the target).

Fixes #1608 - thanks to the reporter, https://github.com/home-assistant/core/pull/156310 was also created to improve the handling of unknown modes.