### PR TITLE
Add fixture for RV20 max plus 1.3.0

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -346,6 +346,7 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
 
 - **RV20 Max Plus**
   - Hardware: 1.0 (EU) / Firmware: 1.0.7
+  - Hardware: 1.0 (EU) / Firmware: 1.3.0
 - **RV30 Max**
   - Hardware: 1.0 (US) / Firmware: 1.2.0
 

--- a/tests/fixtures/smart/RV20 Max Plus(EU)_1.0_1.3.0.json
+++ b/tests/fixtures/smart/RV20 Max Plus(EU)_1.0_1.3.0.json
@@ -1,0 +1,404 @@
+{
+    "component_nego": {
+        "component_list": [
+            {
+                "id": "device",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "time",
+                "ver_code": 1
+            },
+            {
+                "id": "firmware",
+                "ver_code": 1
+            },
+            {
+                "id": "quick_setup",
+                "ver_code": 1
+            },
+            {
+                "id": "clean",
+                "ver_code": 3
+            },
+            {
+                "id": "battery",
+                "ver_code": 1
+            },
+            {
+                "id": "consumables",
+                "ver_code": 2
+            },
+            {
+                "id": "direction_control",
+                "ver_code": 1
+            },
+            {
+                "id": "button_and_led",
+                "ver_code": 1
+            },
+            {
+                "id": "speaker",
+                "ver_code": 3
+            },
+            {
+                "id": "schedule",
+                "ver_code": 3
+            },
+            {
+                "id": "wireless",
+                "ver_code": 1
+            },
+            {
+                "id": "map",
+                "ver_code": 2
+            },
+            {
+                "id": "auto_change_map",
+                "ver_code": -1
+            },
+            {
+                "id": "ble_whole_setup",
+                "ver_code": 1
+            },
+            {
+                "id": "dust_bucket",
+                "ver_code": 1
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            },
+            {
+                "id": "mop",
+                "ver_code": 1
+            },
+            {
+                "id": "do_not_disturb",
+                "ver_code": 1
+            },
+            {
+                "id": "device_local_time",
+                "ver_code": 1
+            },
+            {
+                "id": "charge_pose_clean",
+                "ver_code": 1
+            },
+            {
+                "id": "continue_breakpoint_sweep",
+                "ver_code": 1
+            },
+            {
+                "id": "goto_point",
+                "ver_code": 1
+            },
+            {
+                "id": "furniture",
+                "ver_code": 1
+            },
+            {
+                "id": "map_cloud_backup",
+                "ver_code": 1
+            },
+            {
+                "id": "dev_log",
+                "ver_code": 1
+            },
+            {
+                "id": "map_lock",
+                "ver_code": 1
+            },
+            {
+                "id": "carpet_area",
+                "ver_code": 1
+            },
+            {
+                "id": "clean_angle",
+                "ver_code": 1
+            },
+            {
+                "id": "clean_percent",
+                "ver_code": 1
+            },
+            {
+                "id": "no_pose_config",
+                "ver_code": 1
+            },
+            {
+                "id": "matter",
+                "ver_code": 3
+            }
+        ]
+    },
+    "discovery_result": {
+        "error_code": 0,
+        "result": {
+            "device_id": "00000000000000000000000000000000",
+            "device_model": "RV20 Max Plus(EU)",
+            "device_type": "SMART.TAPOROBOVAC",
+            "factory_default": false,
+            "ip": "127.0.0.123",
+            "is_support_iot_cloud": true,
+            "mac": "B0-19-21-00-00-00",
+            "mgt_encrypt_schm": {
+                "encrypt_type": "TPAP",
+                "http_port": 4433,
+                "is_support_https": true,
+                "lv": 2
+            },
+            "obd_src": "tplink",
+            "owner": "00000000000000000000000000000000",
+            "protocol_version": 1,
+            "tpap": {
+                "dac": 1,
+                "noc": 1,
+                "pake": [
+                    2
+                ],
+                "port": 4433,
+                "tls": 2
+            }
+        }
+    },
+    "getAreaUnit": {
+        "area_unit": 0
+    },
+    "getAutoChangeMap": {
+        "auto_change_map": false
+    },
+    "getAutoDustCollection": {
+        "auto_dust_collection": 1
+    },
+    "getBatteryInfo": {
+        "battery_percentage": 100
+    },
+    "getCarpetClean": {
+        "carpet_clean_prefer": "boost"
+    },
+    "getChildLockInfo": {
+        "child_lock_status": false
+    },
+    "getCleanAttr": {
+        "cistern": 2,
+        "clean_number": 1,
+        "suction": 2
+    },
+    "getCleanInfo": {
+        "clean_area": 0,
+        "clean_percent": 100,
+        "clean_time": 0
+    },
+    "getCleanRecords": {
+        "lastest_day_record": [
+            0,
+            0,
+            0,
+            0
+        ],
+        "record_list": [],
+        "record_list_num": 0,
+        "total_area": 0,
+        "total_number": 0,
+        "total_time": 0
+    },
+    "getCleanStatus": {
+        "clean_status": 3,
+        "is_mapping": false,
+        "is_relocating": false,
+        "is_working": false
+    },
+    "getConsumablesInfo": {
+        "charge_contact_time": 0,
+        "edge_brush_time": 0,
+        "filter_time": 0,
+        "main_brush_lid_time": 0,
+        "rag_time": 0,
+        "roll_brush_time": 0,
+        "sensor_time": 0
+    },
+    "getCurrentVoiceLanguage": {
+        "name": "2",
+        "version": 1
+    },
+    "getDoNotDisturb": {
+        "do_not_disturb": true,
+        "e_min": 480,
+        "s_min": 1320
+    },
+    "getDustCollectionInfo": {
+        "auto_dust_collection": true,
+        "dust_collection_mode": 0
+    },
+    "getMapData": -100000,
+    "getMapInfo": {
+        "auto_change_map": false,
+        "current_map_id": 0,
+        "map_list": [],
+        "map_num": 0,
+        "version": "LDS"
+    },
+    "getMopState": {
+        "mop_state": false
+    },
+    "getVacStatus": {
+        "err_status": [
+            0
+        ],
+        "errorCode_id": [
+            600528863
+        ],
+        "prompt": [],
+        "promptCode_id": [],
+        "status": 6
+    },
+    "getVolume": {
+        "volume": 85
+    },
+    "get_device_info": {
+        "auto_pack_ver": "0.0.27.1882",
+        "avatar": "",
+        "board_sn": "000000000000",
+        "cd": "I01BU0tFRF9CSU5BUlkj",
+        "custom_sn": "000000000000",
+        "device_id": "0000000000000000000000000000000000000000",
+        "fw_id": "00000000000000000000000000000000",
+        "fw_ver": "1.3.0 Build 260301 Rel.183440",
+        "has_set_location_info": true,
+        "hw_id": "00000000000000000000000000000000",
+        "hw_ver": "1.0",
+        "ip": "127.0.0.123",
+        "lang": "",
+        "latitude": 0,
+        "linux_ver": "V23.203.1751612106",
+        "location": "",
+        "longitude": 0,
+        "mac": "B0-19-21-00-00-00",
+        "mcu_ver": "1.1.2578.51",
+        "model": "RV20 Max Plus",
+        "nickname": "I01BU0tFRF9OQU1FIw==",
+        "oem_id": "00000000000000000000000000000000",
+        "overheated": false,
+        "product_id": "1793",
+        "region": "Europe/Berlin",
+        "rssi": -31,
+        "signal_level": 3,
+        "specs": "",
+        "ssid": "I01BU0tFRF9TU0lEIw==",
+        "sub_ver": "0.0.27.1882-1.2.41",
+        "time_diff": 60,
+        "total_ver": "1.2.41",
+        "type": "SMART.TAPOROBOVAC",
+        "vendor_id": "5010"
+    },
+    "get_device_time": {
+        "region": "Europe/Berlin",
+        "time_diff": 60,
+        "timestamp": 1783727145
+    },
+    "get_fw_download_state": {
+        "auto_upgrade": false,
+        "download_progress": 0,
+        "reboot_time": 5,
+        "status": 0,
+        "upgrade_time": 5
+    },
+    "get_inherit_info": null,
+    "get_latest_fw": {
+        "fw_size": 0,
+        "fw_ver": "1.3.0 Build 260301 Rel.183440",
+        "hw_id": "",
+        "need_to_upgrade": false,
+        "oem_id": "",
+        "release_date": "",
+        "release_note": "",
+        "type": 0
+    },
+    "get_next_event": {},
+    "get_schedule_rules": {
+        "enable": false,
+        "rule_list": [],
+        "schedule_rule_max_count": 32,
+        "start_index": 0,
+        "sum": 0
+    },
+    "get_wireless_scan_info": {
+        "ap_list": [
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 3,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 3,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 3,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 2,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            },
+            {
+                "key_type": "wpa2_psk",
+                "signal_level": 1,
+                "ssid": "I01BU0tFRF9TU0lEIw=="
+            }
+        ],
+        "start_index": 0,
+        "sum": 8,
+        "wep_supported": true
+    },
+    "qs_component_nego": {
+        "component_list": [
+            {
+                "id": "quick_setup",
+                "ver_code": 1
+            },
+            {
+                "id": "iot_cloud",
+                "ver_code": 1
+            },
+            {
+                "id": "firmware",
+                "ver_code": 1
+            },
+            {
+                "id": "ble_whole_setup",
+                "ver_code": 1
+            },
+            {
+                "id": "inherit",
+                "ver_code": 1
+            }
+        ],
+        "extra_info": {
+            "device_model": "RV20 Max Plus",
+            "device_type": "SMART.TAPOROBOVAC"
+        }
+    }
+}


