### PR TITLE
Add WhiteLamp SmartCam module for outdoor cameras (e.g. C325WB)

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -318,6 +318,7 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
   - Hardware: 2.0 (US) / Firmware: 1.0.11
 - **C325WB**
   - Hardware: 1.0 (EU) / Firmware: 1.1.17
+  - Hardware: 1.0 (EU) / Firmware: 1.4.4
 - **C460**
   - Hardware: 1.0 (CA) / Firmware: 1.2.0
 - **C520WS**

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -171,6 +171,7 @@ class Module(ABC):
     Camera: Final[ModuleName[smartcam.Camera]] = ModuleName("Camera")
     LensMask: Final[ModuleName[smartcam.LensMask]] = ModuleName("LensMask")
     PanTilt: Final[ModuleName[smartcam.PanTilt]] = ModuleName("PanTilt")
+    WhiteLamp: Final[ModuleName[smartcam.WhiteLamp]] = ModuleName("WhiteLamp")
 
     # Vacuum modules
     Clean: Final[ModuleName[smart.Clean]] = ModuleName("Clean")

--- a/kasa/smartcam/modules/__init__.py
+++ b/kasa/smartcam/modules/__init__.py
@@ -22,6 +22,7 @@ from .petdetection import PetDetection
 from .tamperdetection import TamperDetection
 from .time import Time
 from .vehicledetection import VehicleDetection
+from .whitelamp import WhiteLamp
 
 __all__ = [
     "Alarm",
@@ -46,4 +47,5 @@ __all__ = [
     "LensMask",
     "TamperDetection",
     "VehicleDetection",
+    "WhiteLamp",
 ]

--- a/kasa/smartcam/modules/whitelamp.py
+++ b/kasa/smartcam/modules/whitelamp.py
@@ -1,0 +1,96 @@
+"""Module for white lamp (floodlight) controls on Tapo outdoor cameras."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated
+
+from ...feature import Feature
+from ...module import FeatureAttribute
+from ...smart.smartmodule import allow_update_after
+from ..smartcammodule import SmartCamModule
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class WhiteLamp(SmartCamModule):
+    """Implementation of white lamp controls for outdoor cameras (e.g. C325WB).
+
+    The white lamp is the built-in floodlight that can be triggered manually
+    or by motion events. It is distinct from the LED status indicator.
+    """
+
+    REQUIRED_COMPONENT = "whiteLamp"
+
+    QUERY_GETTER_NAME = "getWhitelampStatus"
+    QUERY_MODULE_NAME = "image"
+
+    def query(self) -> dict:
+        """Query to execute during the update cycle."""
+        q = super().query()
+        q["getWhitelampStatus"] = {self.QUERY_MODULE_NAME: {"get_wtl_status": ["null"]}}
+        q["getWhitelampConfig"] = {self.QUERY_MODULE_NAME: {"name": "switch"}}
+        return q
+
+    def _initialize_features(self) -> None:
+        """Initialize features after the initial update."""
+        self._add_feature(
+            Feature(
+                self._device,
+                id="white_lamp_state",
+                name="White lamp state",
+                container=self,
+                attribute_getter="is_on",
+                attribute_setter="set_state",
+                type=Feature.Type.Switch,
+                category=Feature.Category.Primary,
+            )
+        )
+        config = self.data["getWhitelampConfig"]["image"]["switch"]
+        if "wtl_intensity_level" in config:
+            self._add_feature(
+                Feature(
+                    self._device,
+                    id="white_lamp_brightness",
+                    name="White lamp brightness",
+                    container=self,
+                    attribute_getter="brightness",
+                    attribute_setter="set_brightness",
+                    range_getter=lambda: (1, 100),
+                    type=Feature.Type.Number,
+                    category=Feature.Category.Config,
+                )
+            )
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the white lamp is on."""
+        return int(self.data["getWhitelampStatus"]["status"]) == 1
+
+    @allow_update_after
+    async def set_state(self, on: bool) -> Annotated[dict, FeatureAttribute()]:
+        """Turn the white lamp on or off."""
+        if self.is_on != on:
+            return await self.call(
+                "reverseWhitelampStatus", {"image": {"reverse_wtl_status": ["null"]}}
+            )
+        return {}
+
+    @property
+    def brightness(self) -> Annotated[int, FeatureAttribute()]:
+        """Return the current brightness (1-100)."""
+        return int(
+            self.data["getWhitelampConfig"]["image"]["switch"]["wtl_intensity_level"]
+        )
+
+    @allow_update_after
+    async def set_brightness(
+        self, brightness: int
+    ) -> Annotated[dict, FeatureAttribute()]:
+        """Set the white lamp brightness (1-100)."""
+        return await self._device._query_setter_helper(
+            "setWhitelampConfig",
+            self.QUERY_MODULE_NAME,
+            "switch",
+            {"wtl_intensity_level": str(brightness)},
+        )

--- a/kasa/smartcam/smartcammodule.py
+++ b/kasa/smartcam/smartcammodule.py
@@ -58,7 +58,7 @@ class SmartCamModule(SmartModule):
         "devicemodule"
     )
 
