### PR TITLE
Add ENETUNREACH to non-retryable errors in XorTransport

### DIFF
--- a/kasa/transports/xortransport.py
+++ b/kasa/transports/xortransport.py
@@ -29,7 +29,12 @@ from kasa.json import loads as json_loads
 from .basetransport import BaseTransport
 
 _LOGGER = logging.getLogger(__name__)
-_NO_RETRY_ERRORS = {errno.EHOSTDOWN, errno.EHOSTUNREACH, errno.ECONNREFUSED}
+_NO_RETRY_ERRORS = {
+    errno.EHOSTDOWN,
+    errno.EHOSTUNREACH,
+    errno.ENETUNREACH,
+    errno.ECONNREFUSED,
+}
 _UNSIGNED_INT_NETWORK_ORDER = struct.Struct(">I")
 
 

--- a/tests/protocols/test_iotprotocol.py
+++ b/tests/protocols/test_iotprotocol.py
@@ -807,10 +807,17 @@ async def test_transport_credentials_hash_from_config(mocker, transport_class):
     [
         (ConnectionRefusedError("dummy exception"), False),
         (OSError(errno.EHOSTDOWN, os.strerror(errno.EHOSTDOWN)), False),
+        (OSError(errno.ENETUNREACH, os.strerror(errno.ENETUNREACH)), False),
         (OSError(errno.ECONNRESET, os.strerror(errno.ECONNRESET)), True),
         (Exception("dummy exception"), True),
     ],
-    ids=("ConnectionRefusedError", "OSErrorNoRetry", "OSErrorRetry", "Exception"),
+    ids=(
+        "ConnectionRefusedError",
+        "OSErrorHostDown",
+        "OSErrorNetUnreach",
+        "OSErrorRetry",
+        "Exception",
+    ),
 )
 @pytest.mark.parametrize(
     ("protocol_class", "transport_class"),


### PR DESCRIPTION
## Summary
- Add `errno.ENETUNREACH` (Network unreachable) to `_NO_RETRY_ERRORS` in `XorTransport`
- Add test case for ENETUNREACH in `test_protocol_will_retry_on_connect`

## Problem
When a device returns `ENETUNREACH` (errno 101, "Network unreachable"), the error is not in `_NO_RETRY_ERRORS` and is treated as a retryable `_RetryableError`. This causes python-kasa to retry the connection 3 additional times before giving up.

`ENETUNREACH` is semantically equivalent to `EHOSTUNREACH` (which is already in `_NO_RETRY_ERRORS`) — both indicate the destination cannot be reached at the network layer. Retrying immediately will not resolve the condition.

In containerized environments (e.g., Home Assistant running in Docker with bridge networking), a single ICMP "Network unreachable" response can temporarily poison the container's routing cache. The unnecessary retries reinforce the poisoned cache entry, causing cascading failures for other devices on the same subnet.

## Test plan
- Added `ENETUNREACH` to the parameterized `test_protocol_will_retry_on_connect` test
- Verified that `ENETUNREACH` results in a single connection attempt (no retries), matching behavior of `EHOSTDOWN`
- Full test suite passes (185/185)