### PR TITLE
Add segment effect support for RGBIC light strips

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -296,6 +296,7 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
   - Hardware: 1.0 (US) / Firmware: 1.1.3
 - **L930-5**
   - Hardware: 1.0 (EU) / Firmware: 1.2.5
+  - Hardware: 1.0 (EU) / Firmware: 1.4.3
   - Hardware: 1.0 (US) / Firmware: 1.1.2
 
 ### Cameras

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -146,6 +146,7 @@ class Module(ABC):
         "LightEffect"
     )
     IotLightEffect: Final[ModuleName[iot.LightEffect]] = ModuleName("LightEffect")
+    SegmentEffect: Final[ModuleName[smart.SegmentEffect]] = ModuleName("SegmentEffect")
     TemperatureSensor: Final[ModuleName[smart.TemperatureSensor]] = ModuleName(
         "TemperatureSensor"
     )

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -36,6 +36,7 @@ from .motionsensor import MotionSensor
 from .overheatprotection import OverheatProtection
 from .powerprotection import PowerProtection
 from .reportmode import ReportMode
+from .segmenteffect import SegmentEffect
 from .speaker import Speaker
 from .temperaturecontrol import TemperatureControl
 from .temperaturesensor import TemperatureSensor
@@ -81,6 +82,7 @@ __all__ = [
     "Consumables",
     "CleanRecords",
     "SmartLightEffect",
+    "SegmentEffect",
     "PowerProtection",
     "OverheatProtection",
     "Speaker",

--- a/kasa/smart/modules/segmenteffect.py
+++ b/kasa/smart/modules/segmenteffect.py
@@ -1,0 +1,181 @@
+"""Module for RGBIC light-strip per-segment effects (Tapo app "segment" effects).
+
+DRAFT for python-kasa (target: kasa/smart/modules/segmenteffect.py).
+Implements the `segment_effect` SMART component used by RGBIC strips such as the
+Tapo L930 for the per-segment custom effects you create in the Tapo app
+(breathe / circulating / chasing / flicker / bloom / stacking).
+
+These are a SEPARATE subsystem from `lighting_effect` (handled by LightStripEffect):
+they are activated with the `apply_segment_effect_rule` method, not
+`set_lighting_effect`. Verified against a live L930 and the reverse-engineered
+`SegmentEffect` schema in the mihai-dinculescu/tapo library.
+
+COEXISTENCE NOTE
+----------------
+`LightStripEffect` renames itself to "LightEffect" assuming a device supports only
+one effect system. RGBIC strips expose BOTH `light_strip_lighting_effect` and
+`segment_effect`, so this module keeps its own name ("SegmentEffect") to avoid the
+clash. Surfacing it in Home Assistant requires either exposing it as a second
+effect source (e.g. a dedicated select) or unifying the two effect lists upstream.
+
+WIRING (to register the module):
+    * add `from .segmenteffect import SegmentEffect` and `"SegmentEffect"` to
+      kasa/smart/modules/__init__.py
+    * add `SegmentEffect: Final[ModuleName[...]] = ModuleName("SegmentEffect")`
+      to the Module container in kasa/module.py
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..smartmodule import SmartModule, allow_update_after
+
+
+class SegmentEffect(SmartModule):
+    """Per-segment dynamic light effects for RGBIC strips."""
+
+    REQUIRED_COMPONENT = "segment_effect"
+
+    OFF = "Off"
+
+    def query(self) -> dict:
+        """Fetch the currently active segment effect rule.
+
+        The saved-effect list comes from `get_preset_rules`, which is already
+        fetched by the LightPreset module (REQUIRED_COMPONENT="preset"); we reuse
+        it instead of issuing a duplicate query.
+        """
+        return {"get_segment_effect_rule": None}
+
+    # --- helpers -----------------------------------------------------------
+
+    @property
+    def _active_rule(self) -> dict[str, Any]:
+        # Single-key queries are unwrapped by SmartModule.data, so this is the
+        # get_segment_effect_rule payload directly.
+        rule = self.data
+        return rule if isinstance(rule, dict) else {}
+
+    @property
+    def _preset_states(self) -> list[dict[str, Any]]:
+        # Reuse get_preset_rules fetched by the LightPreset module.
+        preset_rules = self._device._last_update.get("get_preset_rules") or {}
+        return preset_rules.get("states") or []
+
+    def _custom_effects(self) -> dict[str, dict[str, Any]]:
+        """Map name -> stored segment_effect rule, for saved custom effects."""
+        effects: dict[str, dict[str, Any]] = {}
+        for state in self._preset_states:
+            if not isinstance(state, dict):
+                continue
+            rule = state.get("segment_effect")
+            if isinstance(rule, dict) and rule.get("custom") and rule.get("name"):
+                effects[rule["name"]] = rule
+        return effects
+
+    @staticmethod
+    def _build_payload(
+        rule: dict[str, Any], *, enable: bool, brightness: int | None = None
+    ) -> dict[str, Any]:
+        """Build the apply_segment_effect_rule payload from a stored rule.
+
+        `deviceType: "strip"` is required for custom effects, and `speed` must be
+        included or the firmware resets it to 0 (no animation).
+        """
+        states = rule.get("states") or []
+        payload: dict[str, Any] = {
+            "brightness": brightness
+            if brightness is not None
+            else rule.get("brightness", 100),
+            "custom": 1,
+            "deviceType": "strip",
+            "display_colors": rule.get("display_colors") or states,
+            "enable": 1 if enable else 0,
+            "id": rule.get("id", ""),
+            "name": rule.get("name", "Custom"),
+            "segments": rule.get("segments") or [],
+            "states": states,
+            "type": rule.get("type", "breathe"),
+        }
+        if rule.get("speed") is not None:
+            payload["speed"] = rule["speed"]
+        if rule.get("carousel") is not None:
+            payload["carousel"] = rule["carousel"]
+        return payload
+
+    # --- LightEffect-like interface ---------------------------------------
+
+    @property
+    def has_custom_effects(self) -> bool:
+        """Return True if the device supports setting custom effects."""
+        return True
+
+    @property
+    def effect_list(self) -> list[str]:
+        """Return the saved custom segment effects (plus an Off entry)."""
+        return [self.OFF, *self._custom_effects()]
+
+    @property
+    def effect(self) -> str:
+        """Return the name of the active segment effect, or Off."""
+        rule = self._active_rule
+        if rule.get("enable") and rule.get("name"):
+            return rule["name"]
+        return self.OFF
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether a segment effect is currently running."""
+        return bool(self._active_rule.get("enable"))
+
+    @property
+    def brightness(self) -> int:
+        """Return the active effect brightness."""
+        return self._active_rule.get("brightness", 0)
+
+    @allow_update_after
+    async def set_effect(
+        self,
+        effect: str,
+        *,
+        brightness: int | None = None,
+        transition: int | None = None,
+    ) -> dict:
+        """Activate a saved segment effect by name, or Off to disable it."""
+        if effect == self.OFF:
+            return await self._disable()
+        effects = self._custom_effects()
+        if effect not in effects:
+            raise ValueError(f"Unknown segment effect: {effect}")
+        payload = self._build_payload(
+            effects[effect], enable=True, brightness=brightness
+        )
+        return await self.call("apply_segment_effect_rule", payload)
+
+    @allow_update_after
+    async def set_custom_effect(self, effect_dict: dict) -> dict:
+        """Apply a fully-specified segment effect rule."""
+        payload = self._build_payload(
+            effect_dict, enable=bool(effect_dict.get("enable", 1))
+        )
+        return await self.call("apply_segment_effect_rule", payload)
+
+    @allow_update_after
+    async def set_brightness(
+        self, brightness: int, *, transition: int | None = None
+    ) -> dict:
+        """Adjust brightness of the running segment effect."""
+        rule = self._active_rule
+        if not rule.get("enable"):
+            return {}
+        payload = self._build_payload(rule, enable=True, brightness=brightness)
+        return await self.call("apply_segment_effect_rule", payload)
+
+    async def _disable(self) -> dict:
+        rule = dict(self._active_rule)
+        if not rule.get("enable"):
+            return {}
+        rule["enable"] = 0
+        rule.setdefault("deviceType", "strip")
+        return await self.call("apply_segment_effect_rule", rule)

--- a/kasa/smart/modules/segmenteffect.py
+++ b/kasa/smart/modules/segmenteffect.py
@@ -3,12 +3,28 @@
 DRAFT for python-kasa (target: kasa/smart/modules/segmenteffect.py).
 Implements the `segment_effect` SMART component used by RGBIC strips such as the
 Tapo L930 for the per-segment custom effects you create in the Tapo app
-(breathe / circulating / chasing / flicker / bloom / stacking).
+(breathe / circulating / chasing / flicker / bloom / stacking / none).
 
 These are a SEPARATE subsystem from `lighting_effect` (handled by LightStripEffect):
 they are activated with the `apply_segment_effect_rule` method, not
 `set_lighting_effect`. Verified against a live L930 and the reverse-engineered
-`SegmentEffect` schema in the mihai-dinculescu/tapo library.
+`SegmentEffect` schema in the mihai-dinculescu/tapo library, cross-checked with
+the Tapo Android app v3.18.506 (`SegmentEffectData` bean).
+
+EFFECT TYPES AND RANGES (SegmentEffectData @SerializedName/@IntRange)
+--------------------------------------------------------------------
+* type: one of breathe, circulating, chasing, stacking, flicker, bloom, none.
+* brightness: 1-100.
+* speed: 1-10 for the six animated types; 0 only for the static "none" paint
+  (speed 0 freezes an animated type, so it is rejected for those).
+* per-segment colours (`states` / `display_colors`) are 4 integers [h, s, v, w];
+  the 4th channel is 0 in every rule the app writes. `apply_segment_effect_rule`
+  tolerates 3-int [h, s, v], but `start_segment_effect_test` rejects them with
+  PARAMS_ERROR(-1008), so colours are normalised to 4 ints here.
+* `segments` is DUAL-ENCODED by type: for the six animated types it holds group
+  SIZES (states[i] colours group i, e.g. [50] = one group spanning all LEDs);
+  for the static "none" paint it holds explicit LED INDICES (states[i] colours
+  the LED at segments[i], unlisted LEDs stay off).
 
 COEXISTENCE NOTE
 ----------------
@@ -30,6 +46,52 @@ from __future__ import annotations
 from typing import Any
 
 from ..smartmodule import SmartModule, allow_update_after
+
+#: Valid segment_effect types (Tapo app v3.18.506 SegmentEffectData decompile).
+SEGMENT_EFFECT_TYPES = frozenset(
+    {"breathe", "circulating", "chasing", "stacking", "flicker", "bloom", "none"}
+)
+BRIGHTNESS_MIN = 1
+BRIGHTNESS_MAX = 100
+SPEED_MIN = 1
+SPEED_MAX = 10
+
+
+def _clamp(value: int, low: int, high: int) -> int:
+    return max(low, min(high, int(value)))
+
+
+def _normalize_colors(colors: list[Any]) -> list[list[int]]:
+    """Normalise per-segment colours to the device's 4-int [h, s, v, w] form.
+
+    Pads 3-int [h, s, v] to [h, s, v, 0] and drops malformed entries. Required by
+    start_segment_effect_test, which rejects 3-int colours with PARAMS_ERROR.
+    """
+    normalised: list[list[int]] = []
+    for color in colors:
+        if not isinstance(color, list | tuple) or len(color) < 3:
+            continue
+        ints = [int(c) for c in color][:4]
+        ints += [0] * (4 - len(ints))
+        normalised.append(ints)
+    return normalised
+
+
+def _dedupe(colors: list[list[int]]) -> list[list[int]]:
+    """Return the unique palette, preserving order.
+
+    `display_colors` must be the deduplicated palette; the firmware rejects a
+    list with duplicate/oversized entries (PARAMS_ERROR -1008).
+    """
+    seen: set[tuple[int, ...]] = set()
+    palette: list[list[int]] = []
+    for color in colors:
+        key = tuple(color)
+        if key in seen:
+            continue
+        seen.add(key)
+        palette.append(color)
+    return palette
 
 
 class SegmentEffect(SmartModule):
@@ -78,28 +140,45 @@ class SegmentEffect(SmartModule):
     def _build_payload(
         rule: dict[str, Any], *, enable: bool, brightness: int | None = None
     ) -> dict[str, Any]:
-        """Build the apply_segment_effect_rule payload from a stored rule.
+        """Build the apply_segment_effect_rule / *_test payload from a rule.
 
         `deviceType: "strip"` is required for custom effects, and `speed` must be
-        included or the firmware resets it to 0 (no animation).
+        included or the firmware resets it to 0 (no animation). Per-segment
+        colours are normalised to the device's 4-int [h, s, v, w] form,
+        `display_colors` is reduced to the unique palette, and brightness/speed
+        are clamped to their documented ranges.
+
+        The `segments` field is dual-encoded by `type`: group SIZES for the six
+        animated types, explicit LED INDICES for the static "none" paint (see the
+        module docstring).
         """
-        states = rule.get("states") or []
+        effect_type = rule.get("type", "breathe")
+        if effect_type not in SEGMENT_EFFECT_TYPES:
+            raise ValueError(
+                f"Invalid segment effect type {effect_type!r}; "
+                f"expected one of {sorted(SEGMENT_EFFECT_TYPES)}"
+            )
+        bri = brightness if brightness is not None else rule.get("brightness", 100)
+        states = _normalize_colors(rule.get("states") or [])
+        display = rule.get("display_colors")
+        display_colors = _dedupe(_normalize_colors(display) if display else states)
         payload: dict[str, Any] = {
-            "brightness": brightness
-            if brightness is not None
-            else rule.get("brightness", 100),
+            "brightness": _clamp(bri, BRIGHTNESS_MIN, BRIGHTNESS_MAX),
             "custom": 1,
             "deviceType": "strip",
-            "display_colors": rule.get("display_colors") or states,
+            "display_colors": display_colors,
             "enable": 1 if enable else 0,
             "id": rule.get("id", ""),
             "name": rule.get("name", "Custom"),
             "segments": rule.get("segments") or [],
             "states": states,
-            "type": rule.get("type", "breathe"),
+            "type": effect_type,
         }
-        if rule.get("speed") is not None:
-            payload["speed"] = rule["speed"]
+        speed = rule.get("speed")
+        if speed is not None:
+            # speed 0 is valid only for the static "none" paint.
+            speed_min = 0 if effect_type == "none" else SPEED_MIN
+            payload["speed"] = _clamp(speed, speed_min, SPEED_MAX)
         if rule.get("carousel") is not None:
             payload["carousel"] = rule["carousel"]
         return payload
@@ -160,6 +239,23 @@ class SegmentEffect(SmartModule):
             effect_dict, enable=bool(effect_dict.get("enable", 1))
         )
         return await self.call("apply_segment_effect_rule", payload)
+
+    async def test(self, effect_dict: dict) -> dict:
+        """Preview a segment effect rule live without saving it.
+
+        Uses start_segment_effect_test, which plays the rule but does NOT write
+        it into the device preset table. This avoids the churn where saving an
+        effect makes the firmware (and the Tapo app) rewrite the preset list and
+        evict effects no longer present. Call stop_test() to end the preview.
+        """
+        payload = self._build_payload(
+            effect_dict, enable=bool(effect_dict.get("enable", 1))
+        )
+        return await self.call("start_segment_effect_test", payload)
+
+    async def stop_test(self) -> dict:
+        """Stop a live segment effect preview started with test()."""
+        return await self.call("stop_segment_effect_test", {})
 
     @allow_update_after
     async def set_brightness(

--- a/tests/fakeprotocol_smart.py
+++ b/tests/fakeprotocol_smart.py
@@ -516,6 +516,23 @@ class FakeSmartTransport(BaseTransport):
             info["get_device_info"]["lighting_effect"]["id"] = params["id"]
             info["get_lighting_effect"] = copy.deepcopy(params)
 
+    def _apply_segment_effect_rule(self, info, params):
+        """Set or remove values as per the device behaviour."""
+        if "get_segment_effect_rule" in info:
+            info["get_segment_effect_rule"] = copy.deepcopy(params)
+        segment_effect = info.get("get_device_info", {}).get("segment_effect")
+        if isinstance(segment_effect, dict):
+            for key in (
+                "id",
+                "name",
+                "custom",
+                "enable",
+                "brightness",
+                "display_colors",
+            ):
+                if key in params:
+                    segment_effect[key] = params[key]
+
     def _set_led_info(self, info, params):
         """Set or remove values as per the device behaviour."""
         info["get_led_info"]["led_status"] = params["led_rule"] != "never"
@@ -680,6 +697,9 @@ class FakeSmartTransport(BaseTransport):
             return {"error_code": 0}
         elif method == "set_lighting_effect":
             self._set_light_strip_effect(info, params)
+            return {"error_code": 0}
+        elif method == "apply_segment_effect_rule":
+            self._apply_segment_effect_rule(info, params)
             return {"error_code": 0}
         elif method == "set_led_info":
             self._set_led_info(info, params)

--- a/tests/fixtures/smart/L930-5(EU)_1.0_1.4.3.json
+++ b/tests/fixtures/smart/L930-5(EU)_1.0_1.4.3.json
@@ -1,0 +1,701 @@
+{
+    "component_nego": {
+        "component_list": [
+            {
+                "id": "device",
+                "ver_code": 2
+            },
+            {
+                "id": "light_strip",
+                "ver_code": 1
+            },
+            {
+                "id": "light_strip_lighting_effect",
+                "ver_code": 2
+            },
+            {
+                "id": "firmware",
+                "ver_code": 2
+            },
+            {
+                "id": "quick_setup",
+                "ver_code": 3
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "time",
+                "ver_code": 1
+            },
+            {
+                "id": "wireless",
+                "ver_code": 1
+            },
+            {
+                "id": "schedule",
+                "ver_code": 2
+            },
+            {
+                "id": "countdown",
+                "ver_code": 2
+            },
+            {
+                "id": "antitheft",
+                "ver_code": 1
+            },
+            {
+                "id": "account",
+                "ver_code": 1
+            },
+            {
+                "id": "synchronize",
+                "ver_code": 1
+            },
+            {
+                "id": "sunrise_sunset",
+                "ver_code": 1
+            },
+            {
+                "id": "brightness",
+                "ver_code": 1
+            },
+            {
+                "id": "cloud_connect",
+                "ver_code": 1
+            },
+            {
+                "id": "color_temperature",
+                "ver_code": 1
+            },
+            {
+                "id": "default_states",
+                "ver_code": 1
+            },
+            {
+                "id": "preset",
+                "ver_code": 3
+            },
+            {
+                "id": "color",
+                "ver_code": 1
+            },
+            {
+                "id": "on_off_gradually",
+                "ver_code": 4
+            },
+            {
+                "id": "device_local_time",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "music_rhythm",
+                "ver_code": 3
+            },
+            {
+                "id": "bulb_quick_control",
+                "ver_code": 1
+            },
+            {
+                "id": "localSmart",
+                "ver_code": 1
+            },
+            {
+                "id": "homekit",
+                "ver_code": 2
+            },
+            {
+                "id": "segment",
+                "ver_code": 1
+            },
+            {
+                "id": "segment_effect",
+                "ver_code": 2
+            },
+            {
+                "id": "music_rhythm_v2",
+                "ver_code": 4
+            },
+            {
+                "id": "auto_light",
+                "ver_code": 1
+            },
+            {
+                "id": "tpap",
+                "ver_code": 1
+            }
+        ]
+    },
+    "discovery_result": {
+        "error_code": 0,
+        "result": {
+            "device_id": "00000000000000000000000000000000",
+            "device_model": "L930-5(EU)",
+            "device_type": "SMART.TAPOBULB",
+            "factory_default": false,
+            "ip": "127.0.0.123",
+            "is_support_iot_cloud": true,
+            "mac": "78-8C-B5-00-00-00",
+            "mgt_encrypt_schm": {
+                "encrypt_type": "KLAP",
+                "http_port": 80,
+                "is_support_https": false,
+                "lv": 2
+            },
+            "obd_src": "apple",
+            "owner": "00000000000000000000000000000000",
+            "protocol_version": 1
+        }
+    },
+    "get_antitheft_rules": {
+        "antitheft_rule_max_count": 1,
+        "enable": false,
+        "rule_list": []
+    },
+    "get_auto_light_info": {
+        "enable": false,
+        "mode": "light_track"
+    },
+    "get_auto_update_info": {
+        "enable": true,
+        "random_range": 120,
+        "time": 180
+    },
+    "get_connect_cloud_state": {
+        "status": 0
+    },
+    "get_countdown_rules": {
+        "countdown_rule_max_count": 1,
+        "enable": false,
+        "rule_list": []
+    },
+    "get_device_info": {
+        "avatar": "light_strip",
+        "brightness": 100,
+        "color_temp": 0,
+        "color_temp_range": [
+            2500,
+            6500
+        ],
+        "default_states": {
+            "state": {
+                "segment_effect": {
+                    "brightness": 100,
+                    "carousel": 1,
+                    "custom": 1,
+                    "display_colors": [
+                        [
+                            40,
+                            100,
+                            100,
+                            0
+                        ],
+                        [
+                            60,
+                            100,
+                            100,
+                            0
+                        ]
+                    ],
+                    "enable": 1,
+                    "id": "TapoStrip_08Flh317MG1LiaQQHODnwV",
+                    "name": "Effetto 70",
+                    "segments": [
+                        50
+                    ],
+                    "speed": 5,
+                    "states": [
+                        [
+                            40,
+                            100,
+                            100,
+                            0
+                        ],
+                        [
+                            60,
+                            100,
+                            100,
+                            0
+                        ]
+                    ],
+                    "type": "stacking"
+                }
+            },
+            "type": "last_states"
+        },
+        "device_id": "0000000000000000000000000000000000000000",
+        "device_on": true,
+        "fw_id": "00000000000000000000000000000000",
+        "fw_ver": "1.4.3 Build 260430 Rel.163123",
+        "has_set_location_info": true,
+        "hue": 0,
+        "hw_id": "00000000000000000000000000000000",
+        "hw_ver": "1.0",
+        "ip": "127.0.0.123",
+        "lang": "it_IT",
+        "latitude": 0,
+        "lighting_effect": {
+            "brightness": 100,
+            "custom": 0,
+            "display_colors": [
+                [
+                    120,
+                    100,
+                    100
+                ],
+                [
+                    240,
+                    100,
+                    100
+                ],
+                [
+                    260,
+                    100,
+                    100
+                ],
+                [
+                    280,
+                    100,
+                    100
+                ]
+            ],
+            "enable": 0,
+            "id": "TapoStrip_1MClvV18i15Jq3bvJVf0eP",
+            "name": "Aurora"
+        },
+        "longitude": 0,
+        "mac": "B8-FB-B3-00-00-00",
+        "model": "L930",
+        "music_rhythm_enable": false,
+        "music_rhythm_mode": "single_lamp",
+        "nickname": "I01BU0tFRF9OQU1FIw==",
+        "oem_id": "00000000000000000000000000000000",
+        "overheated": false,
+        "region": "Europe/Rome",
+        "rssi": -37,
+        "saturation": 0,
+        "segment_effect": {
+            "brightness": 100,
+            "custom": 1,
+            "display_colors": [
+                [
+                    40,
+                    100,
+                    100,
+                    0
+                ],
+                [
+                    60,
+                    100,
+                    100,
+                    0
+                ]
+            ],
+            "enable": 0,
+            "id": "TapoStrip_08Flh317MG1LiaQQHODnwV",
+            "name": "Effetto 70"
+        },
+        "signal_level": 3,
+        "specs": "",
+        "ssid": "I01BU0tFRF9TU0lEIw==",
+        "time_diff": 60,
+        "type": "SMART.TAPOBULB"
+    },
+    "get_device_segment": {
+        "segment": 50
+    },
+    "get_device_time": {
+        "region": "Europe/Rome",
+        "time_diff": 60,
+        "timestamp": 1780035338
+    },
+    "get_device_usage": {
+        "power_usage": {
+            "past30": 64,
+            "past30_mwh": 64206,
+            "past7": 64,
+            "past7_mwh": 64206,
+            "today": 6,
+            "today_mwh": 5640
+        },
+        "saved_power": {
+            "past30": 397,
+            "past30_mwh": 396794,
+            "past7": 397,
+            "past7_mwh": 396794,
+            "today": 52,
+            "today_mwh": 52360
+        },
+        "time_usage": {
+            "past30": 461,
+            "past7": 461,
+            "today": 58
+        }
+    },
+    "get_fw_download_state": {
+        "auto_upgrade": false,
+        "download_progress": 0,
+        "reboot_time": 5,
+        "status": 0,
+        "upgrade_time": 5
+    },
+    "get_homekit_info": {
+        "mfi_setup_code": "000-00-000",
+        "mfi_setup_id": "0000",
+        "mfi_token_token": "0000000000000000000000000000000000000000000000000000000000000+000000000/00000000000000000000000000/0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000+000/000000==",
+        "mfi_token_uuid": "00000000-0000-0000-0000-000000000000"
+    },
+    "get_inherit_info": {
+        "inherit_status": false
+    },
+    "get_latest_fw": {
+        "fw_size": 0,
+        "fw_ver": "1.4.3 Build 260430 Rel.163123",
+        "hw_id": "",
+        "need_to_upgrade": false,
+        "oem_id": "",
+        "release_date": "",
+        "release_note": "",
+        "type": 0
+    },
+    "get_lighting_effect": {
+        "brightness": 100,
+        "custom": 0,
+        "direction": 4,
+        "display_colors": [
+            [
+                120,
+                100,
+                100
+            ],
+            [
+                240,
+                100,
+                100
+            ],
+            [
+                260,
+                100,
+                100
+            ],
+            [
+                280,
+                100,
+                100
+            ]
+        ],
+        "duration": 0,
+        "enable": 0,
+        "expansion_strategy": 1,
+        "id": "TapoStrip_1MClvV18i15Jq3bvJVf0eP",
+        "name": "Aurora",
+        "repeat_times": 0,
+        "segments": [
+            0
+        ],
+        "sequence": [
+            [
+                120,
+                100,
+                100
+            ],
+            [
+                240,
+                100,
+                100
+            ],
+            [
+                260,
+                100,
+                100
+            ],
+            [
+                280,
+                100,
+                100
+            ]
+        ],
+        "spread": 7,
+        "transition": 1500,
+        "type": "sequence"
+    },
+    "get_next_event": {},
+    "get_on_off_gradually_info": {
+        "change_state": {
+            "enable": false
+        },
+        "off_state": {
+            "duration": 1,
+            "enable": true,
+            "max_duration": 60
+        },
+        "on_state": {
+            "duration": 1,
+            "enable": true,
+            "max_duration": 60
+        }
+    },
+    "get_preset_rules": {
+        "start_index": 0,
+        "states": [
+            {
+                "brightness": 50,
+                "color_temp": 4500,
+                "hue": 0,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 240,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 0,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 120,
+                "saturation": 100
+            },
+            {
+                "brightness": 100,
+                "color_temp": 0,
+                "hue": 277,
+                "saturation": 86
+            },
+            {
+                "segment_effect": {
+                    "brightness": 100,
+                    "carousel": 0,
+                    "custom": 1,
+                    "display_colors": [
+                        [
+                            10,
+                            89,
+                            100,
+                            0
+                        ]
+                    ],
+                    "enable": 1,
+                    "id": "TapoStrip_0zN3DaZ2jbK3r5lwrArpUr",
+                    "name": "Rosso pulse",
+                    "segments": [
+                        50
+                    ],
+                    "speed": 10,
+                    "states": [
+                        [
+                            10,
+                            89,
+                            100,
+                            0
+                        ]
+                    ],
+                    "type": "breathe"
+                }
+            },
+            {
+                "segment_effect": {
+                    "brightness": 100,
+                    "carousel": 1,
+                    "custom": 1,
+                    "display_colors": [
+                        [
+                            40,
+                            100,
+                            100,
+                            0
+                        ],
+                        [
+                            60,
+                            100,
+                            100,
+                            0
+                        ]
+                    ],
+                    "enable": 1,
+                    "id": "TapoStrip_08Flh317MG1LiaQQHODnwV",
+                    "name": "Effetto 70",
+                    "segments": [
+                        50
+                    ],
+                    "speed": 5,
+                    "states": [
+                        [
+                            40,
+                            100,
+                            100,
+                            0
+                        ],
+                        [
+                            60,
+                            100,
+                            100,
+                            0
+                        ]
+                    ],
+                    "type": "stacking"
+                }
+            }
+        ],
+        "sum": 7
+    },
+    "get_schedule_rules": {
+        "enable": false,
+        "rule_list": [],
+        "schedule_rule_max_count": 32,
+        "start_index": 0,
+        "sum": 0
+    },
+    "get_segment_effect_rule": {
+        "brightness": 100,
+        "carousel": 1,
+        "custom": 1,
+        "display_colors": [
+            [
+                40,
+                100,
+                100,
+                0
+            ],
+            [
+                60,
+                100,
+                100,
+                0
+            ]
+        ],
+        "enable": 0,
+        "id": "TapoStrip_08Flh317MG1LiaQQHODnwV",
+        "name": "Effetto 70",
+        "segments": [
+            50
+        ],
+        "speed": 5,
+        "states": [
+            [
+                40,
+                100,
+                100,
+                0
+            ],
+            [
+                60,
+                100,
+                100,
+                0
+            ]
+        ],
+        "type": "stacking"
+    },
+    "get_wireless_scan_info": {
+        "ap_list": [
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 3,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "bssid": "000000000000",
+                "channel": 0,
+                "cipher_type": 2,
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            }
+        ],
+        "start_index": 0,
+        "sum": 8,
+        "wep_supported": false
+    },
+    "qs_component_nego": {
+        "component_list": [
+            {
+                "id": "quick_setup",
+                "ver_code": 3
+            },
+            {
+                "id": "sunrise_sunset",
+                "ver_code": 1
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "firmware",
+                "ver_code": 2
+            }
+        ],
+        "extra_info": {
+            "device_model": "L930",
+            "device_type": "SMART.TAPOBULB",
+            "is_klap": true
+        }
+    }
+}

--- a/tests/smart/modules/test_segment_effect.py
+++ b/tests/smart/modules/test_segment_effect.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import pytest
+from pytest_mock import MockerFixture
+
+from kasa import Device, Module
+from kasa.smart.modules import SegmentEffect
+
+from ...device_fixtures import parametrize
+
+segment_effect = parametrize(
+    "has segment effect",
+    component_filter="segment_effect",
+    protocol_filter={"SMART"},
+)
+
+
+@segment_effect
+async def test_segment_effect_list(dev: Device) -> None:
+    """Saved custom segment effects are listed with a leading Off entry."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    assert segment.effect_list
+    assert segment.effect_list[0] == SegmentEffect.OFF
+
+
+@segment_effect
+async def test_segment_effect_set(dev: Device, mocker: MockerFixture) -> None:
+    """Activating a saved effect sends apply_segment_effect_rule and reads back."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    custom = [e for e in segment.effect_list if e != SegmentEffect.OFF]
+    if not custom:
+        pytest.skip("fixture has no saved custom segment effects")
+
+    call = mocker.spy(segment, "call")
+
+    for effect in custom:
+        await segment.set_effect(effect)
+
+        method, payload = call.call_args[0]
+        assert method == "apply_segment_effect_rule"
+        assert payload["name"] == effect
+        assert payload["enable"] == 1
+        assert payload["custom"] == 1
+        assert payload["deviceType"] == "strip"
+        assert "type" in payload
+
+        await dev.update()
+        assert segment.effect == effect
+        assert segment.is_active
+
+    # Off disables the running effect.
+    await segment.set_effect(SegmentEffect.OFF)
+    method, payload = call.call_args[0]
+    assert method == "apply_segment_effect_rule"
+    assert payload["enable"] == 0
+
+    await dev.update()
+    assert segment.effect == SegmentEffect.OFF
+    assert not segment.is_active
+
+
+@segment_effect
+async def test_segment_effect_unknown(dev: Device) -> None:
+    """Setting an unknown effect raises."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    with pytest.raises(ValueError, match="Unknown segment effect"):
+        await segment.set_effect("foobar")

--- a/tests/smart/modules/test_segment_effect.py
+++ b/tests/smart/modules/test_segment_effect.py
@@ -71,3 +71,121 @@ async def test_segment_effect_unknown(dev: Device) -> None:
 
     with pytest.raises(ValueError, match="Unknown segment effect"):
         await segment.set_effect("foobar")
+
+
+@segment_effect
+async def test_segment_effect_properties(dev: Device) -> None:
+    """Module exposes custom-effect capability and brightness."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    assert segment.has_custom_effects is True
+    assert isinstance(segment.brightness, int)
+
+
+@segment_effect
+async def test_segment_set_custom_effect(dev: Device, mocker: MockerFixture) -> None:
+    """A fully-specified rule is sent verbatim; speed/carousel are optional."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+    call = mocker.spy(segment, "call")
+
+    await segment.set_custom_effect(
+        {
+            "id": "TapoStrip_test",
+            "name": "Custom test",
+            "type": "breathe",
+            "segments": [50],
+            "states": [[10, 89, 100, 0]],
+            "brightness": 50,
+            "speed": 8,
+            "carousel": 1,
+            "enable": 1,
+        }
+    )
+    method, payload = call.call_args[0]
+    assert method == "apply_segment_effect_rule"
+    assert payload["deviceType"] == "strip"
+    assert payload["speed"] == 8
+    assert payload["carousel"] == 1
+    assert payload["enable"] == 1
+
+    # A minimal rule omits speed/carousel rather than sending them as defaults.
+    await segment.set_custom_effect(
+        {
+            "id": "TapoStrip_min",
+            "name": "Minimal",
+            "type": "bloom",
+            "segments": [0],
+            "states": [[0, 0, 100, 0]],
+        }
+    )
+    _, minimal = call.call_args[0]
+    assert "speed" not in minimal
+    assert "carousel" not in minimal
+
+
+@segment_effect
+async def test_segment_set_brightness(dev: Device, mocker: MockerFixture) -> None:
+    """set_brightness updates a running effect and is a no-op when idle."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    custom = [e for e in segment.effect_list if e != SegmentEffect.OFF]
+    if not custom:
+        pytest.skip("fixture has no saved custom segment effects")
+
+    await segment.set_effect(custom[0])
+    await dev.update()
+
+    call = mocker.spy(segment, "call")
+    await segment.set_brightness(42)
+    method, payload = call.call_args[0]
+    assert method == "apply_segment_effect_rule"
+    assert payload["brightness"] == 42
+    assert payload["enable"] == 1
+
+    # Once disabled, set_brightness does nothing.
+    await segment.set_effect(SegmentEffect.OFF)
+    await dev.update()
+    call.reset_mock()
+    assert await segment.set_brightness(10) == {}
+    call.assert_not_called()
+
+
+@segment_effect
+async def test_segment_off_when_idle(dev: Device, mocker: MockerFixture) -> None:
+    """Selecting Off while no effect is running sends nothing."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    await segment.set_effect(SegmentEffect.OFF)
+    await dev.update()
+
+    call = mocker.spy(segment, "call")
+    assert await segment.set_effect(SegmentEffect.OFF) == {}
+    call.assert_not_called()
+
+
+@segment_effect
+async def test_segment_custom_effects_skip_non_dict(
+    dev: Device, mocker: MockerFixture
+) -> None:
+    """Non-dict preset entries are ignored when building the effect list."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    injected = {
+        "custom": 1,
+        "name": "Injected",
+        "type": "breathe",
+        "segments": [0],
+        "states": [[0, 0, 100, 0]],
+    }
+    mocker.patch.object(
+        type(segment),
+        "_preset_states",
+        new_callable=mocker.PropertyMock,
+        return_value=["not-a-dict", {"segment_effect": injected}],
+    )
+    assert segment._custom_effects() == {"Injected": injected}

--- a/tests/smart/modules/test_segment_effect.py
+++ b/tests/smart/modules/test_segment_effect.py
@@ -189,3 +189,101 @@ async def test_segment_custom_effects_skip_non_dict(
         return_value=["not-a-dict", {"segment_effect": injected}],
     )
     assert segment._custom_effects() == {"Injected": injected}
+
+
+@segment_effect
+async def test_segment_effect_clamps_and_normalizes(
+    dev: Device, mocker: MockerFixture
+) -> None:
+    """Custom rules clamp brightness/speed and pad colours to 4 ints."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    call = mocker.patch.object(segment, "call")
+    await segment.set_custom_effect(
+        {
+            "type": "breathe",
+            "name": "T",
+            "brightness": 500,  # over max -> 100
+            "speed": 99,  # over max -> 10
+            "segments": [50],
+            "states": [[40, 100, 100], [40, 100, 100], [60, 100, 100]],
+        }
+    )
+    method, payload = call.call_args[0]
+    assert method == "apply_segment_effect_rule"
+    assert payload["brightness"] == 100
+    assert payload["speed"] == 10
+    # 3-int colours are padded to the device's 4-int [h, s, v, w] form.
+    assert all(len(c) == 4 for c in payload["states"])
+    # display_colors is the deduped palette, not the per-segment list.
+    assert payload["display_colors"] == [[40, 100, 100, 0], [60, 100, 100, 0]]
+
+
+@segment_effect
+async def test_segment_effect_none_allows_speed_zero(
+    dev: Device, mocker: MockerFixture
+) -> None:
+    """The static 'none' paint permits speed 0; animated types clamp to >=1."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    call = mocker.patch.object(segment, "call")
+    await segment.set_custom_effect(
+        {
+            "type": "none",
+            "name": "S",
+            "speed": 0,
+            "segments": [0],
+            "states": [[0, 100, 100]],
+        }
+    )
+    assert call.call_args[0][1]["speed"] == 0
+
+    await segment.set_custom_effect(
+        {
+            "type": "breathe",
+            "name": "A",
+            "speed": 0,
+            "segments": [50],
+            "states": [[0, 100, 100]],
+        }
+    )
+    assert call.call_args[0][1]["speed"] == 1
+
+
+@segment_effect
+async def test_segment_effect_invalid_type(dev: Device) -> None:
+    """An unknown effect type raises."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    with pytest.raises(ValueError, match="Invalid segment effect type"):
+        await segment.set_custom_effect({"type": "wobble", "states": []})
+
+
+@segment_effect
+async def test_segment_effect_preview(dev: Device, mocker: MockerFixture) -> None:
+    """test()/stop_test() drive the churn-free start/stop test methods."""
+    segment = dev.modules.get(Module.SegmentEffect)
+    assert isinstance(segment, SegmentEffect)
+
+    call = mocker.patch.object(segment, "call")
+    await segment.test(
+        {
+            "type": "stacking",
+            "name": "P",
+            "segments": [50],
+            "states": [[40, 100, 100], [60, 100, 100]],
+            "speed": 5,
+            "carousel": 1,
+        }
+    )
+    method, payload = call.call_args[0]
+    assert method == "start_segment_effect_test"
+    assert all(len(c) == 4 for c in payload["states"])
+
+    await segment.stop_test()
+    method, payload = call.call_args[0]
+    assert method == "stop_segment_effect_test"
+    assert payload == {}


### PR DESCRIPTION
## Summary

RGBIC light strips such as the L930 (also L920 / L430) expose a dedicated
`segment_effect` SMART component for the **per-segment custom effects created in
the Tapo app** (breathe, circulating, chasing, flicker, bloom, stacking, and the
static "none" paint). These
are a separate subsystem from the `lighting_effect` system handled by
`LightStripEffect`, and are activated with the **`apply_segment_effect_rule`**
method rather than `set_lighting_effect`. python-kasa currently has no support
for them.

This PR adds a `SegmentEffect` module:

- `REQUIRED_COMPONENT = "segment_effect"`
- reads the active rule via `get_segment_effect_rule` and the saved-effect list
  from `get_preset_rules` (already fetched by `LightPreset`, so no extra query)
- `effect` / `effect_list` / `is_active` / `brightness` / `has_custom_effects`
- `set_effect(name | "Off")`, `set_custom_effect(rule)`, `set_brightness()`
- `test(rule)` / `stop_test()` for a **churn-free live preview** via
  `start_segment_effect_test` / `stop_segment_effect_test` — plays a rule without
  rewriting the device preset table (saving an effect makes the firmware/app
  rewrite the preset list and evict effects no longer present)
- payload includes `deviceType: "strip"` (required for custom effects) and
  preserves `speed` (the firmware resets it to 0 / no animation if omitted)

The rule builder is hardened against the documented `SegmentEffectData` ranges
(decompiled from the Tapo Android app v3.18.506, cross-checked on a live L930):

- validates `type` against the seven segment types (raises on anything else)
- clamps `brightness` to 1-100 and `speed` to 1-10; `speed: 0` is permitted only
  for the static "none" paint (it freezes an animated type otherwise)
- normalises per-segment colours to the device's 4-int `[h, s, v, w]` form and
  reduces `display_colors` to the unique palette — `start_segment_effect_test`
  rejects 3-int `[h, s, v]` colours with `PARAMS_ERROR(-1008)` (apply tolerates
  them), so normalising keeps both code paths working
- the `segments` field is dual-encoded by `type`: group **sizes** for the six
  animated types, explicit LED **indices** for the static "none" paint

Also adds a `FakeSmartTransport` handler for `apply_segment_effect_rule`, tests,
and an L930 fixture (fw 1.4.3) that contains real saved segment effects.

## Open question for maintainers

`LightStripEffect` names itself `"LightEffect"` on the assumption that a device
supports only one effect system, but RGBIC strips expose **both**
`light_strip_lighting_effect` and `segment_effect`. This PR therefore registers
the new module under its own name (`Module.SegmentEffect`) so the two coexist.
I'm happy to change the approach — e.g. unify both into the `LightEffect`
interface and route `set_effect` to the correct subsystem — if you prefer.

## Notes on the fixture

The `L930-5(EU)_1.0_1.4.3` fixture was captured from a real device. The region
suffix is assumed; the device `brightness` was normalised to a resting value and
the active segment rule set to `enable: 0` (the two custom effects remain in the
preset slots). Happy to regenerate it with `dump_devinfo` if you'd rather.

## Test plan

- [ ] `uv run pytest tests/smart/modules/test_segment_effect.py`
- [ ] `uv run pytest -k "1.4.3"` (full suite against the new fixture)
- [ ] `pre-commit run -a` (ruff / mypy / generate-supported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