-    SmartCamWhiteLamp: Final[ModuleName[modules.WhiteLamp]] = ModuleName("whiteLamp")
+    SmartCamWhiteLamp: Final[ModuleName[modules.WhiteLamp]] = ModuleName("WhiteLamp")
 
     #: Module name to be queried
     QUERY_MODULE_NAME: str

--- a/kasa/smartcam/smartcammodule.py
+++ b/kasa/smartcam/smartcammodule.py
@@ -58,6 +58,8 @@ class SmartCamModule(SmartModule):
         "devicemodule"
     )
 
+    SmartCamWhiteLamp: Final[ModuleName[modules.WhiteLamp]] = ModuleName("whiteLamp")
+
     #: Module name to be queried
     QUERY_MODULE_NAME: str
     #: Section name or names to be queried

--- a/tests/fakeprotocol_smartcam.py
+++ b/tests/fakeprotocol_smartcam.py
@@ -356,6 +356,12 @@ class FakeSmartCamTransport(BaseTransport):
                 return {"error_code": -1}
         elif method == "removeChildDeviceList":
             return self._hub_remove_device(info, request_dict["params"]["childControl"])
+        elif method == "reverseWhitelampStatus":
+            if "getWhitelampStatus" in info:
+                info["getWhitelampStatus"]["status"] = (
+                    0 if info["getWhitelampStatus"]["status"] == 1 else 1
+                )
+            return {"result": {}, "error_code": 0}
         # actions
         elif method in [
             "addScanChildDeviceList",

--- a/tests/fixtures/smartcam/C325WB(EU)_1.0_1.4.4.json
+++ b/tests/fixtures/smartcam/C325WB(EU)_1.0_1.4.4.json
@@ -1,0 +1,1030 @@
+{
+    "discovery_result": {
+        "error_code": 0,
+        "result": {
+            "decrypted_data": {
+                "connect_ssid": "#MASKED_SSID#",
+                "connect_type": "wireless",
+                "device_id": "0000000000000000000000000000000000000000",
+                "http_port": 443,
+                "last_alarm_time": "1782194633",
+                "last_alarm_type": "motion",
+                "owner": "00000000000000000000000000000000",
+                "sd_status": "normal"
+            },
+            "device_id": "00000000000000000000000000000000",
+            "device_model": "C325WB",
+            "device_name": "#MASKED_NAME#",
+            "device_type": "SMART.IPCAMERA",
+            "encrypt_info": {
+                "data": "",
+                "key": "",
+                "sym_schm": "AES"
+            },
+            "encrypt_type": [
+                "3"
+            ],
+            "factory_default": false,
+            "firmware_version": "1.4.4 Build 260228 Rel.29289n",
+            "hardware_version": "1.0",
+            "ip": "127.0.0.123",
+            "isResetWiFi": false,
+            "is_support_iot_cloud": true,
+            "mac": "3C-52-A1-00-00-00",
+            "mgt_encrypt_schm": {
+                "is_support_https": true
+            },
+            "protocol_version": 1,
+            "sv": 1
+        }
+    },
+    "getAlertConfig": {
+        "msg_alarm": {
+            "capability": {
+                "alarm_duration_support": "1",
+                "alarm_volume_support": "1",
+                "alert_event_type_support": "1",
+                "usr_def_audio_alarm_max_num": "2",
+                "usr_def_audio_alarm_support": "1",
+                "usr_def_audio_max_duration": "15",
+                "usr_def_audio_type": "0",
+                "usr_def_start_file_id": "8195"
+            },
+            "chn1_msg_alarm_info": {
+                "alarm_duration": "0",
+                "alarm_mode": [
+                    "light"
+                ],
+                "alarm_type": "0",
+                "alarm_volume": "normal",
+                "enabled": "on",
+                "light_alarm_enabled": "on",
+                "light_type": "0",
+                "sound_alarm_enabled": "on"
+            },
+            "usr_def_audio": []
+        }
+    },
+    "getAlertPlan": {
+        "msg_alarm_plan": {
+            "chn1_msg_alarm_plan": {
+                "alarm_plan_1": "1800-0700,127",
+                "enabled": "on"
+            }
+        }
+    },
+    "getAlertTypeList": {
+        "msg_alarm": {
+            "alert_type": {
+                "alert_type_list": [
+                    "Siren",
+                    "Emergency",
+                    "Red Alert"
+                ]
+            }
+        }
+    },
+    "getAppComponentList": {
+        "app_component": {
+            "app_component_list": [
+                {
+                    "name": "sdCard",
+                    "version": 1
+                },
+                {
+                    "name": "timezone",
+                    "version": 1
+                },
+                {
+                    "name": "system",
+                    "version": 4
+                },
+                {
+                    "name": "led",
+                    "version": 1
+                },
+                {
+                    "name": "playback",
+                    "version": 6
+                },
+                {
+                    "name": "detection",
+                    "version": 3
+                },
+                {
+                    "name": "alert",
+                    "version": 2
+                },
+                {
+                    "name": "firmware",
+                    "version": 2
+                },
+                {
+                    "name": "account",
+                    "version": 2
+                },
+                {
+                    "name": "quickSetup",
+                    "version": 1
+                },
+                {
+                    "name": "video",
+                    "version": 3
+                },
+                {
+                    "name": "lensMask",
+                    "version": 2
+                },
+                {
+                    "name": "lightFrequency",
+                    "version": 1
+                },
+                {
+                    "name": "osd",
+                    "version": 2
+                },
+                {
+                    "name": "record",
+                    "version": 1
+                },
+                {
+                    "name": "videoRotation",
+                    "version": 1
+                },
+                {
+                    "name": "audio",
+                    "version": 3
+                },
+                {
+                    "name": "diagnose",
+                    "version": 1
+                },
+                {
+                    "name": "msgPush",
+                    "version": 3
+                },
+                {
+                    "name": "linecrossingDetection",
+                    "version": 2
+                },
+                {
+                    "name": "deviceShare",
+                    "version": 1
+                },
+                {
+                    "name": "tamperDetection",
+                    "version": 1
+                },
+                {
+                    "name": "darkLightNightVision",
+                    "version": 3
+                },
+                {
+                    "name": "tapoCare",
+                    "version": 1
+                },
+                {
+                    "name": "blockZone",
+                    "version": 1
+                },
+                {
+                    "name": "personDetection",
+                    "version": 2
+                },
+                {
+                    "name": "needSubscriptionServiceList",
+                    "version": 1
+                },
+                {
+                    "name": "vehicleDetection",
+                    "version": 1
+                },
+                {
+                    "name": "petDetection",
+                    "version": 1
+                },
+                {
+                    "name": "whiteLamp",
+                    "version": 1
+                },
+                {
+                    "name": "markerBox",
+                    "version": 1
+                },
+                {
+                    "name": "nvmp",
+                    "version": 1
+                },
+                {
+                    "name": "detectionRegion",
+                    "version": 2
+                },
+                {
+                    "name": "recordDownload",
+                    "version": 1
+                },
+                {
+                    "name": "iotCloud",
+                    "version": 1
+                },
+                {
+                    "name": "snapshot",
+                    "version": 2
+                },
+                {
+                    "name": "upnpc",
+                    "version": 2
+                },
+                {
+                    "name": "staticIp",
+                    "version": 2
+                },
+                {
+                    "name": "timeFormat",
+                    "version": 1
+                },
+                {
+                    "name": "encryption",
+                    "version": 3
+                },
+                {
+                    "name": "relayPreConnection",
+                    "version": 1
+                },
+                {
+                    "name": "hubManage",
+                    "version": 1
+                },
+                {
+                    "name": "webrtc",
+                    "version": 1
+                },
+                {
+                    "name": "webrtcBypassDtls",
+                    "version": 1
+                },
+                {
+                    "name": "webrtcCapability",
+                    "version": 1
+                }
+            ]
+        }
+    },
+    "getAudioConfig": {
+        "audio_config": {
+            "microphone": {
+                "bitrate": "64",
+                "channels": "1",
+                "echo_cancelling": "off",
+                "encode_type": "G711alaw",
+                "input_device_type": "MicIn",
+                "mute": "off",
+                "noise_cancelling": "on",
+                "sampling_rate": "8",
+                "volume": "60"
+            },
+            "speaker": {
+                "mute": "off",
+                "output_device_type": "SpeakerOut",
+                "volume": "100"
+            }
+        }
+    },
+    "getCircularRecordingConfig": {
+        "harddisk_manage": {
+            "harddisk": {
+                "loop": "on"
+            }
+        }
+    },
+    "getClockStatus": {
+        "system": {
+            "clock_status": {
+                "local_time": "2026-06-23 17:24:23",
+                "seconds_from_1970": 1782228263
+            }
+        }
+    },
+    "getConnectStatus": {
+        "onboarding": {
+            "get_connect_status": {
+                "status": 0
+            }
+        }
+    },
+    "getConnectionType": {
+        "link_type": "wifi",
+        "rssi": "2",
+        "rssiValue": -64,
+        "ssid": "I01BU0tFRF9TU0lEIw=="
+    },
+    "getDetectionConfig": {
+        "motion_detection": {
+            "motion_det": {
+                "digital_sensitivity": "80",
+                "enabled": "on",
+                "non_vehicle_enabled": "off",
+                "people_enabled": "off",
+                "sensitivity": "high",
+                "vehicle_enabled": "off"
+            }
+        }
+    },
+    "getDeviceInfo": {
+        "device_info": {
+            "basic_info": {
+                "avatar": "camera c310",
+                "barcode": "",
+                "dev_id": "0000000000000000000000000000000000000000",
+                "device_alias": "#MASKED_NAME#",
+                "device_info": "C325WB 1.0 IPC",
+                "device_model": "C325WB",
+                "device_name": "#MASKED_NAME#",
+                "device_type": "SMART.IPCAMERA",
+                "features": 3,
+                "ffs": false,
+                "has_set_location_info": 1,
+                "hw_desc": "00000000000000000000000000000000",
+                "hw_id": "00000000000000000000000000000000",
+                "hw_version": "1.0",
+                "is_cal": true,
+                "latitude": 0,
+                "longitude": 0,
+                "mac": "3C-52-A1-00-00-00",
+                "manufacturer_name": "TP-Link",
+                "mobile_access": "0",
+                "no_rtsp_constrain": 1,
+                "oem_id": "00000000000000000000000000000000",
+                "region": "EU",
+                "sw_version": "1.4.4 Build 260228 Rel.29289n",
+                "tss": false
+            }
+        }
+    },
+    "getFirmwareAutoUpgradeConfig": {
+        "auto_upgrade": {
+            "common": {
+                "enabled": "on",
+                "random_range": "120",
+                "time": "03:00"
+            }
+        }
+    },
+    "getFirmwareUpdateStatus": {
+        "cloud_config": {
+            "upgrade_status": {
+                "lastUpgradingSuccess": true,
+                "state": "normal"
+            }
+        }
+    },
+    "getLastAlarmInfo": {
+        "system": {
+            "last_alarm_info": {
+                "last_alarm_time": "1782194633",
+                "last_alarm_type": "motion"
+            }
+        }
+    },
+    "getLdc": {
+        "image": {
+            "common": {
+                "area_compensation": "default",
+                "auto_exp_antiflicker": "off",
+                "auto_exp_gain_max": "0",
+                "backlight": "off",
+                "chroma": "50",
+                "contrast": "50",
+                "dehaze": "off",
+                "eis": "off",
+                "exp_gain": "0",
+                "exp_level": "0",
+                "exp_type": "auto",
+                "focus_limited": "10",
+                "focus_type": "manual",
+                "high_light_compensation": "off",
+                "inf_delay": "5",
+                "inf_end_time": "21600",
+                "inf_sensitivity": "4",
+                "inf_sensitivity_day2night": "1400",
+                "inf_sensitivity_night2day": "9100",
+                "inf_start_time": "64800",
+                "inf_type": "off",
+                "iris_level": "160",
+                "light_freq_mode": "auto",
+                "lock_blue_colton": "0",
+                "lock_blue_gain": "0",
+                "lock_gb_gain": "0",
+                "lock_gr_gain": "0",
+                "lock_green_colton": "0",
+                "lock_red_colton": "0",
+                "lock_red_gain": "0",
+                "lock_source": "local",
+                "luma": "50",
+                "saturation": "50",
+                "sharpness": "50",
+                "shutter": "1/25",
+                "smartir": "auto_ir",
+                "smartir_level": "0",
+                "smartwtl": "auto_wtl",
+                "smartwtl_digital_level": "100",
+                "smartwtl_level": "5",
+                "style": "original",
+                "wb_B_gain": "50",
+                "wb_G_gain": "50",
+                "wb_R_gain": "50",
+                "wb_type": "auto",
+                "wd_gain": "50",
+                "wide_dynamic": "off",
+                "wtl_delay": "5",
+                "wtl_end_time": "21600",
+                "wtl_sensitivity": "4",
+                "wtl_sensitivity_day2night": "1400",
+                "wtl_sensitivity_night2day": "9100",
+                "wtl_start_time": "64800",
+                "wtl_type": "auto"
+            },
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "wtl_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "100"
+            }
+        }
+    },
+    "getLedStatus": {
+        "led": {
+            "config": {
+                "enabled": "off"
+            }
+        }
+    },
+    "getLensMaskConfig": {
+        "lens_mask": {
+            "lens_mask_info": {
+                "enabled": "off"
+            }
+        }
+    },
+    "getLightFrequencyInfo": {
+        "image": {
+            "common": {
+                "area_compensation": "default",
+                "auto_exp_antiflicker": "off",
+                "auto_exp_gain_max": "0",
+                "backlight": "off",
+                "chroma": "50",
+                "contrast": "50",
+                "dehaze": "off",
+                "eis": "off",
+                "exp_gain": "0",
+                "exp_level": "0",
+                "exp_type": "auto",
+                "focus_limited": "10",
+                "focus_type": "manual",
+                "high_light_compensation": "off",
+                "inf_delay": "5",
+                "inf_end_time": "21600",
+                "inf_sensitivity": "4",
+                "inf_sensitivity_day2night": "1400",
+                "inf_sensitivity_night2day": "9100",
+                "inf_start_time": "64800",
+                "inf_type": "off",
+                "iris_level": "160",
+                "light_freq_mode": "auto",
+                "lock_blue_colton": "0",
+                "lock_blue_gain": "0",
+                "lock_gb_gain": "0",
+                "lock_gr_gain": "0",
+                "lock_green_colton": "0",
+                "lock_red_colton": "0",
+                "lock_red_gain": "0",
+                "lock_source": "local",
+                "luma": "50",
+                "saturation": "50",
+                "sharpness": "50",
+                "shutter": "1/25",
+                "smartir": "auto_ir",
+                "smartir_level": "0",
+                "smartwtl": "auto_wtl",
+                "smartwtl_digital_level": "100",
+                "smartwtl_level": "5",
+                "style": "original",
+                "wb_B_gain": "50",
+                "wb_G_gain": "50",
+                "wb_R_gain": "50",
+                "wb_type": "auto",
+                "wd_gain": "50",
+                "wide_dynamic": "off",
+                "wtl_delay": "5",
+                "wtl_end_time": "21600",
+                "wtl_sensitivity": "4",
+                "wtl_sensitivity_day2night": "1400",
+                "wtl_sensitivity_night2day": "9100",
+                "wtl_start_time": "64800",
+                "wtl_type": "auto"
+            }
+        }
+    },
+    "getLinecrossingDetectionConfig": {
+        "linecrossing_detection": {
+            "arming_schedule": {
+                "friday": "[\"0000-2400\"]",
+                "monday": "[\"0000-2400\"]",
+                "saturday": "[\"0000-2400\"]",
+                "sunday": "[\"0000-2400\"]",
+                "thursday": "[\"0000-2400\"]",
+                "tuesday": "[\"0000-2400\"]",
+                "wednesday": "[\"0000-2400\"]"
+            },
+            "detection": {
+                "enabled": "off"
+            }
+        }
+    },
+    "getMediaEncrypt": {
+        "cet": {
+            "media_encrypt": {
+                "enabled": "on"
+            }
+        }
+    },
+    "getMsgPushConfig": {
+        "msg_push": {
+            "chn1_msg_push_info": {
+                "notification_enabled": "on",
+                "rich_notification_enabled": "off"
+            }
+        }
+    },
+    "getNightVisionCapability": {
+        "image_capability": {
+            "supplement_lamp": {
+                "night_vision_mode_range": [
+                    "wtl_night_vision",
+                    "md_night_vision",
+                    "shed_night_vision"
+                ],
+                "supplement_lamp_type": [
+                    "infrared_lamp",
+                    "white_lamp"
+                ]
+            }
+        }
+    },
+    "getNightVisionModeConfig": {
+        "image": {
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "wtl_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "100"
+            }
+        }
+    },
+    "getPersonDetectionConfig": {
+        "people_detection": {
+            "detection": {
+                "enabled": "on",
+                "sensitivity": "80"
+            }
+        }
+    },
+    "getPetDetectionConfig": {
+        "pet_detection": {
+            "detection": {
+                "enabled": "on",
+                "sensitivity": "60"
+            }
+        }
+    },
+    "getRecordPlan": {
+        "record_plan": {
+            "chn1_channel": {
+                "enabled": "on",
+                "friday": "[\"0000-2400:2\"]",
+                "monday": "[\"0000-2400:2\"]",
+                "saturday": "[\"0000-2400:2\"]",
+                "sunday": "[\"0000-2400:2\"]",
+                "thursday": "[\"0000-2400:2\"]",
+                "tuesday": "[\"0000-2400:2\"]",
+                "wednesday": "[\"0000-2400:2\"]"
+            }
+        }
+    },
+    "getRotationStatus": {
+        "image": {
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "wtl_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "100"
+            }
+        }
+    },
+    "getSdCardStatus": {
+        "harddisk_manage": {
+            "hd_info": [
+                {
+                    "hd_info_1": {
+                        "crossline_free_space": "0B",
+                        "crossline_free_space_accurate": "0B",
+                        "crossline_total_space": "0B",
+                        "crossline_total_space_accurate": "0B",
+                        "detect_status": "normal",
+                        "disk_name": "1",
+                        "free_space": "0B",
+                        "free_space_accurate": "0B",
+                        "loop_record_status": "1",
+                        "msg_push_free_space": "0B",
+                        "msg_push_free_space_accurate": "0B",
+                        "msg_push_total_space": "0B",
+                        "msg_push_total_space_accurate": "0B",
+                        "percent": "0",
+                        "picture_free_space": "0B",
+                        "picture_free_space_accurate": "0B",
+                        "picture_total_space": "0B",
+                        "picture_total_space_accurate": "0B",
+                        "record_duration": "0",
+                        "record_free_duration": "0",
+                        "record_start_time": "1718989319",
+                        "rw_attr": "rw",
+                        "status": "normal",
+                        "total_space": "118.8GB",
+                        "total_space_accurate": "127531646976B",
+                        "type": "local",
+                        "video_free_space": "0B",
+                        "video_free_space_accurate": "0B",
+                        "video_total_space": "114.0GB",
+                        "video_total_space_accurate": "122406567936B",
+                        "write_protect": "0"
+                    }
+                }
+            ]
+        }
+    },
+    "getTamperDetectionConfig": {
+        "tamper_detection": {
+            "tamper_det": {
+                "digital_sensitivity": "20",
+                "enabled": "off",
+                "sensitivity": "low"
+            }
+        }
+    },
+    "getTimezone": {
+        "system": {
+            "basic": {
+                "timezone": "UTC+01:00",
+                "timing_mode": "ntp",
+                "zone_id": "Europe/Brussels"
+            }
+        }
+    },
+    "getVehicleDetectionConfig": {
+        "vehicle_detection": {
+            "detection": {
+                "enabled": "off",
+                "sensitivity": "60"
+            }
+        }
+    },
+    "getVideoCapability": {
+        "video_capability": {
+            "main": {
+                "bitrate_types": [
+                    "cbr",
+                    "vbr"
+                ],
+                "bitrates": [
+                    "256",
+                    "512",
+                    "1024",
+                    "1536",
+                    "3072"
+                ],
+                "encode_types": [
+                    "H264",
+                    "H265"
+                ],
+                "frame_rates": [
+                    "65537",
+                    "65546",
+                    "65551",
+                    "65556"
+                ],
+                "hdrs": [
+                    "0",
+                    "1"
+                ],
+                "minor_stream_support": "1",
+                "qualitys": [
+                    "1",
+                    "3",
+                    "5"
+                ],
+                "resolutions": [
+                    "2688*1520",
+                    "1920*1080",
+                    "1280*720"
+                ]
+            }
+        }
+    },
+    "getVideoQualities": {
+        "video": {
+            "main": {
+                "bitrate": "1536",
+                "bitrate_type": "vbr",
+                "default_bitrate": "3072",
+                "encode_type": "H264",
+                "frame_rate": "65556",
+                "hdr": "1",
+                "name": "VideoEncoder_1",
+                "quality": "3",
+                "resolution": "2688*1520",
+                "smart_codec": "off"
+            }
+        }
+    },
+    "getWhitelampConfig": {
+        "image": {
+            "switch": {
+                "best_view_distance": "0",
+                "clear_licence_plate_mode": "off",
+                "flip_type": "off",
+                "full_color_min_keep_time": "5",
+                "full_color_people_enhance": "off",
+                "image_scene_mode": "normal",
+                "image_scene_mode_autoday": "normal",
+                "image_scene_mode_autonight": "normal",
+                "image_scene_mode_common": "normal",
+                "image_scene_mode_shedday": "normal",
+                "image_scene_mode_shednight": "normal",
+                "ldc": "off",
+                "night_vision_mode": "wtl_night_vision",
+                "overexposure_people_suppression": "off",
+                "rotate_type": "off",
+                "schedule_end_time": "64800",
+                "schedule_start_time": "21600",
+                "switch_mode": "common",
+                "wtl_force_time": "300",
+                "wtl_intensity_level": "100"
+            }
+        }
+    },
+    "getWhitelampStatus": {
+        "rest_time": 0,
+        "status": 0
+    },
+    "get_audio_capability": {
+        "get": {
+            "audio_capability": {
+                "device_microphone": {
+                    "aec": "1",
+                    "channels": "1",
+                    "echo_cancelling": "0",
+                    "encode_type": [
+                        "G711alaw"
+                    ],
+                    "half_duplex": "1",
+                    "mute": "1",
+                    "noise_cancelling": "1",
+                    "sampling_rate": [
+                        "8"
+                    ],
+                    "volume": "1"
+                },
+                "device_speaker": {
+                    "channels": "1",
+                    "decode_type": [
+                        "G711alaw",
+                        "G711ulaw"
+                    ],
+                    "mute": "0",
+                    "output_device_type": "0",
+                    "sampling_rate": [
+                        "8",
+                        "16"
+                    ],
+                    "system_volume": "95",
+                    "volume": "1"
+                }
+            }
+        }
+    },
+    "get_audio_config": {
+        "get": {
+            "audio_config": {
+                "microphone": {
+                    "bitrate": "64",
+                    "channels": "1",
+                    "echo_cancelling": "off",
+                    "encode_type": "G711alaw",
+                    "input_device_type": "MicIn",
+                    "mute": "off",
+                    "noise_cancelling": "on",
+                    "sampling_rate": "8",
+                    "volume": "60"
+                },
+                "speaker": {
+                    "mute": "off",
+                    "output_device_type": "SpeakerOut",
+                    "volume": "100"
+                }
+            }
+        }
+    },
+    "get_cet": {
+        "get": {
+            "cet": {
+                "vhttpd": {
+                    "port": "8800"
+                }
+            }
+        }
+    },
+    "get_function": {
+        "get": {
+            "function": {
+                "module_spec": {
+                    "ae_weighting_table_resolution": "5*5",
+                    "ai_enhance_capability": "1",
+                    "ai_enhance_range": [
+                        "traditional_enhance"
+                    ],
+                    "alarm_out_num": "0",
+                    "app_version": "1.0.0",
+                    "audio": [
+                        "speaker",
+                        "microphone"
+                    ],
+                    "auth_encrypt": "1",
+                    "auto_ip_configurable": "1",
+                    "backlight_coexistence": "1",
+                    "change_password": "1",
+                    "client_info": "1",
+                    "cloud_storage_version": "1.0",
+                    "config_recovery": [
+                        "audio_config",
+                        "image",
+                        "OSD",
+                        "video"
+                    ],
+                    "custom_area_compensation": "1",
+                    "daynight_subdivision": "1",
+                    "device_share": [
+                        "preview",
+                        "playback",
+                        "voice",
+                        "cloud_storage",
+                        "motor"
+                    ],
+                    "diagnose": "1",
+                    "diagnose_capability": "1",
+                    "download": [
+                        "video"
+                    ],
+                    "events": [
+                        "motion",
+                        "tamper"
+                    ],
+                    "greeter": "1.0",
+                    "http_system_state_audio_support": "1",
+                    "image_capability": "1",
+                    "image_list": [
+                        "supplement_lamp",
+                        "expose"
+                    ],
+                    "led": "1",
+                    "lens_mask": "1",
+                    "linkage_capability": "1",
+                    "local_storage": "1",
+                    "media_encrypt": "1",
+                    "msg_alarm_list": [
+                        "sound",
+                        "light"
+                    ],
+                    "msg_push": "1",
+                    "multi_user": "0",
+                    "network": [
+                        "wifi",
+                        "ethernet"
+                    ],
+                    "osd_capability": "1",
+                    "ota_upgrade": "1",
+                    "p2p_support_versions": [
+                        "2.0"
+                    ],
+                    "playback": [
+                        "local",
+                        "p2p",
+                        "relay"
+                    ],
+                    "playback_scale": "1",
+                    "playback_version": "1.1",
+                    "preview": [
+                        "local",
+                        "p2p",
+                        "relay"
+                    ],
+                    "privacy_mask_api_version": "1.0",
+                    "ptz": "1",
+                    "record_max_slot_cnt": "10",
+                    "record_type": [
+                        "timing",
+                        "motion"
+                    ],
+                    "relay_support_versions": [
+                        "2.0"
+                    ],
+                    "remote_upgrade": "1",
+                    "reonboarding": "1",
+                    "smart_codec": "0",
+                    "smart_detection": "1",
+                    "smart_msg_push_capability": "1",
+                    "ssl_cer_version": "1.0",
+                    "storage_api_version": "2.2",
+                    "stream_max_sessions": "10",
+                    "streaming_support_versions": [
+                        "2.0"
+                    ],
+                    "tapo_care_version": "1.0.0",
+                    "target_track": "1",
+                    "timing_reboot": "1",
+                    "tums": "1",
+                    "tums_config": "1",
+                    "tums_msg_push": "1",
+                    "verification_change_password": "1",
+                    "video_codec": [
+                        "h264",
+                        "h265"
+                    ],
+                    "video_detection_digital_sensitivity": "1",
+                    "video_message": "1",
+                    "wide_range_inf_sensitivity": "1",
+                    "wifi_cascade_connection": "0",
+                    "wifi_connection_info": "1",
+                    "wireless_hotspot": "0"
+                }
+            }
+        }
+    },
+    "scanApList": {
+        "onboarding": {
+            "scan": {
+                "ap_list": [],
+                "public_key": "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC2gPw3lC9iEVdZ7eLaQj9RAH1T\nZDkl3Wb19LjNdrp26xAFzoWXVnr1f1yUPylZdFzEN5iZUhMLFzkQ6bmesbCygsob\nH0ogPfggb+k3S2z7/aOuVyVskc+VV5niRkZrOhSO/WzH5YjFnRs2uLtN5Z+sQTq4\nXH5qpUULByLXR3xjVwIDAQAB\n-----END PUBLIC KEY-----\n",
+                "wpa3_supported": "true"
+            }
+        }
+    }
+}

