### PR TITLE
Add selective room cleaning to vacuum clean module

### DIFF
--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 import logging
+from dataclasses import dataclass
 from datetime import timedelta
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Annotated, Literal
 
 from ...feature import Feature
@@ -12,6 +14,10 @@ from ...module import FeatureAttribute
 from ..smartmodule import SmartModule
 
 _LOGGER = logging.getLogger(__name__)
+
+# Only known value for start_type in setSwitchClean; required for
+# targeted cleaning modes (Room) but not for StandardHome.
+_START_TYPE_RESUME = 1
 
 
 class Status(IntEnum):
@@ -56,6 +62,65 @@ class FanSpeed(IntEnum):
     Turbo = 3
     Max = 4
     Ultra = 5
+
+
+class CleanMode(IntEnum):
+    """Clean mode for ``setSwitchClean`` and ``getCleanStatus``.
+
+    Used as ``clean_mode`` in commands and ``clean_status`` in status responses.
+    """
+
+    #: Clean all rooms with uniform settings.
+    StandardHome = 0
+    #: Clean all rooms with per-room settings and custom order.
+    AdvancedHome = 1
+    #: Clean a small area around the vacuum's current position.
+    Spot = 2
+    #: Clean selected rooms only.
+    Room = 3
+    #: Clean user-defined rectangular areas.
+    Zone = 4
+    #: Run a saved custom cleaning preset.
+    Custom = 5
+
+
+@dataclass
+class CleanAreaSettings:
+    """Per-area cleaning settings shared by rooms and zones."""
+
+    #: Suction power level (matches :class:`FanSpeed` values).
+    suction: int = 0
+    #: Water level for mopping.
+    cistern: int = 0
+    #: Number of cleaning passes.
+    clean_number: int = 0
+
+
+@dataclass
+class RoomInfo(CleanAreaSettings):
+    """Information about a room on the vacuum's map."""
+
+    #: Room ID used in cleaning commands.
+    id: int = 0
+    #: Human-readable room name (base64-decoded from the device).
+    name: str | None = None
+    #: Color index used for map rendering.
+    color: int = 0
+
+
+class AreaType(StrEnum):
+    """Type of area entry in map data."""
+
+    #: A named room.
+    Room = "room"
+    #: A user-defined rectangular cleaning zone.
+    Area = "area"
+    #: A virtual wall boundary.
+    VirtualWall = "virtual_wall"
+    #: A no-go zone.
+    Forbid = "forbid"
+    #: A detected carpet region.
+    CarpetRectangle = "carpet_rectangle"
 
 
 class AreaUnit(IntEnum):
