### PR TITLE
tests: centralize transport and session cleanup in conftest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
 import sys
 import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import aiohttp
 import pytest
 
 # TODO: this and runner fixture could be moved to tests/cli/conftest.py
@@ -16,6 +18,7 @@ from kasa import (
     DeviceConfig,
     SmartProtocol,
 )
+from kasa.httpclient import HttpClient
 from kasa.transports.basetransport import BaseTransport
 
 from .device_fixtures import *  # noqa: F403
@@ -24,6 +27,45 @@ from .fixtureinfo import fixture_info  # noqa: F401
 
 # Parametrize tests to run with device both on and off
 turn_on = pytest.mark.parametrize("turn_on", [True, False])
+
+
+@pytest.fixture(autouse=True)
+async def _close_transport_and_http_sessions(monkeypatch):
+    """Ensure all transports and http clients close their sessions after tests."""
+    transports: list[BaseTransport] = []
+    http_clients: list[HttpClient] = []
+    aiohttp_sessions: list[aiohttp.ClientSession] = []
+
+    original_transport_init = BaseTransport.__init__
+    original_http_init = HttpClient.__init__
+    original_session_init = aiohttp.ClientSession.__init__
+
+    @functools.wraps(original_transport_init)
+    def _track_transport(self, *args, **kwargs):
+        original_transport_init(self, *args, **kwargs)
+        transports.append(self)
+
+    @functools.wraps(original_http_init)
+    def _track_http(self, *args, **kwargs):
+        original_http_init(self, *args, **kwargs)
+        http_clients.append(self)
+
+    @functools.wraps(original_session_init)
+    def _track_session(self, *args, **kwargs):
+        original_session_init(self, *args, **kwargs)
+        aiohttp_sessions.append(self)
+
+    monkeypatch.setattr(BaseTransport, "__init__", _track_transport)
+    monkeypatch.setattr(HttpClient, "__init__", _track_http)
+    monkeypatch.setattr(aiohttp.ClientSession, "__init__", _track_session)
+    yield
+    for transport in transports:
+        await transport.close()
+    for client in http_clients:
+        await client.close()
+    for session in aiohttp_sessions:
+        if not session.closed:
+            await session.close()
 
 
 def load_fixture(foldername, filename):

--- a/tests/transports/test_klaptransport.py
+++ b/tests/transports/test_klaptransport.py
@@ -411,7 +411,6 @@ async def test_handshake(
 
     config = DeviceConfig("127.0.0.1", credentials=client_credentials)
     protocol = IotProtocol(transport=transport_class(config=config))
-    protocol._transport.http_client = aiohttp.ClientSession()
 
     response_status = 200
     await protocol._transport.perform_handshake()


### PR DESCRIPTION
## Summary

Add a centralized autouse fixture in `tests/conftest.py` that automatically tracks and cleans up all `BaseTransport`, `HttpClient`, and `aiohttp.ClientSession` instances created during tests. This prevents resource leaks (unclosed sessions/transports) from polluting test output with warnings.

### Changes

**`tests/conftest.py`** — New `_close_transport_and_http_sessions` autouse fixture:
- Monkeypatches `BaseTransport.__init__`, `HttpClient.__init__`, and `aiohttp.ClientSession.__init__` to track all created instances
- After each test, closes all tracked transports, HTTP clients, and aiohttp sessions
- Covers all 6 transport types via the single `BaseTransport` patch point (all call `super().__init__()`)
- Catches leaks from tests that create sessions without explicit cleanup (9 raw `aiohttp.ClientSession()` calls across `test_deviceconfig.py`, `test_discovery.py`, `test_device_factory.py`, and transport tests)

**`tests/transports/test_klaptransport.py`** — Remove dead code:
- Removed `protocol._transport.http_client = aiohttp.ClientSession()` in `test_handshake` — this set a nonexistent attribute (the transport uses `_http_client`, not `http_client`), creating a dangling session that was never used

### Files changed (2)

`tests/conftest.py`, `tests/transports/test_klaptransport.py`

### Merge order

This is **PR 4 of 9** in the test modernization series. Must merge before #1684 and #1688 (which modify conflicting lines in the same files).

| Order | PR | Scope |
|-------|-----|-------|
| 1 | #1677 | Tests: cleanup and fixes |
| 2 | #1681 | CI: pin GitHub Actions to SHA |
| 3 | #1682 | Docs: modernize docstrings |
| **4** | **#1683** | **Tests: centralize session cleanup** |
| 5 | #1684 | Tests: transport type annotations |
| 6 | #1685 | Tests: IoT type annotations |
| 7 | #1686 | Tests: Smart type annotations |
| 8 | #1687 | Tests: CLI/protocols/smartcam type annotations |
| 9 | #1688 | Tests: top-level type annotations |

> **Merge note:** #1684 touches `test_klaptransport.py` in the same area (splits protocol creation into a local `transport` variable). Merging #1683 first avoids a trivial context conflict — take #1684's version which completely supersedes the affected lines.

### Verification

- 3,581 tests pass across all affected test files
- All pre-commit hooks pass
- Full test suite passes after sequential merge of all 9 PRs (10,656 passed, 194 skipped)