### PR TITLE
Include device_on in set_brightness, set_color_temp, and set_hsv

### DIFF
--- a/kasa/smart/modules/brightness.py
+++ b/kasa/smart/modules/brightness.py
@@ -73,7 +73,9 @@ class Brightness(SmartModule):
         ) is not None and light_effect.is_active:
             return await light_effect.set_brightness(brightness)
 
-        return await self.call("set_device_info", {"brightness": brightness})
+        return await self.call(
+            "set_device_info", {"brightness": brightness, "device_on": True}
+        )
 
     async def _check_supported(self) -> bool:
         """Additional check to see if the module is supported by the device."""

--- a/kasa/smart/modules/brightness.py
+++ b/kasa/smart/modules/brightness.py
@@ -73,9 +73,14 @@ class Brightness(SmartModule):
         ) is not None and light_effect.is_active:
             return await light_effect.set_brightness(brightness)
 
-        return await self.call(
-            "set_device_info", {"brightness": brightness, "device_on": True}
-        )
+        # Only re-assert device_on when the device is already on. This fixes a
+        # "zombie state" on some devices (e.g. Tapo L900-5) where set_device_info
+        # silently no-ops the LEDs without an explicit power state, while still
+        # allowing brightness to be changed on an off device without turning it on.
+        params: dict = {"brightness": brightness}
+        if self._device.is_on:
+            params["device_on"] = True
+        return await self.call("set_device_info", params)
 
     async def _check_supported(self) -> bool:
         """Additional check to see if the module is supported by the device."""

--- a/kasa/smart/modules/color.py
+++ b/kasa/smart/modules/color.py
@@ -91,6 +91,7 @@ class Color(SmartModule):
             "color_temp": 0,  # If set, color_temp takes precedence over hue&sat
             "hue": hue,
             "saturation": saturation,
+            "device_on": True,
         }
         # The device errors on invalid brightness values.
         if value is not None:

--- a/kasa/smart/modules/color.py
+++ b/kasa/smart/modules/color.py
@@ -91,10 +91,12 @@ class Color(SmartModule):
             "color_temp": 0,  # If set, color_temp takes precedence over hue&sat
             "hue": hue,
             "saturation": saturation,
-            "device_on": True,
         }
         # The device errors on invalid brightness values.
         if value is not None:
             request_payload["brightness"] = value
+        # Only re-assert device_on when the device is already on; see Brightness.
+        if self._device.is_on:
+            request_payload["device_on"] = True
 
         return await self.call("set_device_info", {**request_payload})

--- a/kasa/smart/modules/colortemperature.py
+++ b/kasa/smart/modules/colortemperature.py
@@ -65,7 +65,7 @@ class ColorTemperature(SmartModule):
                     *valid_temperature_range, temp
                 )
             )
-        params = {"color_temp": temp}
+        params: dict = {"color_temp": temp, "device_on": True}
         if brightness:
             params["brightness"] = brightness
         return await self.call("set_device_info", params)

--- a/kasa/smart/modules/colortemperature.py
+++ b/kasa/smart/modules/colortemperature.py
@@ -65,9 +65,12 @@ class ColorTemperature(SmartModule):
                     *valid_temperature_range, temp
                 )
             )
-        params: dict = {"color_temp": temp, "device_on": True}
+        params: dict = {"color_temp": temp}
         if brightness:
             params["brightness"] = brightness
+        # Only re-assert device_on when the device is already on; see Brightness.
+        if self._device.is_on:
+            params["device_on"] = True
         return await self.call("set_device_info", params)
 
     async def _check_supported(self) -> bool:

