### PR TITLE
Add C101 test fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Wall Switches**: S210, S220, S500, S500D, S505, S505D, TS15
 - **Bulbs**: L430C, L430P, L510B, L510E, L530B, L530E, L535E, L630
 - **Light Strips**: L900-10, L900-5, L920-5, L930-5
-- **Cameras**: C100, C110, C210, C220, C225, C325WB, C460, C520WS, C720, TC40, TC65, TC70
+- **Cameras**: C100, C101, C110, C210, C220, C225, C325WB, C460, C520WS, C720, TC40, TC65, TC70
 - **Doorbells and chimes**: D100C, D130, D230
 - **Vacuums**: RV20 Max Plus, RV30 Max
 - **Hubs**: H100, H200

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -300,6 +300,8 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
 
 - **C100**
   - Hardware: 4.0 / Firmware: 1.3.14
+- **C101**
+  - Hardware: 5.0 (US) / Firmware: 1.4.3
 - **C110**
   - Hardware: 2.0 (EU) / Firmware: 1.4.3
 - **C210**

--- a/tests/fixtures/smartcam/C101(US)_5.0_1.4.3.json
+++ b/tests/fixtures/smartcam/C101(US)_5.0_1.4.3.json
@@ -1,0 +1,1154 @@
+{
+    "discovery_result": {
+        "error_code": 0,
+        "result": {
+            "decrypted_data": {
+                "connect_ssid": "#MASKED_SSID#",
+                "connect_type": "wireless",
+                "device_id": "0000000000000000000000000000000000000000",
+                "http_port": 443,
+                "last_alarm_time": "0",
+                "last_alarm_type": "",
+                "owner": "00000000000000000000000000000000",
+                "sd_status": "offline"
+            },
+            "device_id": "00000000000000000000000000000000",
+            "device_model": "C101",
+            "device_name": "#MASKED_NAME#",
+            "device_type": "SMART.IPCAMERA",
+            "encrypt_info": {
+                "data": "",
+                "key": "",
+                "sym_schm": "AES"
+            },
+            "encrypt_type": [
+                "4"
+            ],
+            "factory_default": false,
+            "firmware_version": "1.4.3 Build 251128 Rel.63757n",
+            "hardware_version": "5.0",
+            "ip": "127.0.0.123",
+            "is_support_iot_cloud": true,
+            "mac": "98-03-8E-00-00-00",
+            "mgt_encrypt_schm": {
+                "is_support_https": true
+            },
+            "protocol_version": 1,
+            "sv": 1,
+            "tpap": {
+                "noc": 1,
+                "pake": [
+                    2
+                ],
+                "port": 443,
+                "tls": 1
+            }
+        }
+    },
+    "getAlertConfig": {
+        "msg_alarm": {
+            "capability": {
+                "alarm_duration_support": "1",
+                "alarm_volume_support": "1",
+                "alert_event_type_support": "1",
+                "usr_def_audio_alarm_max_num": "2",
+                "usr_def_audio_alarm_support": "1",
+                "usr_def_audio_max_duration": "15",
+                "usr_def_audio_type": "0",
+                "usr_def_start_file_id": "8195"
+            },
+            "chn1_msg_alarm_info": {
+                "alarm_duration": "0",
+                "alarm_mode": [
+                    "sound"
+                ],
+                "alarm_type": "0",
+                "alarm_volume": "normal",
+                "enabled": "off",
+                "light_alarm_enabled": "on",
+                "light_type": "0",
+                "sound_alarm_enabled": "on"
+            },
+            "usr_def_audio": []
+        }
+    },
+    "getAlertPlan": {
+        "msg_alarm_plan": {
+            "chn1_msg_alarm_plan": {
+                "alarm_plan_1": "0000-2359,127",
+                "enabled": "off"
+            }
+        }
+    },
+    "getAlertTypeList": {
+        "msg_alarm": {
+            "alert_type": {
+                "alert_type_list": [
+                    "Siren",
+                    "Emergency",
+                    "Red Alert"
+                ]
+            }
+        }
+    },
+    "getAppComponentList": {
+        "app_component": {
+            "app_component_list": [
+                {
+                    "name": "sdCard",
+                    "version": 1
+                },
+                {
+                    "name": "timezone",
+                    "version": 1
+                },
+                {
+                    "name": "system",
+                    "version": 3
+                },
+                {
+                    "name": "led",
+                    "version": 1
+                },
+                {
+                    "name": "detection",
+                    "version": 3
+                },
+                {
+                    "name": "alert",
+                    "version": 2
+                },
+                {
+                    "name": "firmware",
+                    "version": 2
+                },
+                {
+                    "name": "account",
+                    "version": 2
+                },
+                {
+                    "name": "quickSetup",
+                    "version": 1
+                },
+                {
+                    "name": "video",
+                    "version": 3
+                },
+                {
+                    "name": "lensMask",
+                    "version": 2
+                },
+                {
+                    "name": "lightFrequency",
+                    "version": 1
+                },
+                {
+                    "name": "dayNightMode",
+                    "version": 1
+                },
+                {
+                    "name": "osd",
+                    "version": 2
+                },
+                {
+                    "name": "record",
+                    "version": 1
+                },
+                {
+                    "name": "videoRotation",
+                    "version": 1
+                },
+                {
+                    "name": "audio",
+                    "version": 3
+                },
+                {
+                    "name": "diagnose",
+                    "version": 1
+                },
+                {
+                    "name": "msgPush",
+                    "version": 2
+                },
+                {
+                    "name": "deviceShare",
+                    "version": 1
+                },
+                {
+                    "name": "tamperDetection",
+                    "version": 1
+                },
+                {
+                    "name": "tapoCare",
+                    "version": 1
+                },
+                {
+                    "name": "blockZone",
+                    "version": 1
+                },
+                {
+                    "name": "personDetection",
+                    "version": 2
+                },
+                {
+                    "name": "babyCryDetection",
+                    "version": 1
+                },
+                {
+                    "name": "needSubscriptionServiceList",
+                    "version": 1
+                },
+                {
+                    "name": "nvmp",
+                    "version": 1
+                },
+                {
+                    "name": "detectionRegion",
+                    "version": 2
+                },
+                {
+                    "name": "recordDownload",
+                    "version": 1
+                },
+                {
+                    "name": "iotCloud",
+                    "version": 1
+                },
+                {
+                    "name": "playback",
+                    "version": 6
+                },
+                {
+                    "name": "upnpc",
+                    "version": 2
+                },
+                {
+                    "name": "staticIp",
+                    "version": 2
+                },
+                {
+                    "name": "timeFormat",
+                    "version": 1
+                },
+                {
+                    "name": "relayPreConnection",
+                    "version": 1
+                },
+                {
+                    "name": "hubManage",
+                    "version": 1
+                },
+                {
+                    "name": "streamCapability",
+                    "version": 1
+                },
+                {
+                    "name": "localCtrl",
+                    "version": 1
+                }
+            ]
+        }
+    },
+    "getAudioConfig": {
+        "audio_config": {
+            "microphone": {
+                "bitrate": "64",
+                "channels": "1",
+                "echo_cancelling": "off",
+                "encode_type": "G711alaw",
+                "input_device_type": "MicIn",
+                "mute": "off",
+                "noise_cancelling": "on",
+                "sampling_rate": "8",
+                "volume": "100"
+            },
+            "speaker": {
+                "mute": "off",
+                "output_device_type": "SpeakerOut",
+                "volume": "100"
+            }
+        }
+    },
+    "getBCDConfig": {
+        "sound_detection": {
+            "bcd": {
+                "digital_sensitivity": "50",
+                "enabled": "off",
+                "sensitivity": "medium"
+            }
+        }
+    },
+    "getCircularRecordingConfig": {
+        "harddisk_manage": {
+            "harddisk": {
+                "loop": "on"
+            }
+        }
+    },
+    "getClockStatus": {
+        "system": {
+            "clock_status": {
+                "local_time": "2026-03-13 18:49:34",
+                "seconds_from_1970": 1773445774
+            }
+        }
+    },
+    "getConnectionType": {
+        "link_type": "wifi",
+        "rssi": "4",
+        "rssiValue": -44,
+        "ssid": "I01BU0tFRF9TU0lEIw=="
+    },
+    "getDetectionConfig": {
+        "motion_detection": {
+            "motion_det": {
+                "digital_sensitivity": "80",
+                "enabled": "off",
+                "non_vehicle_enabled": "off",
+                "people_enabled": "off",
+                "sensitivity": "high",
+                "vehicle_enabled": "off"
+            }
+        }
+    },
+    "getDeviceInfo": {
+        "device_info": {
+            "basic_info": {
+                "avatar": "camera c100",
+                "barcode": "",
+                "dev_id": "0000000000000000000000000000000000000000",
+                "device_alias": "#MASKED_NAME#",
+                "device_info": "C101 5.0 IPC",
+                "device_model": "C101",
+                "device_name": "#MASKED_NAME#",
+                "device_type": "SMART.IPCAMERA",
+                "features": 3,
+                "ffs": false,
+                "has_set_location_info": 1,
+                "hw_desc": "00000000000000000000000000000000",
+                "hw_id": "00000000000000000000000000000000",
+                "hw_version": "5.0",
+                "is_cal": true,
+                "latitude": 0,
+                "longitude": 0,
+                "mac": "98-03-8E-00-00-00",
+                "manufacturer_name": "TP-Link",
+                "mobile_access": "0",
+                "no_rtsp_constrain": 1,
+                "oem_id": "00000000000000000000000000000000",
+                "region": "US",
+                "sw_version": "1.4.3 Build 251128 Rel.63757n"
+            }
+        }
+    },
+    "getFirmwareAutoUpgradeConfig": {
+        "auto_upgrade": {
+            "common": {
+                "enabled": "on",
+                "random_range": "120",
+                "time": "03:00"
+            }
+        }
+    },
+    "getFirmwareUpdateStatus": {
+        "cloud_config": {
+            "upgrade_status": {
+                "lastUpgradingSuccess": true,
+                "state": "normal"
+            }
+        }
+    },
+    "getLastAlarmInfo": {
+        "system": {
+            "last_alarm_info": {
+                "last_alarm_time": "0",
+                "last_alarm_type": ""
+            }
+        }
+    },
+    "getLdc": {
+        "image": {
+            "common": {
+                "area_compensation": "default",
+                "auto_exp_antiflicker": "off",
+                "auto_exp_gain_max": "0",
+                "backlight": "off",
+                "chroma": "50",
+                "contrast": "50",
+                "dehaze": "off",
+                "eis": "off",
+                "exp_gain": "0",
+                "exp_level": "0",
+                "exp_type": "auto",
+                "focus_limited": "10",
+                "focus_type": "manual",
+                "high_light_compensation": "off",
+                "inf_delay": "5",
+                "inf_end_time": "21600",
+                "inf_sensitivity": "4",
+                "inf_sensitivity_day2night": "1400",
+                "inf_sensitivity_night2day": "9100",
+                "inf_start_time": "64800",
+                "inf_type": "auto",
+                "iris_level": "160",
+                "light_freq_mode": "auto",
+                "lock_blue_colton": "0",
+                "lock_blue_gain": "0",
+                "lock_gb_gain": "0",
+                "lock_gr_gain": "0",
+                "lock_green_colton": "0",
+                "lock_red_colton": "0",
+                "lock_red_gain": "0",
+                "lock_source": "local",
+                "luma": "50",
+                "saturation": "50",
+                "sharpness": "50",
+                "shutter": "1/25",
+                "smartir": "auto_ir",
+                "smartir_level": "0",
+                "smartwtl": "auto_wtl",
+                "smartwtl_digital_level": "100",
+                "smartwtl_level": "5",
+                "style": "original",
+                "wb_B_gain": "50",
+                "wb_G_gain": "50",
+                "wb_R_gain": "50",
+                "wb_type": "auto",
+                "wd_gain": "50",
+                "wide_dynamic": "off",
+                "wtl_delay": "5",
+                "wtl_end_time": "21600",
+                "wtl_sensitivity": "4",
+                "wtl_sensitivity_day2night": "1400",
+                "wtl_sensitivity_night2day": "9100",
+                "wtl_start_time": "64800",
+                "wtl_type": "auto"
+            },
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "inf_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "3"
+            }
+        }
+    },
+    "getLedStatus": {
+        "led": {
+            "config": {
+                "enabled": "on"
+            }
+        }
+    },
+    "getLensMaskConfig": {
+        "lens_mask": {
+            "lens_mask_info": {
+                "enabled": "off"
+            }
+        }
+    },
+    "getLightFrequencyInfo": {
+        "image": {
+            "common": {
+                "area_compensation": "default",
+                "auto_exp_antiflicker": "off",
+                "auto_exp_gain_max": "0",
+                "backlight": "off",
+                "chroma": "50",
+                "contrast": "50",
+                "dehaze": "off",
+                "eis": "off",
+                "exp_gain": "0",
+                "exp_level": "0",
+                "exp_type": "auto",
+                "focus_limited": "10",
+                "focus_type": "manual",
+                "high_light_compensation": "off",
+                "inf_delay": "5",
+                "inf_end_time": "21600",
+                "inf_sensitivity": "4",
+                "inf_sensitivity_day2night": "1400",
+                "inf_sensitivity_night2day": "9100",
+                "inf_start_time": "64800",
+                "inf_type": "auto",
+                "iris_level": "160",
+                "light_freq_mode": "auto",
+                "lock_blue_colton": "0",
+                "lock_blue_gain": "0",
+                "lock_gb_gain": "0",
+                "lock_gr_gain": "0",
+                "lock_green_colton": "0",
+                "lock_red_colton": "0",
+                "lock_red_gain": "0",
+                "lock_source": "local",
+                "luma": "50",
+                "saturation": "50",
+                "sharpness": "50",
+                "shutter": "1/25",
+                "smartir": "auto_ir",
+                "smartir_level": "0",
+                "smartwtl": "auto_wtl",
+                "smartwtl_digital_level": "100",
+                "smartwtl_level": "5",
+                "style": "original",
+                "wb_B_gain": "50",
+                "wb_G_gain": "50",
+                "wb_R_gain": "50",
+                "wb_type": "auto",
+                "wd_gain": "50",
+                "wide_dynamic": "off",
+                "wtl_delay": "5",
+                "wtl_end_time": "21600",
+                "wtl_sensitivity": "4",
+                "wtl_sensitivity_day2night": "1400",
+                "wtl_sensitivity_night2day": "9100",
+                "wtl_start_time": "64800",
+                "wtl_type": "auto"
+            }
+        }
+    },
+    "getMediaEncrypt": {
+        "cet": {
+            "media_encrypt": {
+                "enabled": "off"
+            }
+        }
+    },
+    "getMsgPushConfig": {
+        "msg_push": {
+            "chn1_msg_push_info": {
+                "notification_enabled": "on",
+                "rich_notification_enabled": "on"
+            }
+        }
+    },
+    "getNightVisionCapability": {
+        "image_capability": {
+            "supplement_lamp": {
+                "night_vision_mode_range": [
+                    "inf_night_vision"
+                ],
+                "supplement_lamp_type": [
+                    "infrared_lamp"
+                ]
+            }
+        }
+    },
+    "getNightVisionModeConfig": {
+        "image": {
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "inf_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "3"
+            }
+        }
+    },
+    "getPersonDetectionConfig": {
+        "people_detection": {
+            "detection": {
+                "enabled": "on",
+                "sensitivity": "80"
+            }
+        }
+    },
+    "getRecordPlan": {
+        "record_plan": {
+            "chn1_channel": {
+                "enabled": "on",
+                "friday": "[\"0000-2400:2\"]",
+                "monday": "[\"0000-2400:2\"]",
+                "saturday": "[\"0000-2400:2\"]",
+                "sunday": "[\"0000-2400:2\"]",
+                "thursday": "[\"0000-2400:2\"]",
+                "tuesday": "[\"0000-2400:2\"]",
+                "wednesday": "[\"0000-2400:2\"]"
+            }
+        }
+    },
+    "getRotationStatus": {
+        "image": {
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "inf_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "3"
+            }
+        }
+    },
+    "getSdCardStatus": {
+        "harddisk_manage": {
+            "hd_info": [
+                {
+                    "hd_info_1": {
+                        "crossline_free_space": "0B",
+                        "crossline_free_space_accurate": "0B",
+                        "crossline_total_space": "0B",
+                        "crossline_total_space_accurate": "0B",
+                        "detect_status": "offline",
+                        "disk_name": "1",
+                        "free_space": "0B",
+                        "free_space_accurate": "0B",
+                        "loop_record_status": "0",
+                        "msg_push_free_space": "0B",
+                        "msg_push_free_space_accurate": "0B",
+                        "msg_push_total_space": "0B",
+                        "msg_push_total_space_accurate": "0B",
+                        "percent": "0",
+                        "picture_free_space": "0B",
+                        "picture_free_space_accurate": "0B",
+                        "picture_total_space": "0B",
+                        "picture_total_space_accurate": "0B",
+                        "record_duration": "0",
+                        "record_free_duration": "0",
+                        "record_start_time": "0",
+                        "rw_attr": "r",
+                        "status": "offline",
+                        "total_space": "0B",
+                        "total_space_accurate": "0B",
+                        "type": "local",
+                        "video_free_space": "0B",
+                        "video_free_space_accurate": "0B",
+                        "video_total_space": "0B",
+                        "video_total_space_accurate": "0B",
+                        "write_protect": "0"
+                    }
+                }
+            ]
+        }
+    },
+    "getTamperDetectionConfig": {
+        "tamper_detection": {
+            "tamper_det": {
+                "digital_sensitivity": "20",
+                "enabled": "off",
+                "sensitivity": "low"
+            }
+        }
+    },
+    "getTimezone": {
+        "system": {
+            "basic": {
+                "timezone": "UTC-06:00",
+                "timing_mode": "ntp",
+                "zone_id": "America/Chicago"
+            }
+        }
+    },
+    "getVideoCapability": {
+        "video_capability": {
+            "main": {
+                "bitrate_types": [
+                    "cbr",
+                    "vbr"
+                ],
+                "bitrates": [
+                    "256",
+                    "512",
+                    "1024",
+                    "1280",
+                    "2048"
+                ],
+                "change_fps_support": "1",
+                "encode_types": [
+                    "H264",
+                    "H265"
+                ],
+                "frame_rates": [
+                    "65551",
+                    "65556",
+                    "65561",
+                    "65566"
+                ],
+                "minor_stream_support": "1",
+                "qualitys": [
+                    "1",
+                    "3",
+                    "5"
+                ],
+                "resolutions": [
+                    "1920*1080",
+                    "1280*720",
+                    "640*360"
+                ]
+            }
+        }
+    },
+    "getVideoQualities": {
+        "video": {
+            "main": {
+                "bitrate": "1280",
+                "bitrate_type": "vbr",
+                "default_bitrate": "1024",
+                "encode_type": "H264",
+                "frame_rate": "65551",
+                "name": "VideoEncoder_1",
+                "quality": "5",
+                "resolution": "1920*1080",
+                "smart_codec": "off"
+            }
+        }
+    },
+    "getWhitelampConfig": {
+        "image": {
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "inf_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "3"
+            }
+        }
+    },
+    "getWhitelampStatus": {
+        "rest_time": 0,
+        "status": 0
+    },
+    "get_audio_capability": {
+        "get": {
+            "audio_capability": {
+                "device_microphone": {
+                    "aec": "1",
+                    "channels": "1",
+                    "echo_cancelling": "0",
+                    "encode_type": [
+                        "G711alaw"
+                    ],
+                    "half_duplex": "1",
+                    "mute": "1",
+                    "noise_cancelling": "1",
+                    "sampling_rate": [
+                        "8"
+                    ],
+                    "volume": "1"
+                },
+                "device_speaker": {
+                    "channels": "1",
+                    "decode_type": [
+                        "G711alaw",
+                        "G711ulaw"
+                    ],
+                    "mute": "0",
+                    "output_device_type": "0",
+                    "sampling_rate": [
+                        "8",
+                        "16"
+                    ],
+                    "system_volume": "100",
+                    "volume": "1"
+                }
+            }
+        }
+    },
+    "get_audio_config": {
+        "get": {
+            "audio_config": {
+                "microphone": {
+                    "bitrate": "64",
+                    "channels": "1",
+                    "echo_cancelling": "off",
+                    "encode_type": "G711alaw",
+                    "input_device_type": "MicIn",
+                    "mute": "off",
+                    "noise_cancelling": "on",
+                    "sampling_rate": "8",
+                    "volume": "100"
+                },
+                "speaker": {
+                    "mute": "off",
+                    "output_device_type": "SpeakerOut",
+                    "volume": "100"
+                }
+            }
+        }
+    },
+    "get_cet": {
+        "get": {
+            "cet": {
+                "vhttpd": {
+                    "port": "8800"
+                }
+            }
+        }
+    },
+    "get_function": {
+        "get": {
+            "function": {
+                "module_spec": {
+                    "ae_weighting_table_resolution": "5*5",
+                    "ai_enhance_capability": "1",
+                    "ai_enhance_range": [
+                        "traditional_enhance"
+                    ],
+                    "alarm_out_num": "0",
+                    "app_version": "1.0.0",
+                    "audio": [
+                        "speaker",
+                        "microphone"
+                    ],
+                    "auth_encrypt": "1",
+                    "auto_ip_configurable": "1",
+                    "backlight_coexistence": "1",
+                    "change_password": "1",
+                    "client_info": "1",
+                    "cloud_storage_version": "1.0",
+                    "config_recovery": [
+                        "audio_config",
+                        "image",
+                        "OSD",
+                        "video"
+                    ],
+                    "custom_area_compensation": "1",
+                    "daynight_subdivision": "1",
+                    "device_share": [
+                        "preview",
+                        "playback",
+                        "voice",
+                        "cloud_storage",
+                        "motor"
+                    ],
+                    "diagnose": "1",
+                    "diagnose_capability": "1",
+                    "download": [
+                        "video"
+                    ],
+                    "events": [
+                        "motion",
+                        "tamper"
+                    ],
+                    "greeter": "1.0",
+                    "http_system_state_audio_support": "1",
+                    "image_capability": "1",
+                    "image_list": [
+                        "supplement_lamp",
+                        "expose"
+                    ],
+                    "led": "1",
+                    "lens_mask": "1",
+                    "linkage_capability": "1",
+                    "local_storage": "1",
+                    "media_encrypt": "1",
+                    "msg_alarm_list": [
+                        "sound",
+                        "light"
+                    ],
+                    "msg_push": "1",
+                    "multi_user": "0",
+                    "network": [
+                        "wifi",
+                        "ethernet"
+                    ],
+                    "osd_capability": "1",
+                    "ota_upgrade": "1",
+                    "p2p_support_versions": [
+                        "2.0"
+                    ],
+                    "playback": [
+                        "local",
+                        "p2p",
+                        "relay"
+                    ],
+                    "playback_scale": "1",
+                    "playback_version": "1.1",
+                    "preview": [
+                        "local",
+                        "p2p",
+                        "relay"
+                    ],
+                    "privacy_mask_api_version": "1.0",
+                    "ptz": "1",
+                    "record_max_slot_cnt": "10",
+                    "record_type": [
+                        "timing",
+                        "motion"
+                    ],
+                    "relay_support_versions": [
+                        "2.0"
+                    ],
+                    "remote_upgrade": "1",
+                    "reonboarding": "1",
+                    "smart_codec": "0",
+                    "smart_detection": "1",
+                    "smart_msg_push_capability": "1",
+                    "ssl_cer_version": "1.0",
+                    "storage_api_version": "2.2",
+                    "stream_max_sessions": "10",
+                    "streaming_support_versions": [
+                        "2.0"
+                    ],
+                    "tapo_care_version": "1.0.0",
+                    "target_track": "1",
+                    "timing_reboot": "1",
+                    "tums": "1",
+                    "tums_config": "1",
+                    "tums_msg_push": "1",
+                    "verification_change_password": "1",
+                    "video_codec": [
+                        "h264",
+                        "h265"
+                    ],
+                    "video_detection_digital_sensitivity": "1",
+                    "video_message": "1",
+                    "wide_range_inf_sensitivity": "1",
+                    "wifi_cascade_connection": "0",
+                    "wifi_connection_info": "1",
+                    "wireless_hotspot": "0"
+                }
+            }
+        }
+    },
+    "scanApList": {
+        "onboarding": {
+            "scan": {
+                "ap_list": [
+                    {
+                        "auth": 0,
+                        "bssid": "000000000000",
+                        "encryption": 0,
+                        "rssi": 4,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 4,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 5,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 4,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 4,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 0,
+                        "bssid": "000000000000",
+                        "encryption": 0,
+                        "rssi": 4,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 0,
+                        "bssid": "000000000000",
+                        "encryption": 0,
+                        "rssi": 2,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 4,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 1,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 1,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 1,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 4,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 1,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 5,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 4,
+                        "bssid": "000000000000",
+                        "encryption": 3,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 3,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    },
+                    {
+                        "auth": 4,
+                        "bssid": "000000000000",
+                        "encryption": 2,
+                        "rssi": 0,
+                        "ssid": "I01BU0tFRF9TU0lEIw=="
+                    }
+                ],
+                "public_key": "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCXl67tCOTpn83kKtYzQIy6F6Q7\nsq5QBEeaO639zeE7eyNnh3ZA+PlCVsoICB7Gl1Yu/PmK0gfk3hujpcD4RO6TGIVU\n5C8jt7Hz8fgyzUJcKp3z+QUrf3oiLrOsRqzgieQdYkFh7LY9tQkzTkkxrJpmKmln\n3254L9dKKG3uqaEFXwIDAQAB\n-----END PUBLIC KEY-----\n",
+                "wpa3_supported": "false"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Include the C101 camera in documentation (README.md and SUPPORTED.md) and add a comprehensive test fixture at tests/fixtures/smartcam/C101(US)_5.0_1.4.3.json. The fixture contains discovery and API response data for the C101 (Hardware 5.0, Firmware 1.4.3, US) to enable unit/integration tests and validation of support.