### PR TITLE
Expose params field on TriggerLogs LogEntry

### DIFF
--- a/kasa/smart/modules/triggerlogs.py
+++ b/kasa/smart/modules/triggerlogs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Any
 
 from mashumaro import DataClassDictMixin
 from mashumaro.types import Alias
@@ -19,6 +19,7 @@ class LogEntry(DataClassDictMixin):
     event_id: Annotated[str, Alias("eventId")]
     timestamp: int
     event: str
+    params: dict[str, Any] | None = None
 
 
 class TriggerLogs(SmartModule):


### PR DESCRIPTION
The S200B (Smart Button / dial) emits rotation events whose direction and magnitude live in `params.rotate_deg` (signed int, positive = clockwise, negative = anti-clockwise, magnitude in degrees). Today `LogEntry` strips the `params` field on parse, so callers can detect that a rotation happened but not which way.

Add an optional `params: dict[str, Any] | None` field with default None. Fully backwards compatible (existing callers unaffected; events without params get None).

Verified on a Tapo H100 firmware 1.6.1 with an S200B child: captured 9 events across `singleClick` and `rotation` types with the field exposed; `params.rotate_deg` populated for every rotation, absent for singleClick.

Helps #1117.