### PR TITLE
Fix HS300 KLAP v2 direct connect

### DIFF
--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -104,8 +104,8 @@ async def _connect(config: DeviceConfig, protocol: BaseProtocol) -> Device:
     device_class: type[Device] | None
     device: Device | None = None
 
-    if isinstance(protocol, IotProtocol) and isinstance(
-        protocol._transport, XorTransport
+    if isinstance(protocol, IotProtocol) and not isinstance(
+        protocol._transport, LinkieTransportV2
     ):
         info = await protocol.query(GET_SYSINFO_QUERY)
         _perf_log(True, "get_sysinfo")
@@ -228,7 +228,6 @@ def get_protocol(config: DeviceConfig, *, strict: bool = False) -> BaseProtocol 
         str, tuple[type[BaseProtocol], type[BaseTransport]]
     ] = {
         "IOT.XOR": (IotProtocol, XorTransport),
-        "IOT.KLAP": (IotProtocol, KlapTransport),
         "SMART.AES": (SmartProtocol, AesTransport),
         "SMART.KLAP": (SmartProtocol, KlapTransportV2),
         "SMART.KLAP.HTTPS": (SmartProtocol, KlapTransportV2),
@@ -236,6 +235,12 @@ def get_protocol(config: DeviceConfig, *, strict: bool = False) -> BaseProtocol 
         # https to distuingish from SmartProtocol devices
         "SMART.AES.HTTPS": (SmartCamProtocol, SslAesTransport),
     }
+    if protocol_transport_key == "IOT.KLAP":
+        transport_cls: type[BaseTransport] = (
+            KlapTransportV2 if ctype.login_version == 2 else KlapTransport
+        )
+        return IotProtocol(transport=transport_cls(config=config))
+
     if not (prot_tran_cls := supported_device_protocols.get(protocol_transport_key)):
         return None
     protocol_cls, transport_cls = prot_tran_cls

