### PR TITLE
Fix KLAP IoT one-request-per-session firmware behaviour (HS110 SHIP 2.0)

### DIFF
--- a/kasa/iot/iotdevice.py
+++ b/kasa/iot/iotdevice.py
@@ -703,6 +703,13 @@ class IotDevice(Device):
     @property
     def max_device_response_size(self) -> int:
         """Returns the maximum response size the device can safely construct."""
+        # KLAP IoT devices (e.g. HS110 with SHIP 2.0 firmware) only support
+        # one small KLAP request per session. Force individual module queries
+        # by returning 0 so _modular_update never batches them together.
+        from kasa.transports.klaptransport import KlapTransport
+        transport = getattr(getattr(self, 'protocol', None), '_transport', None)
+        if isinstance(transport, KlapTransport):
+            return 0
         return 16 * 1024
 
     @property

--- a/kasa/transports/klaptransport.py
+++ b/kasa/transports/klaptransport.py
@@ -357,13 +357,23 @@ class KlapTransport(BaseTransport):
         if self._encryption_session is not None:
             payload, seq = self._encryption_session.encrypt(request.encode())
 
-        response_status, response_data = await self._http_client.post(
-            self._request_url,
-            params={"seq": seq},
-            data=payload,
-            cookies_dict=self._session_cookie,
-            ssl=await self._get_ssl_context(),
-        )
+        try:
+            response_status, response_data = await self._http_client.post(
+                self._request_url,
+                params={"seq": seq},
+                data=payload,
+                cookies_dict=self._session_cookie,
+                ssl=await self._get_ssl_context(),
+            )
+        except KasaException as ex:
+            # Some IoT devices (e.g. HS110 with SHIP 2.0 firmware) only support
+            # one KLAP request per session. After the first request the session is
+            # invalidated and subsequent POSTs return a raw non-HTTP response.
+            # Reset the handshake so the next retry starts a fresh session.
+            self._handshake_done = False
+            raise _RetryableError(
+                f"Device {self._host} request failed after handshake: {ex}"
+            ) from ex
 
         msg = (
             f"Host is {self._host}, "
@@ -392,8 +402,12 @@ class KlapTransport(BaseTransport):
             try:
                 decrypted_response = self._encryption_session.decrypt(response_data)
             except Exception as ex:
-                raise KasaException(
-                    f"Error trying to decrypt device {self._host} response: {ex}"
+                # Decrypt failure likely means the session was invalidated after
+                # the first request (one-request-per-session IoT firmware behaviour).
+                # Reset handshake so the next retry starts a fresh session.
+                self._handshake_done = False
+                raise _RetryableError(
+                    f"Device {self._host} decrypt failed, will retry with new handshake: {ex}"
                 ) from ex
 
             json_payload = json_loads(decrypted_response)


### PR DESCRIPTION
## Problem

Some IoT devices (confirmed on HS110 with SHIP 2.0 firmware) invalidate the KLAP session after each request. Subsequent requests in the same session return a raw non-HTTP response or fail decryption, causing repeated `UpdateFailed` errors and the entity showing unavailable.

## Fix

**`kasa/transports/klaptransport.py` — `send()`**: Wrap the HTTP post and decrypt calls in try/except so that failures raise `_RetryableError` and reset `_handshake_done = False`. The existing retry logic then starts a fresh session for the next attempt, making every request effectively use its own handshake.

**`kasa/iot/iotdevice.py` — `max_device_response_size`**: Return `0` when the underlying transport is `KlapTransport`. This prevents `_modular_update` from batching multiple module queries into one large request that exceeds the KLAP buffer on these devices, forcing individual per-module queries instead.

## Tested with

- **HS110** (`IOT.SMARTPLUGSWITCH`, KLAP v1, SHIP 2.0 firmware)

Previously caused continuous `UpdateFailed` errors in Home Assistant. Both changes together eliminate the errors entirely.