### PR TITLE
Allow SSL connections to older devices

### DIFF
--- a/kasa/transports/sslaestransport.py
+++ b/kasa/transports/sslaestransport.py
@@ -73,6 +73,7 @@ class SslAesTransport(BaseTransport):
     }
     CIPHERS = ":".join(
         [
+            "ECDHE-RSA-AES128-GCM-SHA256",
             "AES256-GCM-SHA384",
             "AES256-SHA256",
             "AES128-GCM-SHA256",


### PR DESCRIPTION
With recent firmware updates for older devices (like C120) the embedded SSL certificate on the deivce is RSA 1024 type, which is considered insecure nowadays.

 0 s:CN=TPRI-DEVICE, O=TPRI, C=US
   i:CN=TPRI-DEVICE, O=TPRI, C=US
   a:PKEY: RSA, 1024 (bit); sigalg: sha256WithRSAEncryption
   v:NotBefore: Jan  1 00:00:00 2001 GMT; NotAfter: Dec 31 23:59:59 2070 GMT

This fix add cipher used by TP-Link to list of allowed ones.

Related: https://github.com/home-assistant/core/issues/162498