--- a/tests/smartcam/modules/test_whitelamp.py
+++ b/tests/smartcam/modules/test_whitelamp.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from kasa import Device, Module
+from kasa.smartcam.smartcammodule import SmartCamModule
 
 from ...device_fixtures import parametrize
 
@@ -18,6 +19,7 @@ async def test_whitelamp_is_on(dev: Device):
     """Test white lamp on/off state reflects fixture data."""
     whitelamp = dev.modules.get(Module.WhiteLamp)
     assert whitelamp is not None
+    assert dev.modules.get(SmartCamModule.SmartCamWhiteLamp) is whitelamp
 
     assert isinstance(whitelamp.is_on, bool)
 
@@ -81,6 +83,20 @@ async def test_whitelamp_brightness(dev: Device):
     finally:
         await whitelamp.set_brightness(original_brightness)
         await dev.update()
+
+
+@whitelamp_smartcam
+async def test_whitelamp_no_brightness(dev: Device):
+    """Test that brightness feature is absent when device does not support it."""
+    whitelamp = dev.modules.get(Module.WhiteLamp)
+    assert whitelamp is not None
+
+    config = whitelamp.data["getWhitelampConfig"]["image"]["switch"]
+    if "wtl_intensity_level" not in config:
+        assert not whitelamp.has_feature("brightness")
+        assert "white_lamp_brightness" not in dev.features
+    else:
+        pytest.skip("Device supports brightness, skipping no-brightness test")
 
 
 @whitelamp_smartcam

