### PR TITLE
Fix mop set_waterlevel sending setCleanAttr without type field

### DIFF
--- a/kasa/smart/modules/mop.py
+++ b/kasa/smart/modules/mop.py
@@ -85,6 +85,7 @@ class Mop(SmartModule):
         if mode not in name_to_value:
             raise ValueError("Invalid waterlevel %s, available %s", mode, name_to_value)
 
-        settings = self._settings.copy()
-        settings["cistern"] = name_to_value[mode]
-        return await self.call("setCleanAttr", settings)
+        return await self.call(
+            "setCleanAttr",
+            {"cistern": name_to_value[mode], "type": "global"},
+        )

--- a/tests/smart/modules/test_mop.py
+++ b/tests/smart/modules/test_mop.py
@@ -45,10 +45,9 @@ async def test_mop_waterlevel(dev: SmartDevice, mocker: MockerFixture):
     new_level = Waterlevel.High
     await mop_module.set_waterlevel(new_level.name)
 
-    params = mop_module._settings.copy()
-    params["cistern"] = new_level.value
-
-    call.assert_called_with("setCleanAttr", params)
+    call.assert_called_with(
+        "setCleanAttr", {"cistern": new_level.value, "type": "global"}
+    )
 
     await dev.update()
 


### PR DESCRIPTION
Fixes https://github.com/python-kasa/python-kasa/issues/1666  by having set_waterlevel support an amended payload, and updating the test.