### PR TITLE
Fix IOT KLAPv2 transport selection and class detection

### DIFF
--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -104,9 +104,10 @@ async def _connect(config: DeviceConfig, protocol: BaseProtocol) -> Device:
     device_class: type[Device] | None
     device: Device | None = None
 
-    if isinstance(protocol, IotProtocol) and isinstance(
-        protocol._transport, XorTransport
-    ):
+    if isinstance(protocol, IotProtocol) and config.connection_type.device_family in {
+        DeviceFamily.IotSmartPlugSwitch,
+        DeviceFamily.IotSmartBulb,
+    }:
         info = await protocol.query(GET_SYSINFO_QUERY)
         _perf_log(True, "get_sysinfo")
         device_class = get_device_class_from_sys_info(info)
@@ -215,6 +216,19 @@ def get_protocol(config: DeviceConfig, *, strict: bool = False) -> BaseProtocol 
         and ctype.encryption_type is DeviceEncryptionType.Aes
     ):
         return SmartProtocol(transport=SslTransport(config=config))
+
+    # Some IOT devices advertise KLAP with login_version >= 2 and require
+    # KlapTransportV2 despite using an IOT device family.
+    if (
+        ctype.device_family
+        in {
+            DeviceFamily.IotSmartPlugSwitch,
+            DeviceFamily.IotSmartBulb,
+        }
+        and ctype.encryption_type is DeviceEncryptionType.Klap
+        and (ctype.login_version or 1) >= 2
+    ):
+        return IotProtocol(transport=KlapTransportV2(config=config))
 
     protocol_transport_key = (
         protocol_name

--- a/tests/test_device_factory.py
+++ b/tests/test_device_factory.py
@@ -37,6 +37,7 @@ from kasa.deviceconfig import (
     DeviceFamily,
 )
 from kasa.discover import DiscoveryResult
+from kasa.iot import IotPlug, IotStrip
 from kasa.transports import (
     AesTransport,
     BaseTransport,
@@ -260,6 +261,12 @@ ET = DeviceEncryptionType
             id="iot-klap",
         ),
         pytest.param(
+            CP(DF.IotSmartPlugSwitch, ET.Klap, login_version=2, https=False),
+            IotProtocol,
+            KlapTransportV2,
+            id="iot-klap-lv2",
+        ),
+        pytest.param(
             CP(DF.IotSmartPlugSwitch, ET.Xor, https=False),
             IotProtocol,
             XorTransport,
@@ -295,3 +302,41 @@ async def test_get_protocol(
     protocol = get_protocol(config)
     assert isinstance(protocol, expected_protocol)
     assert isinstance(protocol._transport, expected_transport)
+
+
+async def test_connect_iot_klap_uses_sysinfo_for_device_class(mocker):
+    """IOT KLAP devices should derive class from sysinfo (e.g. strip vs plug)."""
+    host = DISCOVERY_MOCK_IP
+    config = DeviceConfig(
+        host=host,
+        credentials=Credentials("user@example.com", "password"),
+        connection_type=CP(
+            DF.IotSmartPlugSwitch,
+            ET.Klap,
+            login_version=2,
+            https=False,
+            http_port=80,
+        ),
+    )
+    query_mock = mocker.patch.object(
+        IotProtocol,
+        "query",
+        return_value={
+            "system": {
+                "get_sysinfo": {
+                    "type": "IOT.SMARTPLUGSWITCH",
+                    "model": "HS300(US)",
+                    "children": [],
+                }
+            }
+        },
+    )
+    strip_update = mocker.patch.object(IotStrip, "update")
+    plug_update = mocker.patch.object(IotPlug, "update")
+
+    dev = await connect(config=config)
+
+    assert isinstance(dev, IotStrip)
+    assert query_mock.await_count == 1
+    assert strip_update.await_count == 1
+    assert plug_update.await_count == 0


### PR DESCRIPTION
## Summary

This PR fixes two related regressions for IOT KLAP devices on newer firmware:

1. **Transport selection**: Use `KlapTransportV2` for IOT KLAP devices when `login_version >= 2`.
2. **Device class detection**: For IOT plug/switch and bulb families, derive class from `system.get_sysinfo` during `connect()` (not family-only mapping), so strips are correctly instantiated as `IotStrip` instead of `IotPlug`.

## Why

- #1648 tracks IOT KLAP v2 auth failures caused by selecting `KlapTransport` for devices that require v2.
- #1691 tracks IOT KLAP misclassification where strips lose child outlets because `_connect()` only used sysinfo-based class detection for XOR.

## Tests

- Added `iot-klap-lv2` coverage in `test_get_protocol` to assert `KlapTransportV2` for login v2.
- Added `test_connect_iot_klap_uses_sysinfo_for_device_class` to ensure KLAP strips are identified from sysinfo and not misclassified as plugs.