--- a/tests/smartcam/modules/test_whitelamp.py
+++ b/tests/smartcam/modules/test_whitelamp.py
@@ -1,0 +1,103 @@
+"""Tests for smartcam white lamp (floodlight) module."""
+
+from __future__ import annotations
+
+import pytest
+
+from kasa import Device, Module
+
+from ...device_fixtures import parametrize
+
+whitelamp_smartcam = parametrize(
+    "has white lamp", component_filter="whiteLamp", protocol_filter={"SMARTCAM"}
+)
+
+
+@whitelamp_smartcam
+async def test_whitelamp_is_on(dev: Device):
+    """Test white lamp on/off state reflects fixture data."""
+    whitelamp = dev.modules.get(Module.WhiteLamp)
+    assert whitelamp is not None
+
+    assert isinstance(whitelamp.is_on, bool)
+
+
+@whitelamp_smartcam
+async def test_whitelamp_set_state(dev: Device):
+    """Test turning white lamp on and off."""
+    whitelamp = dev.modules.get(Module.WhiteLamp)
+    assert whitelamp is not None
+
+    original_state = whitelamp.is_on
+
+    try:
+        await whitelamp.set_state(not original_state)
+        await dev.update()
+        assert whitelamp.is_on is not original_state
+
+        await whitelamp.set_state(original_state)
+        await dev.update()
+        assert whitelamp.is_on is original_state
+    finally:
+        await whitelamp.set_state(original_state)
+        await dev.update()
+
+
+@whitelamp_smartcam
+async def test_whitelamp_set_state_idempotent(dev: Device):
+    """Test that set_state does not toggle when already in requested state."""
+    whitelamp = dev.modules.get(Module.WhiteLamp)
+    assert whitelamp is not None
+
+    original_state = whitelamp.is_on
+
+    try:
+        await whitelamp.set_state(original_state)
+        await dev.update()
+        assert whitelamp.is_on is original_state
+    finally:
+        await whitelamp.set_state(original_state)
+        await dev.update()
+
+
+@whitelamp_smartcam
+async def test_whitelamp_brightness(dev: Device):
+    """Test white lamp brightness getter and setter."""
+    whitelamp = dev.modules.get(Module.WhiteLamp)
+    assert whitelamp is not None
+
+    if not whitelamp.has_feature("brightness"):
+        pytest.skip("Device white lamp does not support brightness control")
+
+    original_brightness = whitelamp.brightness
+    assert isinstance(original_brightness, int)
+    assert 1 <= original_brightness <= 100
+
+    try:
+        new_brightness = 50 if original_brightness != 50 else 75
+        await whitelamp.set_brightness(new_brightness)
+        await dev.update()
+        assert whitelamp.brightness == new_brightness
+    finally:
+        await whitelamp.set_brightness(original_brightness)
+        await dev.update()
+
+
+@whitelamp_smartcam
+async def test_whitelamp_features(dev: Device):
+    """Test white lamp features are registered on the device."""
+    whitelamp = dev.modules.get(Module.WhiteLamp)
+    assert whitelamp is not None
+
+    feature = dev.features.get("white_lamp_state")
+    assert feature is not None
+    assert isinstance(feature.value, bool)
+
+    original_state = feature.value
+    try:
+        await feature.set_value(not original_state)
+        await dev.update()
+        assert feature.value is not original_state
+    finally:
+        await feature.set_value(original_state)
+        await dev.update()


### PR DESCRIPTION
New WhiteLamp module under kasa/smartcam/modules/

- Exposes white_lamp_state (on/off toggle via reverseWhitelampStatus) and white_lamp_brightness (1-100, only if device supports it)
- Adds Module.SmartCamWhiteLamp and Module.WhiteLamp module names
- Adds fixture for C325WB(EU) 1.0 / 1.4.4
- Adds unit tests in tests/smartcam/modules/test_whitelamp.py
- Fixes fake protocol to handle reverseWhitelampStatus toggle command

Pre-commit OK
Tests : OK

Also tested with python-kasa CLI and my own Home Assistant instance with 2 C325WB cameras.

Hope all is compliant with your guidelines and nothing missing.