@@ -276,7 +341,7 @@ class Clean(SmartModule):
         return await self.call(
             "setSwitchClean",
             {
-                "clean_mode": 0,
+                "clean_mode": CleanMode.StandardHome,
                 "clean_on": True,
                 "clean_order": True,
                 "force_clean": False,
@@ -416,8 +481,21 @@ class Clean(SmartModule):
         """Return the ID of the currently active map."""
         return self.data["getMapInfo"]["current_map_id"]
 
-    async def clean_rooms(self, room_ids: list[int], map_id: int | None = None) -> dict:
+    @property
+    def clean_type(self) -> CleanMode | None:
+        """Return the active cleaning mode, or ``None`` if unavailable."""
+        cs = self.data.get("getCleanStatus")
+        if cs is None or "clean_status" not in cs:
+            return None
+        return CleanMode(cs["clean_status"])
+
+    async def clean_rooms(
+        self, room_ids: list[int], *, map_id: int | None = None
+    ) -> dict:
         """Start cleaning specific rooms.
+
+        Per-room settings are not supported; the device uses the global
+        suction / cistern / clean_number values for room cleaning.
 
         :param room_ids: List of room IDs to clean.
         :param map_id: Map ID to clean on. Defaults to the current active map.
@@ -429,24 +507,45 @@ class Clean(SmartModule):
         return await self.call(
             "setSwitchClean",
             {
-                "clean_mode": 3,
+                "clean_mode": CleanMode.Room,
                 "clean_on": True,
                 "clean_order": True,
                 "force_clean": False,
                 "map_id": map_id,
                 "room_list": list(room_ids),
-                "start_type": 1,
+                "start_type": _START_TYPE_RESUME,
             },
         )
 
-    async def get_rooms(self, map_id: int | None = None) -> list[dict]:
+    async def get_rooms(self, map_id: int | None = None) -> list[RoomInfo]:
         """Return the list of rooms for the given map.
+
+        Room names are base64-decoded when present.
 
         :param map_id: Map ID to query. Defaults to the current active map.
         """
         if map_id is None:
             map_id = self.current_map_id
         resp = await self.call("getMapData", {"map_id": map_id, "type": 0})
-        return [
-            area for area in resp.get("area_list", []) if area.get("type") == "room"
-        ]
+
+        rooms: list[RoomInfo] = []
+        for area in resp.get("area_list", []):
+            if area.get("type") != AreaType.Room:
+                continue
+            name = None
+            if raw_name := area.get("name"):
+                try:
+                    name = base64.b64decode(raw_name).decode()
+                except Exception:
+                    name = raw_name
+            rooms.append(
+                RoomInfo(
+                    id=area["id"],
+                    name=name,
+                    color=area.get("color", 0),
+                    suction=area.get("suction", 0),
+                    cistern=area.get("cistern", 0),
+                    clean_number=area.get("clean_number", 0),
+                )
+            )
+        return rooms

--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -482,6 +482,21 @@ class Clean(SmartModule):
         return self.data["getMapInfo"]["current_map_id"]
 
     @property
+    def current_map_name(self) -> str | None:
+        """Return the name of the currently active map, or ``None``."""
+        map_info = self.data["getMapInfo"]
+        current_id = map_info["current_map_id"]
+        for m in map_info.get("map_list", []):
+            if m.get("map_id") == current_id:
+                if raw_name := m.get("map_name"):
+                    try:
+                        return base64.b64decode(raw_name).decode()
+                    except Exception:
+                        return raw_name
+                return None
+        return None
+
+    @property
     def clean_type(self) -> CleanMode | None:
         """Return the active cleaning mode, or ``None`` if unavailable."""
         cs = self.data.get("getCleanStatus")

--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -17,7 +17,10 @@ _LOGGER = logging.getLogger(__name__)
 
 # Only known value for start_type in setSwitchClean; required for
 # targeted cleaning modes (Room) but not for StandardHome.
-_START_TYPE_RESUME = 1
+_START_TYPE_DEFAULT = 1
+
+# Only known value for the type parameter in getMapData.
+_MAP_DATA_TYPE_DEFAULT = 0
 
 
 class Status(IntEnum):
@@ -528,7 +531,7 @@ class Clean(SmartModule):
                 "force_clean": False,
                 "map_id": map_id,
                 "room_list": list(room_ids),
-                "start_type": _START_TYPE_RESUME,
+                "start_type": _START_TYPE_DEFAULT,
             },
         )
 
@@ -541,7 +544,9 @@ class Clean(SmartModule):
         """
         if map_id is None:
             map_id = self.current_map_id
-        resp = await self.call("getMapData", {"map_id": map_id, "type": 0})
+        resp = await self.call(
+            "getMapData", {"map_id": map_id, "type": _MAP_DATA_TYPE_DEFAULT}
+        )
 
         rooms: list[RoomInfo] = []
         for area in resp.get("area_list", []):

--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -547,9 +547,10 @@ class Clean(SmartModule):
         resp = await self.call(
             "getMapData", {"map_id": map_id, "type": _MAP_DATA_TYPE_DEFAULT}
         )
+        map_data = resp.get("getMapData", resp)
 
         rooms: list[RoomInfo] = []
-        for area in resp.get("area_list", []):
+        for area in map_data.get("area_list", []):
             if area.get("type") != AreaType.Room:
                 _LOGGER.debug(
                     "Skipping non-room area: type=%s, id=%s",

--- a/kasa/smart/modules/clean.py
+++ b/kasa/smart/modules/clean.py
@@ -88,8 +88,8 @@ class CleanMode(IntEnum):
 class CleanAreaSettings:
     """Per-area cleaning settings shared by rooms and zones."""
 
-    #: Suction power level (matches :class:`FanSpeed` values).
-    suction: int = 0
+    #: Suction power level, or ``None`` when not configured per-area.
+    suction: FanSpeed | None = None
     #: Water level for mopping.
     cistern: int = 0
     #: Number of cleaning passes.
@@ -546,6 +546,11 @@ class Clean(SmartModule):
         rooms: list[RoomInfo] = []
         for area in resp.get("area_list", []):
             if area.get("type") != AreaType.Room:
+                _LOGGER.debug(
+                    "Skipping non-room area: type=%s, id=%s",
+                    area.get("type"),
+                    area.get("id"),
+                )
                 continue
             name = None
             if raw_name := area.get("name"):
@@ -553,12 +558,14 @@ class Clean(SmartModule):
                     name = base64.b64decode(raw_name).decode()
                 except Exception:
                     name = raw_name
+
+            suction_val = area.get("suction")
             rooms.append(
                 RoomInfo(
                     id=area["id"],
                     name=name,
                     color=area.get("color", 0),
-                    suction=area.get("suction", 0),
+                    suction=FanSpeed(suction_val) if suction_val else None,
                     cistern=area.get("cistern", 0),
                     clean_number=area.get("clean_number", 0),
                 )

--- a/tests/smart/modules/test_clean.py
+++ b/tests/smart/modules/test_clean.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture
 
 from kasa import Module
 from kasa.smart import SmartDevice
-from kasa.smart.modules.clean import ErrorCode, Status
+from kasa.smart.modules.clean import CleanMode, ErrorCode, RoomInfo, Status
 
 from ...device_fixtures import get_parent_and_child_modules, parametrize
 
@@ -253,7 +253,7 @@ async def test_clean_rooms(dev: SmartDevice, mocker: MockerFixture):
     call.assert_called_with(
         "setSwitchClean",
         {
-            "clean_mode": 3,
+            "clean_mode": CleanMode.Room,
             "clean_on": True,
             "clean_order": True,
             "force_clean": False,
@@ -275,7 +275,7 @@ async def test_clean_rooms_explicit_map_id(dev: SmartDevice, mocker: MockerFixtu
     call.assert_called_with(
         "setSwitchClean",
         {
-            "clean_mode": 3,
+            "clean_mode": CleanMode.Room,
             "clean_on": True,
             "clean_order": True,
             "force_clean": False,
@@ -297,13 +297,31 @@ async def test_clean_rooms_empty_raises(dev: SmartDevice):
 
 @clean
 async def test_get_rooms(dev: SmartDevice, mocker: MockerFixture):
-    """Test get_rooms calls getMapData and filters to rooms only."""
+    """Test get_rooms returns RoomInfo objects with decoded names."""
+    import base64
+
     clean = next(get_parent_and_child_modules(dev, Module.Clean))
 
     map_data = {
         "area_list": [
-            {"id": 2, "name": "Kitchen", "type": "room"},
-            {"id": 3, "name": "Living Room", "type": "room"},
+            {
+                "id": 2,
+                "name": base64.b64encode(b"Kitchen").decode(),
+                "type": "room",
+                "color": 1,
+                "suction": 2,
+                "cistern": 1,
+                "clean_number": 1,
+            },
+            {
+                "id": 3,
+                "name": base64.b64encode(b"Living Room").decode(),
+                "type": "room",
+                "color": 2,
+                "suction": 3,
+                "cistern": 2,
+                "clean_number": 2,
+            },
             {"id": 401, "type": "virtual_wall", "vertexs": []},
         ]
     }
@@ -315,18 +333,86 @@ async def test_get_rooms(dev: SmartDevice, mocker: MockerFixture):
         "getMapData", {"map_id": clean.current_map_id, "type": 0}
     )
     assert len(rooms) == 2
-    assert all(r["type"] == "room" for r in rooms)
+    assert all(isinstance(r, RoomInfo) for r in rooms)
+    assert rooms[0].id == 2
+    assert rooms[0].name == "Kitchen"
+    assert rooms[0].color == 1
+    assert rooms[1].id == 3
+    assert rooms[1].name == "Living Room"
 
 
 @clean
 async def test_get_rooms_explicit_map_id(dev: SmartDevice, mocker: MockerFixture):
     """Test get_rooms uses the provided map_id when given."""
+    import base64
+
     clean = next(get_parent_and_child_modules(dev, Module.Clean))
 
-    map_data = {"area_list": [{"id": 1, "name": "Hall", "type": "room"}]}
+    map_data = {
+        "area_list": [
+            {
+                "id": 1,
+                "name": base64.b64encode(b"Hall").decode(),
+                "type": "room",
+            },
+        ]
+    }
     call_mock = mocker.patch.object(clean, "call", return_value=map_data)
 
     rooms = await clean.get_rooms(map_id=99999)
 
     call_mock.assert_called_once_with("getMapData", {"map_id": 99999, "type": 0})
     assert len(rooms) == 1
+    assert rooms[0].name == "Hall"
+
+
+@clean
+async def test_get_rooms_no_name(dev: SmartDevice, mocker: MockerFixture):
+    """Test get_rooms handles rooms without names."""
+    clean = next(get_parent_and_child_modules(dev, Module.Clean))
+
+    map_data = {"area_list": [{"id": 5, "type": "room"}]}
+    mocker.patch.object(clean, "call", return_value=map_data)
+
+    rooms = await clean.get_rooms()
+
+    assert len(rooms) == 1
+    assert rooms[0].id == 5
+    assert rooms[0].name is None
+
+
+@clean
+async def test_clean_type(dev: SmartDevice, mocker: MockerFixture):
+    """Test clean_type returns the correct CleanMode."""
+    clean = next(get_parent_and_child_modules(dev, Module.Clean))
+
+    mocker.patch.object(
+        type(clean),
+        "data",
+        new_callable=mocker.PropertyMock,
+        return_value={**clean.data, "getCleanStatus": {"clean_status": 0}},
+    )
+    assert clean.clean_type is CleanMode.StandardHome
+
+    mocker.patch.object(
+        type(clean),
+        "data",
+        new_callable=mocker.PropertyMock,
+        return_value={**clean.data, "getCleanStatus": {"clean_status": 3}},
+    )
+    assert clean.clean_type is CleanMode.Room
+
+
+@clean
+async def test_clean_type_missing(dev: SmartDevice, mocker: MockerFixture):
+    """Test clean_type returns None when clean_status is unavailable."""
+    clean = next(get_parent_and_child_modules(dev, Module.Clean))
+
+    data_without = {k: v for k, v in clean.data.items() if k != "getCleanStatus"}
+    mocker.patch.object(
+        type(clean),
+        "data",
+        new_callable=mocker.PropertyMock,
+        return_value=data_without,
+    )
+    assert clean.clean_type is None

--- a/tests/smart/modules/test_clean.py
+++ b/tests/smart/modules/test_clean.py
@@ -422,7 +422,6 @@ async def test_get_rooms_no_name(dev: SmartDevice, mocker: MockerFixture):
     assert rooms[0].suction is None
 
 
-
 @clean
 async def test_clean_type(dev: SmartDevice, mocker: MockerFixture):
     """Test clean_type returns the correct CleanMode."""

--- a/tests/smart/modules/test_clean.py
+++ b/tests/smart/modules/test_clean.py
@@ -7,7 +7,7 @@ from pytest_mock import MockerFixture
 
 from kasa import Module
 from kasa.smart import SmartDevice
-from kasa.smart.modules.clean import CleanMode, ErrorCode, RoomInfo, Status
+from kasa.smart.modules.clean import CleanMode, ErrorCode, FanSpeed, RoomInfo, Status
 
 from ...device_fixtures import get_parent_and_child_modules, parametrize
 
@@ -375,8 +375,10 @@ async def test_get_rooms(dev: SmartDevice, mocker: MockerFixture):
     assert rooms[0].id == 2
     assert rooms[0].name == "Kitchen"
     assert rooms[0].color == 1
+    assert rooms[0].suction is FanSpeed.Standard
     assert rooms[1].id == 3
     assert rooms[1].name == "Living Room"
+    assert rooms[1].suction is FanSpeed.Turbo
 
 
 @clean
@@ -417,6 +419,8 @@ async def test_get_rooms_no_name(dev: SmartDevice, mocker: MockerFixture):
     assert len(rooms) == 1
     assert rooms[0].id == 5
     assert rooms[0].name is None
+    assert rooms[0].suction is None
+
 
 
 @clean

--- a/tests/smart/modules/test_clean.py
+++ b/tests/smart/modules/test_clean.py
@@ -242,6 +242,44 @@ async def test_invalid_settings(
 
 
 @clean
+async def test_current_map_name(dev: SmartDevice, mocker: MockerFixture):
+    """Test current_map_name decodes the base64 name of the active map."""
+    import base64
+
+    clean = next(get_parent_and_child_modules(dev, Module.Clean))
+
+    map_info = {
+        "current_map_id": 42,
+        "map_list": [
+            {"map_id": 42, "map_name": base64.b64encode(b"Upstairs").decode()},
+            {"map_id": 99, "map_name": base64.b64encode(b"Downstairs").decode()},
+        ],
+    }
+    mocker.patch.object(
+        type(clean),
+        "data",
+        new_callable=mocker.PropertyMock,
+        return_value={**clean.data, "getMapInfo": map_info},
+    )
+    assert clean.current_map_name == "Upstairs"
+
+
+@clean
+async def test_current_map_name_missing(dev: SmartDevice, mocker: MockerFixture):
+    """Test current_map_name returns None when map_list is empty."""
+    clean = next(get_parent_and_child_modules(dev, Module.Clean))
+
+    map_info = {"current_map_id": 0, "map_list": []}
+    mocker.patch.object(
+        type(clean),
+        "data",
+        new_callable=mocker.PropertyMock,
+        return_value={**clean.data, "getMapInfo": map_info},
+    )
+    assert clean.current_map_name is None
+
+
+@clean
 async def test_clean_rooms(dev: SmartDevice, mocker: MockerFixture):
     """Test clean_rooms sends the correct setSwitchClean payload."""
     clean = next(get_parent_and_child_modules(dev, Module.Clean))


### PR DESCRIPTION
## Summary

Adds support for selective room cleaning to the existing `Clean` module:

- `clean_rooms(room_ids: list[int], map_id: int | None = None)` - sends `setSwitchClean` with `clean_mode: 3` and the verified payload to clean specific rooms
- `get_rooms(map_id: int | None = None)` - on-demand call to `getMapData` returning the filtered list of room areas
- `current_map_id` property - exposes the active map ID from `getMapInfo`, which is now included in the polling query

## Background

The correct `setSwitchClean` payload for selective room cleaning was reverse-engineered by intercepting live device traffic while the official Tapo app performed a room clean (`getSwitchClean` readback). Key findings:

- `clean_mode: 2` is spot clean — the `room_list` field is silently ignored
- `clean_mode: 3` is selective room clean
- `room_list` is a plain `int[]` of room IDs (the pixel values used in the LZ4 map), not an array of objects
- `start_type: 1` is required

This was verified working on an RV30 Max Plus (EU) running firmware 1.3.2, documented in https://github.com/epg-pers/tapo-rv30-ha and discussed in #1592.

## Test plan

- All 48 existing + new tests pass against both RV20 and RV30 fixtures
- `test_clean_rooms` - verifies correct `setSwitchClean` payload with default map ID
- `test_clean_rooms_explicit_map_id` - verifies explicit `map_id` is used when provided
- `test_clean_rooms_empty_raises` - verifies `ValueError` on empty room list
- `test_get_rooms` / `test_get_rooms_explicit_map_id` - verifies `getMapData` call and room filtering