### PR TITLE
Fix __repr__ crash when get_device_info returns SmartErrorCode

### DIFF
--- a/kasa/device.py
+++ b/kasa/device.py
@@ -509,10 +509,13 @@ class Device(ABC):
         update_needed = " - update() needed" if not self._last_update else ""
         if not self._last_update and not self._discovery_info:
             return f"<{self.device_type} at {self.host}{update_needed}>"
-        return (
-            f"<{self.device_type} at {self.host} -"
-            f" {self.alias} ({self.model}){update_needed}>"
-        )
+        try:
+            return (
+                f"<{self.device_type} at {self.host} -"
+                f" {self.alias} ({self.model}){update_needed}>"
+            )
+        except Exception:
+            return f"<{self.device_type} at {self.host}{update_needed}>"
 
     _deprecated_device_type_attributes = {
         # is_type

--- a/tests/smart/test_smartdevice.py
+++ b/tests/smart/test_smartdevice.py
@@ -1010,3 +1010,23 @@ async def test_unpair(dev: SmartDevice, mocker: MockerFixture):
     await unpair_feat.set_value(None)
 
     unpair_call.assert_called_with(child.device_id)
+
+
+@device_smart
+@pytest.mark.requires_dummy
+async def test_device_info_with_smarterrorcode(dev: SmartDevice):
+    """Test that __repr__ doesn't crash when get_device_info is a SmartErrorCode.
+
+    When a device returns INTERNAL_QUERY_ERROR for get_device_info, the response
+    is stored as a SmartErrorCode enum value instead of a dict. __repr__ accesses
+    .model which calls _get_device_info, and should not crash with
+    'SmartErrorCode object is not subscriptable'.
+
+    See https://github.com/python-kasa/python-kasa/issues/1671
+    """
+    # Simulate the device returning an error for get_device_info
+    dev._last_update["get_device_info"] = SmartErrorCode.INTERNAL_QUERY_ERROR
+
+    # __repr__ should not raise
+    result = repr(dev)
+    assert dev.host in result


### PR DESCRIPTION
## Summary

Make `__repr__` resilient so it never raises, following Python convention.

## Problem

When a device returns `INTERNAL_QUERY_ERROR` for `get_device_info`, the response is stored as a `SmartErrorCode` enum in `_last_update`. If another module then raises `DeviceError` and the error is logged with `%s` formatting, `__repr__` calls `self.model` → `device_info` → `_get_device_info`, which does `di["model"]` on the enum and crashes with:

```
TypeError: 'SmartErrorCode' object is not subscriptable
```

This creates a cascade of log spam since the logging error itself triggers more logging.

## Fix

Wrap the `__repr__` body in a try/except that falls back to a basic representation (device type + host) when alias/model access fails. `__repr__` should never raise per Python convention.

## Testing

Added `test_device_info_with_smarterrorcode` — injects `SmartErrorCode.INTERNAL_QUERY_ERROR` into `_last_update["get_device_info"]` and verifies `repr(dev)` does not raise.

Fixes #1671