### PR DESCRIPTION
Used #1592 to dump the fixture, which caused map reset as described in #1516 and #1665.

The device reports matter support, but fails to query information (requires active pairing mode?), the last error from the run is `Device 192.168.x.x received unknown error code: -3016` followed up with the fixture dump, unsure if it finished properly.

```
> python -m devtools.dump_devinfo --host 192.168.x.x
Host given, performing discovery on 192.168.x.x.
Testing component_nego call ..OK
Skipping ble_whole_setup..UNSUPPORTED
Skipping furniture..UNSUPPORTED
Skipping map_cloud_backup..UNSUPPORTED
Skipping dev_log..UNSUPPORTED
Skipping map_lock..UNSUPPORTED
Skipping carpet_area..UNSUPPORTED
Skipping clean_angle..UNSUPPORTED
Skipping clean_percent..UNSUPPORTED
Skipping no_pose_config..UNSUPPORTED
Testing  device..Testing SmartCall(module='device', request={'get_device_info': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  time..Testing SmartCall(module='time', request={'get_device_time': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  firmware..Testing SmartCall(module='firmware', request={'get_fw_download_state': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  firmware..Testing SmartCall(module='firmware', request={'get_latest_fw': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  quick_setup..Testing SmartCall(module='quick_setup', request={'qs_component_nego': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getCarpetClean': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getCleanRecords': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getVacStatus': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getAreaUnit': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getCleanInfo': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getCleanStatus': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  clean..Testing SmartCall(module='clean', request={'getCleanAttr': {'type': 'global'}}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  battery..Testing SmartCall(module='battery', request={'getBatteryInfo': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  consumables..Testing SmartCall(module='consumables', request={'getConsumablesInfo': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  button_and_led..Testing SmartCall(module='button_and_led', request={'getChildLockInfo': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  speaker..Testing SmartCall(module='speaker', request={'getSupportVoiceLanguage': None}, should_succeed=True, child_device_id='', supports_multiple=True)..FAIL Error querying device: 192.168.x.x: UNKNOWN_METHOD_ERROR(-1002) for method: getSupportVoiceLanguage (error_code=UNKNOWN_METHOD_ERROR)
Testing  speaker..Testing SmartCall(module='speaker', request={'getCurrentVoiceLanguage': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  speaker..Testing SmartCall(module='speaker', request={'getVolume': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  schedule..Testing SmartCall(module='schedule', request={'get_schedule_rules': {'start_index': 0, 'schedule_mode': ''}}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  schedule..Testing SmartCall(module='schedule', request={'get_next_event': {'start_index': 0}}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  wireless..Testing SmartCall(module='wireless', request={'get_wireless_scan_info': {'start_index': 0}}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  map..Testing SmartCall(module='map', request={'getMapInfo': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  map..Testing SmartCall(module='map', request={'getMapData': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  auto_change_map..Testing SmartCall(module='auto_change_map', request={'getAutoChangeMap': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  dust_bucket..Testing SmartCall(module='dust_bucket', request={'getAutoDustCollection': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  dust_bucket..Testing SmartCall(module='dust_bucket', request={'getDustCollectionInfo': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  inherit..Testing SmartCall(module='inherit', request={'get_inherit_info': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  mop..Testing SmartCall(module='mop', request={'getMopState': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  do_not_disturb..Testing SmartCall(module='do_not_disturb', request={'getDoNotDisturb': None}, should_succeed=True, child_device_id='', supports_multiple=True)..OK
Testing  matter..Testing SmartCall(module='matter', request={'get_matter_setup_info': None}, should_succeed=True, child_device_id='', supports_multiple=True)..FAIL Error querying device: 192.168.x.x: UNKNOWN_METHOD_ERROR(-1002) for method: get_matter_setup_info (error_code=UNKNOWN_METHOD_ERROR)
Device 192.168.x.x received unknown error code: -3016
Got 29 successes
``` 