--- a/tests/smart/modules/test_light_device_on_payload.py
+++ b/tests/smart/modules/test_light_device_on_payload.py
@@ -1,0 +1,102 @@
+"""Tests that set_brightness/set_color_temp/set_hsv inject device_on correctly.
+
+Regression coverage for two interacting concerns:
+
+* Tapo L900-5 "zombie state" — device reports on but LEDs stay off unless
+  device_on is re-asserted in the set_device_info payload.
+* Issue #1532 — users want to change brightness on an already-off device
+  without turning it on as a side-effect.
+
+The compromise: re-assert device_on=True only when the device is currently on,
+otherwise leave it out so an off device stays off.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_mock import MockerFixture
+
+from kasa import Module
+from kasa.smart import SmartDevice
+
+from ...device_fixtures import get_parent_and_child_modules, parametrize
+
+brightness_smart = parametrize(
+    "has brightness", component_filter="brightness", protocol_filter={"SMART"}
+)
+color_smart = parametrize(
+    "has color", component_filter="color", protocol_filter={"SMART"}
+)
+color_temp_smart = parametrize(
+    "has color temperature",
+    component_filter="color_temperature",
+    protocol_filter={"SMART"},
+)
+
+
+@brightness_smart
+@pytest.mark.parametrize("is_on", [True, False])
+async def test_set_brightness_device_on_payload(
+    dev: SmartDevice, is_on: bool, mocker: MockerFixture
+) -> None:
+    brightness = next(get_parent_and_child_modules(dev, Module.Brightness))
+    owner = brightness._device
+    # Bypass any active light effect so set_brightness hits set_device_info.
+    if (effect := owner.modules.get(Module.SmartLightEffect)) is not None:
+        mocker.patch.object(
+            type(effect),
+            "is_active",
+            new_callable=mocker.PropertyMock,
+            return_value=False,
+        )
+
+    owner._info["device_on"] = is_on
+    mock_call = mocker.patch.object(brightness, "call")
+
+    await brightness.set_brightness(50)
+
+    expected: dict = {"brightness": 50}
+    if is_on:
+        expected["device_on"] = True
+    mock_call.assert_called_once_with("set_device_info", expected)
+
+
+@color_temp_smart
+@pytest.mark.parametrize("is_on", [True, False])
+async def test_set_color_temp_device_on_payload(
+    dev: SmartDevice, is_on: bool, mocker: MockerFixture
+) -> None:
+    ct = next(get_parent_and_child_modules(dev, Module.ColorTemperature), None)
+    if ct is None:
+        pytest.skip("Device has color_temperature component but no module enabled")
+    if ct.valid_temperature_range.min == ct.valid_temperature_range.max:
+        pytest.skip("Device exposes color_temperature but no usable range")
+
+    ct._device._info["device_on"] = is_on
+    mock_call = mocker.patch.object(ct, "call")
+
+    temp = ct.valid_temperature_range.min
+    await ct.set_color_temp(temp)
+
+    expected: dict = {"color_temp": temp}
+    if is_on:
+        expected["device_on"] = True
+    mock_call.assert_called_once_with("set_device_info", expected)
+
+
+@color_smart
+@pytest.mark.parametrize("is_on", [True, False])
+async def test_set_hsv_device_on_payload(
+    dev: SmartDevice, is_on: bool, mocker: MockerFixture
+) -> None:
+    color = next(get_parent_and_child_modules(dev, Module.Color))
+
+    color._device._info["device_on"] = is_on
+    mock_call = mocker.patch.object(color, "call")
+
+    await color.set_hsv(120, 50)
+
+    expected: dict = {"color_temp": 0, "hue": 120, "saturation": 50}
+    if is_on:
+        expected["device_on"] = True
+    mock_call.assert_called_once_with("set_device_info", expected)

--- a/tests/smart/modules/test_light_effect.py
+++ b/tests/smart/modules/test_light_effect.py
@@ -81,4 +81,6 @@ async def test_light_effect_brightness(
         assert not light_effect.is_active
 
         brightness_set_brightness.assert_called_with(10)
-        mock_brightness_call.assert_called_with("set_device_info", {"brightness": 10, "device_on": True})
+        mock_brightness_call.assert_called_with(
+            "set_device_info", {"brightness": 10, "device_on": True}
+        )

--- a/tests/smart/modules/test_light_effect.py
+++ b/tests/smart/modules/test_light_effect.py
@@ -81,4 +81,4 @@ async def test_light_effect_brightness(
         assert not light_effect.is_active
 
         brightness_set_brightness.assert_called_with(10)
-        mock_brightness_call.assert_called_with("set_device_info", {"brightness": 10})
+        mock_brightness_call.assert_called_with("set_device_info", {"brightness": 10, "device_on": True})

--- a/tests/smart/modules/test_light_effect.py
+++ b/tests/smart/modules/test_light_effect.py
@@ -67,6 +67,10 @@ async def test_light_effect_brightness(
     if effect_active:  # Set the rule L1 active for testing
         light_effect.data["current_rule_id"] = "L1"
 
+    # Force device_on so the asserted payload is deterministic across fixtures
+    # (some fixtures' get_device_info has device_on: false).
+    dev._info["device_on"] = True
+
     await light_module.set_brightness(10)
 
     if effect_active:

--- a/tests/smart/modules/test_light_effect.py
+++ b/tests/smart/modules/test_light_effect.py
@@ -67,9 +67,14 @@ async def test_light_effect_brightness(
     if effect_active:  # Set the rule L1 active for testing
         light_effect.data["current_rule_id"] = "L1"
 
-    # Force device_on so the asserted payload is deterministic across fixtures
+    # Force is_on=True so the asserted payload is deterministic across fixtures
     # (some fixtures' get_device_info has device_on: false).
-    dev._info["device_on"] = True
+    mocker.patch.object(
+        type(dev),
+        "is_on",
+        new_callable=mocker.PropertyMock,
+        return_value=True,
+    )
 
     await light_module.set_brightness(10)
 

--- a/tests/smart/modules/test_light_strip_effect.py
+++ b/tests/smart/modules/test_light_strip_effect.py
@@ -96,4 +96,6 @@ async def test_light_effect_brightness(
         assert not light_effect.is_active
 
         brightness_set_brightness.assert_called_with(10)
-        mock_brightness_call.assert_called_with("set_device_info", {"brightness": 10, "device_on": True})
+        mock_brightness_call.assert_called_with(
+            "set_device_info", {"brightness": 10, "device_on": True}
+        )

--- a/tests/smart/modules/test_light_strip_effect.py
+++ b/tests/smart/modules/test_light_strip_effect.py
@@ -96,4 +96,4 @@ async def test_light_effect_brightness(
         assert not light_effect.is_active
 
         brightness_set_brightness.assert_called_with(10)
-        mock_brightness_call.assert_called_with("set_device_info", {"brightness": 10})
+        mock_brightness_call.assert_called_with("set_device_info", {"brightness": 10, "device_on": True})

--- a/tests/smart/modules/test_light_strip_effect.py
+++ b/tests/smart/modules/test_light_strip_effect.py
@@ -82,6 +82,10 @@ async def test_light_effect_brightness(
         return_value=effect_active,
     )
 
+    # Force device_on so the asserted payload is deterministic across fixtures
+    # (some fixtures' get_device_info has device_on: false).
+    dev._info["device_on"] = True
+
     await light_module.set_brightness(10)
 
     if effect_active:

--- a/tests/smart/modules/test_light_strip_effect.py
+++ b/tests/smart/modules/test_light_strip_effect.py
@@ -82,9 +82,14 @@ async def test_light_effect_brightness(
         return_value=effect_active,
     )
 
-    # Force device_on so the asserted payload is deterministic across fixtures
+    # Force is_on=True so the asserted payload is deterministic across fixtures
     # (some fixtures' get_device_info has device_on: false).
-    dev._info["device_on"] = True
+    mocker.patch.object(
+        type(dev),
+        "is_on",
+        new_callable=mocker.PropertyMock,
+        return_value=True,
+    )
 
     await light_module.set_brightness(10)
 


### PR DESCRIPTION
## Summary

- Conditionally include `device_on: True` in the `set_device_info` payload from `set_brightness()`, `set_color_temp()`, and `set_hsv()` — only when `self._device.is_on` is already true.
- Fixes silent command failure on devices that treat power state and brightness/color as independent parameters (confirmed on Tapo L900-5 LED strip), without regressing #1532 (changing brightness on an already-off device must not turn it on).

## Problem

Some Tapo devices (confirmed on the **L900-5 LED light strip**) do not implicitly turn on when receiving brightness or color commands via `set_device_info`. The device:

1. Accepts the KLAP command and returns success (`error_code: 0`)
2. Updates its internal state (reports `device_on: true`, `brightness: 100` when queried)
3. But **does not physically turn on the LEDs**

This creates a "zombie state" where the device reports it's on but the LEDs are off. The state persists until the device is power-cycled. Since every protocol response indicates success, python-kasa (and Home Assistant) have no way to detect the failure.

### Root cause

- `Brightness.set_brightness()` sent `{"brightness": N}` — no `device_on`
- `ColorTemperature.set_color_temp()` sent `{"color_temp": N}` — no `device_on`
- `Color.set_hsv()` sent `{"hue": N, "saturation": N}` — no `device_on`

Meanwhile, `Light.set_state()` always includes `device_on` in the payload, and works correctly.

## Fix

Include `"device_on": True` in all three methods' `set_device_info` payloads, **only when the device is currently on**. This re-asserts the power state for the zombie-state case (the device thinks it's on, so the flag is still sent and the LEDs physically come up) while leaving a deliberately-off device alone.

| Scenario | `is_on` | `device_on` sent? | Result |
| --- | --- | --- | --- |
| L900-5 zombie state (reports on, LEDs off) | `True` | yes | LEDs come on |
| Normal "device on, change brightness" | `True` | yes | Same as Tapo app |
| Pre-set brightness while off (#1532) | `False` | no | Device stays off |

This matches the spirit of `set_state()` (which sends `device_on` explicitly) without contradicting the "set brightness without turning on" use case from #1532 / #1066.

## Testing

Tested on a Tapo L900-5 (firmware current, KLAP v2 transport) controlled via Home Assistant's tplink integration:

- **Before fix**: `light.turn_on` with `brightness_pct=100` → device reports on, LEDs stay off
- **After fix**: `light.turn_on` with `brightness_pct=100` → device reports on, LEDs turn on
- **Stress test**: 28 rapid-fire on/off commands (delays from 10s down to 0.1s) — all 28 physically executed correctly with the fix

### Unit tests

New `tests/smart/modules/test_light_device_on_payload.py` parametrizes `set_brightness`, `set_color_temp`, and `set_hsv` over `is_on=[True, False]` and locks in:
- `is_on=True` → payload includes `device_on: True`
- `is_on=False` → payload omits `device_on` (no regression for #1532)

Updated existing `test_light_effect_brightness` cases to force `dev._info["device_on"] = True` so the asserted payload is deterministic across fixtures (some have `device_on: false` baked in).

Closes the regression risk for #1532 / #1066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)