--- a/tests/test_device_factory.py
+++ b/tests/test_device_factory.py
@@ -260,6 +260,12 @@ ET = DeviceEncryptionType
             id="iot-klap",
         ),
         pytest.param(
+            CP(DF.IotSmartPlugSwitch, ET.Klap, login_version=2, https=False),
+            IotProtocol,
+            KlapTransportV2,
+            id="iot-klap-lv2",
+        ),
+        pytest.param(
             CP(DF.IotSmartPlugSwitch, ET.Xor, https=False),
             IotProtocol,
             XorTransport,

--- a/tests/test_hs300_klap_lv2.py
+++ b/tests/test_hs300_klap_lv2.py
@@ -25,9 +25,7 @@ def _get_credentials_from_request(request) -> Credentials:
     password = request.config.getoption("--password") or os.environ.get("KASA_PASSWORD")
 
     if not username or not password:
-        pytest.skip(
-            "requires --username/--password or KASA_USERNAME/KASA_PASSWORD"
-        )
+        pytest.skip("requires --username/--password or KASA_USERNAME/KASA_PASSWORD")
 
     return Credentials(username=username, password=password)
 

--- a/tests/test_hs300_klap_lv2.py
+++ b/tests/test_hs300_klap_lv2.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from kasa import Credentials, IotProtocol
+from kasa.device_factory import connect
+from kasa.deviceconfig import (
+    DeviceConfig,
+    DeviceConnectionParameters,
+    DeviceEncryptionType,
+    DeviceFamily,
+)
+from kasa.iot import IotStrip
+from kasa.transports import KlapTransportV2
+
+from .conftest import load_fixture
+from .fakeprotocol_iot import FakeIotTransport
+
+
+def _get_credentials_from_request(request) -> Credentials:
+    username = request.config.getoption("--username") or os.environ.get("KASA_USERNAME")
+    password = request.config.getoption("--password") or os.environ.get("KASA_PASSWORD")
+
+    if not username or not password:
+        pytest.skip(
+            "requires --username/--password or KASA_USERNAME/KASA_PASSWORD"
+        )
+
+    return Credentials(username=username, password=password)
+
+
+@pytest.mark.requires_dummy
+async def test_hs300_iot_klap_lv2_connect_uses_strip_fixture(mocker):
+    """Verify direct connect uses KLAP v2 and creates an IotStrip for HS300."""
+    fixture_data = FakeIotTransport._build_fake_proto(
+        json.loads(load_fixture("iot", "HS300(US)_2.0_1.0.12.json"))
+    )
+    config = DeviceConfig(
+        host="127.0.0.123",
+        credentials=Credentials("dummy_user", "dummy_password"),
+        connection_type=DeviceConnectionParameters(
+            device_family=DeviceFamily.IotSmartPlugSwitch,
+            encryption_type=DeviceEncryptionType.Klap,
+            login_version=2,
+            http_port=80,
+        ),
+    )
+
+    async def _query(self, *_args, **_kwargs):
+        assert isinstance(self, IotProtocol)
+        assert isinstance(self._transport, KlapTransportV2)
+        return fixture_data
+
+    async def _update(self, *_args, **_kwargs):
+        return None
+
+    mocker.patch("kasa.IotProtocol.query", new=_query)
+    mocker.patch.object(IotStrip, "update", new=_update)
+
+    dev = await connect(config=config)
+    try:
+        assert isinstance(dev, IotStrip)
+        assert isinstance(dev.protocol, IotProtocol)
+        assert isinstance(dev.protocol._transport, KlapTransportV2)
+        assert dev.model == "HS300"
+        assert dev.port == 80
+        assert dev.sys_info["child_num"] == 6
+        assert dev.config.connection_type.login_version == 2
+    finally:
+        await dev.disconnect()
+
+
+async def test_hs300_iot_klap_lv2_direct_connect_real_device(request):
+    """Verify the explicit HS300 KLAP lv2 config reconnects correctly."""
+    ip = request.config.getoption("--ip")
+    if not ip:
+        pytest.skip("requires --ip to run against a real device")
+
+    credentials = _get_credentials_from_request(request)
+    config = DeviceConfig(
+        host=ip,
+        credentials=credentials,
+        timeout=10,
+        connection_type=DeviceConnectionParameters(
+            device_family=DeviceFamily.IotSmartPlugSwitch,
+            encryption_type=DeviceEncryptionType.Klap,
+            login_version=2,
+            http_port=80,
+        ),
+    )
+
+    dev = await connect(config=config)
+    try:
+        assert isinstance(dev, IotStrip)
+        assert isinstance(dev.protocol, IotProtocol)
+        assert isinstance(dev.protocol._transport, KlapTransportV2)
+        assert dev.model == "HS300"
+        assert dev.port == 80
+        assert len(dev.children) == 6
+        assert dev.config.connection_type.login_version == 2
+    finally:
+        await dev.disconnect()


### PR DESCRIPTION
## Summary

This fixes direct connection for HS300 devices that report `IOT.SMARTPLUGSWITCH` with `KLAP` and `login_version=2`.

Changes:
- select `KlapTransportV2` for `IOT.KLAP` devices when `login_version == 2`
- use `get_sysinfo`-based class detection for IOT direct-connect transports beyond XOR, so HS300 is created as `IotStrip` instead of `IotPlug`
- add focused coverage for the HS300 KLAP v2 direct-connect path

## Testing

Fixture-backed:
- `./.venv/bin/python -m pytest -q tests/test_hs300_klap_lv2.py -k strip_fixture`

Real hardware:
- `./.venv/bin/python -m pytest -q tests/test_hs300_klap_lv2.py --ip=<hs300-ip> -k real_device`

Additional targeted coverage:
- `./.venv/bin/python -m pytest -q -o addopts= tests/test_device_factory.py -k test_get_protocol`

## Notes

I was able to verify this against an HS300 that uses `KLAP` with `login_version=2`.

I could not test this against older HS300 variants that still use the older direct-connect path, since I do not have access to those devices.

I used Codex CLI to help trace the failure, inspect the local git history, and narrow the fix to the HS300 KLAP v2 direct-connect path.