### PR TITLE
Feature/dlklap transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ venv
 
 /build
 docs/build
+
+# MacOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ The following devices have been tested and confirmed as working. If your device 
 - **Cameras**: C100, C101, C110, C210, C220, C225, C325WB, C460, C520WS, C720, TC40, TC65, TC70
 - **Doorbells and chimes**: D100C, D130, D230
 - **Vacuums**: RV20 Max Plus, RV30 Max
+- **Locks**: DL100
 - **Hubs**: H100, H200
 - **Hub-Connected Devices[^3]**: S200B, S200D, T100, T110, T300, T310, T315
 

--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -352,6 +352,11 @@ All Tapo devices require authentication.<br>Hub-Connected Devices may work acros
 - **RV30 Max**
   - Hardware: 1.0 (US) / Firmware: 1.2.0
 
+### Locks
+
+- **DL100**
+  - Hardware: 1.0 (US) / Firmware: 1.0.17
+
 ### Hubs
 
 - **H100**

--- a/devtools/generate_supported.py
+++ b/devtools/generate_supported.py
@@ -39,6 +39,7 @@ DEVICE_TYPE_TO_PRODUCT_GROUP = {
     DeviceType.Doorbell: "Doorbells and chimes",
     DeviceType.Chime: "Doorbells and chimes",
     DeviceType.Vacuum: "Vacuums",
+    DeviceType.Lock: "Locks",
     DeviceType.Hub: "Hubs",
     DeviceType.Sensor: "Hub-Connected Devices",
     DeviceType.Thermostat: "Hub-Connected Devices",

--- a/kasa/device_factory.py
+++ b/kasa/device_factory.py
@@ -30,6 +30,7 @@ from .smartcam import SmartCamDevice
 from .transports import (
     AesTransport,
     BaseTransport,
+    DlklapTransport,
     KlapTransport,
     KlapTransportV2,
     LinkieTransportV2,
@@ -232,6 +233,7 @@ def get_protocol(config: DeviceConfig, *, strict: bool = False) -> BaseProtocol 
         "SMART.AES": (SmartProtocol, AesTransport),
         "SMART.KLAP": (SmartProtocol, KlapTransportV2),
         "SMART.KLAP.HTTPS": (SmartProtocol, KlapTransportV2),
+        "SMART.DLKLAP": (SmartProtocol, DlklapTransport),
         # H200 is device family SMART.TAPOHUB and uses SmartCamProtocol so use
         # https to distuingish from SmartProtocol devices
         "SMART.AES.HTTPS": (SmartCamProtocol, SslAesTransport),

--- a/kasa/device_type.py
+++ b/kasa/device_type.py
@@ -24,6 +24,7 @@ class DeviceType(Enum):
     Vacuum = "vacuum"
     Chime = "chime"
     Doorbell = "doorbell"
+    Lock = "lock"
     Unknown = "unknown"
 
     @staticmethod

--- a/kasa/deviceconfig.py
+++ b/kasa/deviceconfig.py
@@ -62,6 +62,7 @@ class DeviceEncryptionType(Enum):
     Klap = "KLAP"
     Aes = "AES"
     Xor = "XOR"
+    Dlklap = "DLKLAP"
 
 
 class DeviceFamily(Enum):
@@ -81,6 +82,7 @@ class DeviceFamily(Enum):
     SmartTapoRobovac = "SMART.TAPOROBOVAC"
     SmartTapoChime = "SMART.TAPOCHIME"
     SmartTapoDoorbell = "SMART.TAPODOORBELL"
+    SmartTapoLock = "SMART.TAPOLOCK"
 
 
 class _DeviceConfigBaseMixin(DataClassJSONMixin):

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -71,8 +71,8 @@ if TYPE_CHECKING:
     from .device import Device
     from .iot import modules as iot
     from .smart import modules as smart
-    from .smartcam import modules as smartcam
     from .smart.modules import Lock
+    from .smartcam import modules as smartcam
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/kasa/module.py
+++ b/kasa/module.py
@@ -72,6 +72,7 @@ if TYPE_CHECKING:
     from .iot import modules as iot
     from .smart import modules as smart
     from .smartcam import modules as smartcam
+    from .smart.modules import Lock
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -140,6 +141,7 @@ class Module(ABC):
     LightTransition: Final[ModuleName[smart.LightTransition]] = ModuleName(
         "LightTransition"
     )
+    Lock: Final[ModuleName[Lock]] = ModuleName("Lock")
     MotionSensor: Final[ModuleName[smart.MotionSensor]] = ModuleName("MotionSensor")
     ReportMode: Final[ModuleName[smart.ReportMode]] = ModuleName("ReportMode")
     SmartLightEffect: Final[ModuleName[smart.SmartLightEffect]] = ModuleName(

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -43,8 +43,10 @@ from .thermostat import Thermostat
 from .time import Time
 from .triggerlogs import TriggerLogs
 from .waterleaksensor import WaterleakSensor
+from .lock import Lock
 
 __all__ = [
+    "Lock",
     "Alarm",
     "Time",
     "Energy",

--- a/kasa/smart/modules/__init__.py
+++ b/kasa/smart/modules/__init__.py
@@ -30,6 +30,7 @@ from .lighteffect import LightEffect
 from .lightpreset import LightPreset
 from .lightstripeffect import LightStripEffect
 from .lighttransition import LightTransition
+from .lock import Lock
 from .matter import Matter
 from .mop import Mop
 from .motionsensor import MotionSensor
@@ -43,7 +44,6 @@ from .thermostat import Thermostat
 from .time import Time
 from .triggerlogs import TriggerLogs
 from .waterleaksensor import WaterleakSensor
-from .lock import Lock
 
 __all__ = [
     "Lock",

--- a/kasa/smart/modules/lock.py
+++ b/kasa/smart/modules/lock.py
@@ -1,0 +1,72 @@
+"""Implementation of lock module for TP-Link DL100 smart locks."""
+
+from __future__ import annotations
+
+import logging
+
+from ...feature import Feature
+from ..smartmodule import SmartModule
+
+_LOGGER = logging.getLogger(__name__)
+
+# lock_status polarity is device-verified and counterintuitive:
+#   0 == bolt extended  == LOCKED
+#   1 == bolt retracted == UNLOCKED
+#   2 UNINITIALIZED, 3 JAM_IN_UNLOCKING, 4 JAM_IN_LOCKING
+LOCK_STATUS_LOCKED = 0
+LOCK_STATUS_UNLOCKED = 1
+
+
+class Lock(SmartModule):
+    """Implementation of lock module for SMART.TAPOLOCK devices (DL100)."""
+
+    # No component list is exposed by the DL100; depend on the sysinfo key.
+    REQUIRED_COMPONENT = None
+    SYSINFO_LOOKUP_KEYS = ["lock_status"]
+
+    # Owner (local) path always uses this synthetic user id. Do NOT send
+    # tplink_account / access_info / lock_type / unlock_type for the owner.
+    SA_USER_ID = "local_1"
+
+    def _initialize_features(self) -> None:
+        """Initialize features after the initial update."""
+        self._add_feature(
+            Feature(
+                self._device,
+                id="is_locked",
+                name="Locked",
+                container=self,
+                attribute_getter="is_locked",
+                icon="mdi:lock",
+                category=Feature.Category.Primary,
+                type=Feature.Type.BinarySensor,
+            )
+        )
+
+    def query(self) -> dict:
+        """Query to execute during the update cycle."""
+        return {}
+
+    @property
+    def is_locked(self) -> bool:
+        """Return True when the bolt is extended (lock_status == 0)."""
+        return self._device.sys_info["lock_status"] == LOCK_STATUS_LOCKED
+
+    async def lock(self) -> dict:
+        """Lock the device (extend the bolt)."""
+        return await self._set_lock_status(LOCK_STATUS_LOCKED)
+
+    async def unlock(self) -> dict:
+        """Unlock the device (retract the bolt)."""
+        return await self._set_lock_status(LOCK_STATUS_UNLOCKED)
+
+    async def _set_lock_status(self, status: int) -> dict:
+        """Send setLockStatus for the owner (local) path.
+
+        SmartProtocol wraps this into the multipleRequest envelope the device
+        expects, so we only supply the method name and params here.
+        """
+        return await self.call(
+            "setLockStatus",
+            {"lock_status": status, "sa_user_id": self.SA_USER_ID},
+        )

--- a/kasa/smart/modules/lock.py
+++ b/kasa/smart/modules/lock.py
@@ -42,6 +42,38 @@ class Lock(SmartModule):
                 type=Feature.Type.BinarySensor,
             )
         )
+        # The DL100 reports battery in getDeviceInfo but does NOT advertise the
+        # "battery_detect" component, so the generic BatterySensor module never
+        # loads for it. Expose battery here instead, mirroring BatterySensor's
+        # feature ids so downstream consumers (e.g. Home Assistant) stay
+        # consistent.
+        if "battery_percentage" in self._device.sys_info:
+            self._add_feature(
+                Feature(
+                    self._device,
+                    id="battery_level",
+                    name="Battery level",
+                    container=self,
+                    attribute_getter="battery",
+                    icon="mdi:battery",
+                    unit_getter=lambda: "%",
+                    category=Feature.Category.Info,
+                    type=Feature.Type.Sensor,
+                )
+            )
+        if "at_low_battery" in self._device.sys_info:
+            self._add_feature(
+                Feature(
+                    self._device,
+                    id="battery_low",
+                    name="Battery low",
+                    container=self,
+                    attribute_getter="battery_low",
+                    icon="mdi:alert",
+                    category=Feature.Category.Debug,
+                    type=Feature.Type.BinarySensor,
+                )
+            )
 
     def query(self) -> dict:
         """Query to execute during the update cycle."""
@@ -51,6 +83,16 @@ class Lock(SmartModule):
     def is_locked(self) -> bool:
         """Return True when the bolt is extended (lock_status == 0)."""
         return self._device.sys_info["lock_status"] == LOCK_STATUS_LOCKED
+
+    @property
+    def battery(self) -> int:
+        """Return the battery level percentage."""
+        return self._device.sys_info["battery_percentage"]
+
+    @property
+    def battery_low(self) -> bool:
+        """Return True if the battery is low."""
+        return bool(self._device.sys_info["at_low_battery"])
 
     async def lock(self) -> dict:
         """Lock the device (extend the bolt)."""

--- a/kasa/smart/smartdevice.py
+++ b/kasa/smart/smartdevice.py
@@ -886,6 +886,8 @@ class SmartDevice(Device):
             return DeviceType.Vacuum
         if "TAPOCHIME" in device_type:
             return DeviceType.Chime
+        if "TAPOLOCK" in device_type:
+            return DeviceType.Lock
         _LOGGER.warning("Unknown device type, falling back to plug")
         return DeviceType.Plug
 

--- a/kasa/transports/__init__.py
+++ b/kasa/transports/__init__.py
@@ -2,6 +2,7 @@
 
 from .aestransport import AesEncyptionSession, AesTransport
 from .basetransport import BaseTransport
+from .dlklaptransport import DlklapTransport
 from .klaptransport import KlapTransport, KlapTransportV2
 from .linkietransport import LinkieTransportV2
 from .sslaestransport import SslAesTransport
@@ -14,6 +15,7 @@ __all__ = [
     "SslTransport",
     "SslAesTransport",
     "BaseTransport",
+    "DlklapTransport",
     "KlapTransport",
     "KlapTransportV2",
     "LinkieTransportV2",

--- a/kasa/transports/dlklaptransport.py
+++ b/kasa/transports/dlklaptransport.py
@@ -152,10 +152,15 @@ class DlklapTransport(BaseTransport):
         -- which is inconsistent with the KLAP/AES transports that always
         expose a non-null hash derived from the (possibly empty) credentials.
         The real credential requirement is enforced later in ``_ensure_login``.
+
+        NOTE: this token is deliberately derived from the (non-secret) username
+        only. The password must never be fed into a fast hash such as SHA256:
+        DLKLAP authenticates against the cloud in ``_ensure_login`` (where a
+        wrong password is rejected), so this value exists purely as a stable,
+        non-null sentinel and carries no authentication weight.
         """
         username = self._credentials.username if self._credentials else ""
-        password = self._credentials.password if self._credentials else ""
-        return _sha256(f"{username}:{password}".encode()).hex()
+        return _sha256(username.encode()).hex()
 
     async def send(self, request: str) -> dict[str, Any]:
         """Encrypt ``request``, POST to /app/request, return the decrypted dict.

--- a/kasa/transports/dlklaptransport.py
+++ b/kasa/transports/dlklaptransport.py
@@ -50,12 +50,12 @@ from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from kasa.deviceconfig import DeviceConfig
-from kasa.httpclient import HttpClient
 from kasa.exceptions import (
     AuthenticationError,
     KasaException,
     _RetryableError,
 )
+from kasa.httpclient import HttpClient
 from kasa.json import loads as json_loads
 
 from .basetransport import BaseTransport
@@ -213,9 +213,7 @@ class DlklapTransport(BaseTransport):
         rand4 = secrets.token_bytes(4)
         secret = await self._handshake0(lock_client, rand4)
         control_key = await self._fetch_control_key(secret, rand4)
-        local_seed, remote_seed, lmk = await self._handshake1(
-            lock_client, control_key
-        )
+        local_seed, remote_seed, lmk = await self._handshake1(lock_client, control_key)
         await self._handshake2(lock_client, local_seed, remote_seed, lmk)
 
         self._session = _DlklapSession(local_seed, remote_seed, lmk)
@@ -226,7 +224,7 @@ class DlklapTransport(BaseTransport):
         if self._lock_client is None:
             timeout = httpx.Timeout(READ_TIMEOUT, connect=CONNECT_TIMEOUT)
             # verify=False: the device speaks plain HTTP, no TLS involved.
-            self._lock_client = httpx.AsyncClient(timeout=timeout, verify=False)
+            self._lock_client = httpx.AsyncClient(timeout=timeout, verify=False)  # noqa: S501
         return self._lock_client
 
     def _lock_headers(self, *, with_cookie: bool = False) -> dict[str, str]:
@@ -285,7 +283,10 @@ class DlklapTransport(BaseTransport):
         """
         if self._device_id:
             return
-        assert self._token is not None
+        if self._token is None:
+            raise KasaException(
+                "DLKLAP: cloud login required before resolving device id"
+            )
         _LOGGER.debug("DLKLAP resolving device id from cloud device list")
         async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=True) as client:
             resp = await client.post(
@@ -298,9 +299,7 @@ class DlklapTransport(BaseTransport):
         if body.get("error_code", -1) != 0:
             raise KasaException(f"getDeviceList failed: {body.get('msg', body)}")
         devices = body.get("result", {}).get("deviceList", [])
-        locks = [
-            d for d in devices if d.get("deviceType") == self.DEVICE_TYPE
-        ]
+        locks = [d for d in devices if d.get("deviceType") == self.DEVICE_TYPE]
         if len(locks) == 1:
             self._device_id = locks[0]["deviceId"]
         elif not locks:
@@ -315,14 +314,13 @@ class DlklapTransport(BaseTransport):
 
     # -- Step 2: handshake0 -------------------------------------------------
 
-    async def _handshake0(
-        self, lock_client: httpx.AsyncClient, rand4: bytes
-    ) -> str:
+    async def _handshake0(self, lock_client: httpx.AsyncClient, rand4: bytes) -> str:
         """Wake the lock and obtain the 236-char base64 ``secret``.
 
         Body is 33 raw bytes: sha((hex(rand4)+accountId).upper())[:32] + 0x00.
         """
-        assert self._account_id is not None
+        if self._account_id is None:
+            raise KasaException("DLKLAP: cloud login required before handshake0")
         hash_input = (rand4.hex() + self._account_id).upper().encode("ascii")
         body = _sha256(hash_input) + b"\x00"  # 32 + 1 = 33 bytes
 
@@ -343,8 +341,7 @@ class DlklapTransport(BaseTransport):
             ) as ex:
                 last_exc = ex
                 _LOGGER.debug(
-                    "handshake0 attempt %s/%s to %s failed (%s), lock may be "
-                    "waking",
+                    "handshake0 attempt %s/%s to %s failed (%s), lock may be waking",
                     attempt,
                     HANDSHAKE0_RETRIES,
                     self._host,
@@ -360,8 +357,10 @@ class DlklapTransport(BaseTransport):
 
     async def _fetch_control_key(self, secret: str, rand4: bytes) -> str:
         """Exchange the handshake0 ``secret`` for a per-session control key."""
-        assert self._token is not None
-        assert self._device_id is not None
+        if self._token is None or self._device_id is None:
+            raise KasaException(
+                "DLKLAP: login and device id required before control-key exchange"
+            )
         url = CONTROL_KEY_URL_FMT.format(device_id=self._device_id)
         headers = {
             "Content-Type": "application/json",
@@ -378,7 +377,7 @@ class DlklapTransport(BaseTransport):
         # This host presents TP-Link's PRIVATE CA (not a public root), so TLS
         # verification must be disabled for THIS call only. The login call above
         # carries the account password and stays fully verified.
-        async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=False) as client:
+        async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=False) as client:  # noqa: S501
             resp = await client.post(
                 url,
                 json={"secret": secret, "random": rand4.hex().upper()},
@@ -388,9 +387,7 @@ class DlklapTransport(BaseTransport):
         body = resp.json()
         control_key = body.get("controlKey")
         if not control_key:
-            raise AuthenticationError(
-                f"Cloud did not return a controlKey: {body}"
-            )
+            raise AuthenticationError(f"Cloud did not return a controlKey: {body}")
         return control_key
 
     # -- Step 4: handshake1 -------------------------------------------------
@@ -416,8 +413,7 @@ class DlklapTransport(BaseTransport):
         raw = resp.content
         if len(raw) != 48:
             raise KasaException(
-                f"handshake1 from {self._host} returned {len(raw)} bytes, "
-                "expected 48"
+                f"handshake1 from {self._host} returned {len(raw)} bytes, expected 48"
             )
         remote_seed = raw[:16]
         server_proof = raw[16:]
@@ -466,7 +462,8 @@ class DlklapTransport(BaseTransport):
     # -- Step 7: encrypted request ------------------------------------------
 
     async def _send_encrypted(self, request: str) -> dict[str, Any]:
-        assert self._session is not None
+        if self._session is None:
+            raise KasaException("DLKLAP: no active session")
         lock_client = self._get_lock_client()
         payload, seq = self._session.encrypt(request.encode())
         try:

--- a/kasa/transports/dlklaptransport.py
+++ b/kasa/transports/dlklaptransport.py
@@ -1,0 +1,530 @@
+"""Implementation of the TP-Link DLKLAP protocol used by the DL100 smart lock.
+
+DLKLAP is a proprietary variant of KLAP (see ``klaptransport.py``) with two key
+differences:
+
+1. It runs over plain **HTTP :80** (never HTTPS to the device).
+2. Before the usual handshake1/handshake2 it requires a **cloud-assisted**
+   ``handshake0`` step: the client wakes the lock with a challenge derived from
+   the TP-Link cloud ``accountId``, the lock returns a ``secret``, and the
+   client exchanges that ``secret`` with the TP-Link cloud for a per-session
+   ``controlKey``. That control key then plays the role KLAP's ``auth_hash``
+   plays in seeding handshake1/handshake2 and the encryption session.
+
+Sequence (all device steps are device-verified on DL100 fw 1.0.17):
+
+    cloud login            -> token, accountId
+    handshake0  (device)   -> secret            (wakes the lock radio)
+    control-key (cloud)    -> controlKey
+    handshake1  (device)   -> R + server_proof  (+ TP_SESSIONID cookie)
+    handshake2  (device)   -> 200
+    derive lsk/ldk/iv/seq
+    /app/request (device)  -> encrypted app-layer calls
+
+Only ONE handshake0 may complete per session -- a second one rotates device
+state and invalidates the minted control key (cloud error 15033). All session
+establishment is therefore serialized through ``self._handshake_lock``.
+
+Implementation note
+-------------------
+Unlike the other transports this one uses ``httpx`` directly rather than
+``kasa.httpclient.HttpClient``. The raw 33-byte ``handshake0`` body must reach
+the device byte-for-byte; wrapping middleware that re-encodes ``text/plain``
+binary payloads corrupts it (this is the same reason the TypeScript reference
+implementation uses ``node:http`` rather than undici). Migrating to
+``HttpClient`` is a possible follow-up once it is confirmed not to mutate the
+body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import secrets
+import uuid
+from typing import Any
+
+import httpx
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from kasa.deviceconfig import DeviceConfig
+from kasa.exceptions import (
+    AuthenticationError,
+    KasaException,
+    _RetryableError,
+)
+from kasa.json import loads as json_loads
+
+from .basetransport import BaseTransport
+
+_LOGGER = logging.getLogger(__name__)
+
+# Cloud endpoints.
+CLOUD_LOGIN_URL = "https://wap.tplinkcloud.com/"
+CONTROL_KEY_URL_FMT = (
+    "https://use1-app-server.iot.i.tplinknbu.com/v1/things/{device_id}/control-key"
+)
+
+# Networking.
+DEFAULT_HTTP_PORT = 80
+# Battery locks sleep their radio; the first TCP SYN can be dropped while it
+# wakes, so we allow a generous connect timeout and a few handshake0 retries.
+CONNECT_TIMEOUT = 15.0
+READ_TIMEOUT = 15.0
+HANDSHAKE0_RETRIES = 4
+HANDSHAKE0_RETRY_DELAY = 2.0
+
+SESSION_COOKIE_NAME = "TP_SESSIONID"
+
+
+def _sha256(payload: bytes) -> bytes:
+    return hashlib.sha256(payload).digest()  # noqa: S324
+
+
+class DlklapTransport(BaseTransport):
+    """Implementation of the DLKLAP protocol for TP-Link DL100 smart locks.
+
+    Required credentials are the TP-Link **cloud** account username (email) and
+    password -- the same account the lock is registered to. The device id is
+    resolved from the cloud device list on first connect (see
+    :meth:`_ensure_device_id`).
+    """
+
+    DEFAULT_PORT: int = DEFAULT_HTTP_PORT
+    DEVICE_TYPE: str = "SMART.TAPOLOCK"
+
+    def __init__(self, *, config: DeviceConfig) -> None:
+        super().__init__(config=config)
+
+        if not self._credentials or not self._credentials.username:
+            raise AuthenticationError(
+                "DLKLAP requires TP-Link cloud credentials "
+                "(username/email and password)."
+            )
+
+        # A stable app-instance UUID reused for the lifetime of the transport.
+        self._terminal_uuid: str = str(uuid.uuid4()).upper()
+
+        # Cloud-derived state.
+        self._token: str | None = None
+        self._account_id: str | None = None
+        self._device_id: str | None = None
+
+        # Live session state.
+        self._session: _DlklapSession | None = None
+        self._session_cookie: str | None = None
+        self._handshake_done: bool = False
+        self._handshake_lock = asyncio.Lock()
+
+        # Persistent HTTP client to the lock. The TP_SESSIONID cookie is
+        # connection-scoped, so hs0/hs1/hs2/request must all reuse this client.
+        self._lock_client: httpx.AsyncClient | None = None
+
+        _LOGGER.debug("Created DLKLAP transport for %s", self._host)
+        self._base_url = f"http://{self._host}:{self._port}"
+
+    # -- BaseTransport interface --------------------------------------------
+
+    @property
+    def default_port(self) -> int:
+        """Default port for the transport (DLKLAP is always HTTP :80)."""
+        if port := self._config.connection_type.http_port:
+            return port
+        return self.DEFAULT_PORT
+
+    @property
+    def credentials_hash(self) -> str | None:
+        """DLKLAP authenticates via the cloud; no reusable local hash."""
+        return None
+
+    async def send(self, request: str) -> dict[str, Any]:
+        """Encrypt ``request``, POST to /app/request, return the decrypted dict.
+
+        On any failure the session is cleared and a single fresh re-handshake is
+        attempted before giving up.
+        """
+        async with self._handshake_lock:
+            last_exc: Exception | None = None
+            for attempt in range(2):
+                try:
+                    if not self._handshake_done or self._session is None:
+                        await self._establish_session()
+                    return await self._send_encrypted(request)
+                except _RetryableError as ex:
+                    last_exc = ex
+                    _LOGGER.debug(
+                        "DLKLAP send attempt %s to %s failed, resetting session",
+                        attempt + 1,
+                        self._host,
+                    )
+                    await self.reset()
+            raise KasaException(
+                f"DLKLAP request to {self._host} failed after retry"
+            ) from last_exc
+
+    async def close(self) -> None:
+        """Close the HTTP client and reset internal state."""
+        await self.reset()
+        client, self._lock_client = self._lock_client, None
+        if client is not None:
+            await client.aclose()
+
+    async def reset(self) -> None:
+        """Reset handshake/session state (keeps the cloud token)."""
+        self._handshake_done = False
+        self._session = None
+        self._session_cookie = None
+
+    # -- Session establishment ----------------------------------------------
+
+    async def _establish_session(self) -> None:
+        """Full handshake0 -> control-key -> handshake1/2 -> derive keys."""
+        _LOGGER.debug("Starting DLKLAP handshake with %s", self._host)
+        await self.reset()
+
+        await self._ensure_login()
+        await self._ensure_device_id()
+
+        lock_client = self._get_lock_client()
+        rand4 = secrets.token_bytes(4)
+        secret = await self._handshake0(lock_client, rand4)
+        control_key = await self._fetch_control_key(secret, rand4)
+        local_seed, remote_seed, lmk = await self._handshake1(
+            lock_client, control_key
+        )
+        await self._handshake2(lock_client, local_seed, remote_seed, lmk)
+
+        self._session = _DlklapSession(local_seed, remote_seed, lmk)
+        self._handshake_done = True
+        _LOGGER.debug("DLKLAP handshake with %s complete", self._host)
+
+    def _get_lock_client(self) -> httpx.AsyncClient:
+        if self._lock_client is None:
+            timeout = httpx.Timeout(READ_TIMEOUT, connect=CONNECT_TIMEOUT)
+            # verify=False: the device speaks plain HTTP, no TLS involved.
+            self._lock_client = httpx.AsyncClient(timeout=timeout, verify=False)
+        return self._lock_client
+
+    def _lock_headers(self, *, with_cookie: bool = False) -> dict[str, str]:
+        headers = {
+            "Content-Type": "text/plain",
+            "Referer": f"{self._base_url}/",
+            "Accept": "application/json",
+            "requestByApp": "true",
+        }
+        if with_cookie and self._session_cookie:
+            headers["Cookie"] = self._session_cookie
+        return headers
+
+    # -- Step 1: cloud login ------------------------------------------------
+
+    async def _ensure_login(self) -> None:
+        if self._token and self._account_id:
+            return
+        _LOGGER.debug("DLKLAP cloud login")
+        assert self._credentials is not None
+        async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=True) as client:
+            resp = await client.post(
+                CLOUD_LOGIN_URL,
+                json={
+                    "method": "login",
+                    "params": {
+                        "appType": "Tapo_Android",
+                        "cloudUserName": self._credentials.username,
+                        "cloudPassword": self._credentials.password,
+                        "terminalUUID": self._terminal_uuid,
+                        "refreshTokenNeeded": False,
+                    },
+                },
+            )
+        resp.raise_for_status()
+        body = resp.json()
+        if body.get("error_code", -1) != 0:
+            raise AuthenticationError(
+                f"DLKLAP cloud login failed: {body.get('msg', body)}"
+            )
+        self._token = body["result"]["token"]
+        self._account_id = body["result"]["accountId"]
+
+    async def _ensure_device_id(self) -> None:
+        """Resolve the cloud device id for this lock.
+
+        NOTE: not yet device-verified. The cloud device list does not expose the
+        device LAN IP, so when the account owns more than one lock we cannot
+        reliably match by ``self._host``. For now we pick the single
+        ``SMART.TAPOLOCK`` device if there is exactly one; otherwise an explicit
+        override must be supplied. This should be revisited before merge.
+        """
+        if self._device_id:
+            return
+        assert self._token is not None
+        _LOGGER.debug("DLKLAP resolving device id from cloud device list")
+        async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=True) as client:
+            resp = await client.post(
+                CLOUD_LOGIN_URL,
+                params={"token": self._token},
+                json={"method": "getDeviceList"},
+            )
+        resp.raise_for_status()
+        body = resp.json()
+        if body.get("error_code", -1) != 0:
+            raise KasaException(f"getDeviceList failed: {body.get('msg', body)}")
+        devices = body.get("result", {}).get("deviceList", [])
+        locks = [
+            d for d in devices if d.get("deviceType") == self.DEVICE_TYPE
+        ]
+        if len(locks) == 1:
+            self._device_id = locks[0]["deviceId"]
+        elif not locks:
+            raise KasaException(
+                f"No {self.DEVICE_TYPE} device found in the cloud account"
+            )
+        else:
+            raise KasaException(
+                "Multiple locks found; DLKLAP device-id auto-resolution cannot "
+                "yet disambiguate by IP. Supply the device id explicitly."
+            )
+
+    # -- Step 2: handshake0 -------------------------------------------------
+
+    async def _handshake0(
+        self, lock_client: httpx.AsyncClient, rand4: bytes
+    ) -> str:
+        """Wake the lock and obtain the 236-char base64 ``secret``.
+
+        Body is 33 raw bytes: sha((hex(rand4)+accountId).upper())[:32] + 0x00.
+        """
+        assert self._account_id is not None
+        hash_input = (rand4.hex() + self._account_id).upper().encode("ascii")
+        body = _sha256(hash_input) + b"\x00"  # 32 + 1 = 33 bytes
+
+        last_exc: Exception | None = None
+        for attempt in range(1, HANDSHAKE0_RETRIES + 1):
+            try:
+                resp = await lock_client.post(
+                    f"{self._base_url}/app/handshake0",
+                    content=body,
+                    headers=self._lock_headers(),
+                )
+                resp.raise_for_status()
+                return resp.text.strip()
+            except (
+                httpx.ConnectTimeout,
+                httpx.ConnectError,
+                httpx.ReadTimeout,
+            ) as ex:
+                last_exc = ex
+                _LOGGER.debug(
+                    "handshake0 attempt %s/%s to %s failed (%s), lock may be "
+                    "waking",
+                    attempt,
+                    HANDSHAKE0_RETRIES,
+                    self._host,
+                    type(ex).__name__,
+                )
+                await asyncio.sleep(HANDSHAKE0_RETRY_DELAY)
+        raise _RetryableError(
+            f"handshake0 could not reach {self._host} after "
+            f"{HANDSHAKE0_RETRIES} attempts: {last_exc!r}"
+        )
+
+    # -- Step 3: cloud control-key ------------------------------------------
+
+    async def _fetch_control_key(self, secret: str, rand4: bytes) -> str:
+        """Exchange the handshake0 ``secret`` for a per-session control key."""
+        assert self._token is not None
+        assert self._device_id is not None
+        url = CONTROL_KEY_URL_FMT.format(device_id=self._device_id)
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"ut|{self._token}",
+            "app-cid": f"app:Tapo_Android:{self._terminal_uuid}",
+            "App-Type": "Tapo_Android",
+            "x-app-name": "Tapo_Android",
+            "UUID": self._terminal_uuid,
+            "Terminal-Id": self._terminal_uuid,
+            "x-term-id": self._terminal_uuid,
+            "Platform": "ANDROID",
+            "X-App-Os": "android",
+        }
+        # This host presents TP-Link's PRIVATE CA (not a public root), so TLS
+        # verification must be disabled for THIS call only. The login call above
+        # carries the account password and stays fully verified.
+        async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=False) as client:
+            resp = await client.post(
+                url,
+                json={"secret": secret, "random": rand4.hex().upper()},
+                headers=headers,
+            )
+        resp.raise_for_status()
+        body = resp.json()
+        control_key = body.get("controlKey")
+        if not control_key:
+            raise AuthenticationError(
+                f"Cloud did not return a controlKey: {body}"
+            )
+        return control_key
+
+    # -- Step 4: handshake1 -------------------------------------------------
+
+    async def _handshake1(
+        self, lock_client: httpx.AsyncClient, control_key: str
+    ) -> tuple[bytes, bytes, bytes]:
+        """Verify the device and capture the session cookie.
+
+        Returns ``(local_seed, remote_seed, lmk)`` where ``lmk = sha(ck)``.
+        """
+        ck = control_key.upper().encode("ascii")  # 64 ASCII bytes
+        lmk = _sha256(ck)
+        local_seed = secrets.token_bytes(16)
+        body = local_seed + _sha256(local_seed + ck)  # 16 + 32 = 48 bytes
+
+        resp = await lock_client.post(
+            f"{self._base_url}/app/handshake1",
+            content=body,
+            headers=self._lock_headers(),
+        )
+        resp.raise_for_status()
+        raw = resp.content
+        if len(raw) != 48:
+            raise KasaException(
+                f"handshake1 from {self._host} returned {len(raw)} bytes, "
+                "expected 48"
+            )
+        remote_seed = raw[:16]
+        server_proof = raw[16:]
+
+        expected = _sha256(local_seed + remote_seed + _sha256(ck))
+        if expected != server_proof:
+            raise AuthenticationError(
+                f"handshake1 server proof mismatch from {self._host}; the "
+                "control key is wrong or stale."
+            )
+
+        cookie = self._extract_session_cookie(resp)
+        if not cookie:
+            raise KasaException(
+                f"handshake1 from {self._host} did not set {SESSION_COOKIE_NAME}"
+            )
+        self._session_cookie = cookie
+        return local_seed, remote_seed, lmk
+
+    @staticmethod
+    def _extract_session_cookie(resp: httpx.Response) -> str | None:
+        raw = resp.headers.get("set-cookie", "")
+        for part in raw.split(";"):
+            part = part.strip()
+            if part.startswith(f"{SESSION_COOKIE_NAME}="):
+                return part
+        return None
+
+    # -- Step 5: handshake2 -------------------------------------------------
+
+    async def _handshake2(
+        self,
+        lock_client: httpx.AsyncClient,
+        local_seed: bytes,
+        remote_seed: bytes,
+        lmk: bytes,
+    ) -> None:
+        body = _sha256(remote_seed + local_seed + lmk)  # 32 bytes
+        resp = await lock_client.post(
+            f"{self._base_url}/app/handshake2",
+            content=body,
+            headers=self._lock_headers(with_cookie=True),
+        )
+        resp.raise_for_status()
+
+    # -- Step 7: encrypted request ------------------------------------------
+
+    async def _send_encrypted(self, request: str) -> dict[str, Any]:
+        assert self._session is not None
+        lock_client = self._get_lock_client()
+        payload, seq = self._session.encrypt(request.encode())
+        try:
+            resp = await lock_client.post(
+                f"{self._base_url}/app/request",
+                params={"seq": seq},
+                content=payload,
+                headers=self._lock_headers(with_cookie=True),
+            )
+        except (httpx.ConnectError, httpx.TimeoutException) as ex:
+            raise _RetryableError(
+                f"DLKLAP request transport error to {self._host}: {ex!r}"
+            ) from ex
+
+        if resp.status_code == 403:
+            # Security/session error -- force a fresh handshake next time.
+            raise _RetryableError(
+                f"Got HTTP 403 from {self._host}; session likely expired"
+            )
+        if resp.status_code != 200:
+            raise KasaException(
+                f"Device {self._host} responded with {resp.status_code} to "
+                f"request with seq {seq}"
+            )
+
+        try:
+            decrypted = self._session.decrypt(resp.content)
+        except Exception as ex:  # noqa: BLE001
+            raise KasaException(
+                f"Error decrypting response from {self._host}: {ex}"
+            ) from ex
+        return json_loads(decrypted)
+
+
+class _DlklapSession:
+    """Encryption session state for DLKLAP (mirrors ``KlapEncryptionSession``).
+
+    Holds the derived keys and the request sequence number, which the device
+    expects to increment by one on every request.
+    """
+
+    def __init__(self, local_seed: bytes, remote_seed: bytes, lmk: bytes) -> None:
+        self._local_seed = local_seed
+        self._remote_seed = remote_seed
+        self._lmk = lmk
+        self._lsk = self._kdf(b"lsk")[:16]  # AES-128 key
+        self._ldk = self._kdf(b"ldk")[:28]  # MAC key
+        iv_full = self._kdf(b"iv")
+        self._ivb = iv_full[:12]  # 12-byte IV base
+        self._seq = int.from_bytes(iv_full[28:32], "big") & 0x7FFFFFFF
+        self._aes = algorithms.AES(self._lsk)
+
+    def _kdf(self, tag: bytes) -> bytes:
+        return _sha256(tag + self._local_seed + self._remote_seed + self._lmk)
+
+    def encrypt(self, msg: bytes) -> tuple[bytes, int]:
+        """Encrypt ``msg`` and increment the sequence number.
+
+        Returns ``(mac + ciphertext, seq)``. The MAC uses the 4-byte seq form
+        (NOT the full IV): ``sha(ldk + seq4 + ciphertext)``.
+        """
+        self._seq += 1
+        seq_b = self._seq.to_bytes(4, "big")
+        iv = self._ivb + seq_b  # 16-byte IV
+        cipher = Cipher(self._aes, modes.CBC(iv))
+        encryptor = cipher.encryptor()
+        padder = padding.PKCS7(128).padder()
+        padded = padder.update(msg) + padder.finalize()
+        ciphertext = encryptor.update(padded) + encryptor.finalize()
+        mac = _sha256(self._ldk + seq_b + ciphertext)
+        return mac + ciphertext, self._seq
+
+    def decrypt(self, msg: bytes) -> str:
+        """Decrypt a response body (first 32 bytes are the MAC).
+
+        The DL100 prefixes the JSON with a few bytes, so we return the substring
+        from the first ``{`` onward.
+        """
+        seq_b = self._seq.to_bytes(4, "big")
+        iv = self._ivb + seq_b
+        cipher = Cipher(self._aes, modes.CBC(iv))
+        decryptor = cipher.decryptor()
+        padded = decryptor.update(msg[32:]) + decryptor.finalize()
+        unpadder = padding.PKCS7(128).unpadder()
+        plaintext = unpadder.update(padded) + unpadder.finalize()
+        start = plaintext.index(ord("{"))
+        return plaintext[start:].decode()

--- a/kasa/transports/dlklaptransport.py
+++ b/kasa/transports/dlklaptransport.py
@@ -50,6 +50,7 @@ from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from kasa.deviceconfig import DeviceConfig
+from kasa.httpclient import HttpClient
 from kasa.exceptions import (
     AuthenticationError,
     KasaException,
@@ -98,11 +99,9 @@ class DlklapTransport(BaseTransport):
     def __init__(self, *, config: DeviceConfig) -> None:
         super().__init__(config=config)
 
-        if not self._credentials or not self._credentials.username:
-            raise AuthenticationError(
-                "DLKLAP requires TP-Link cloud credentials "
-                "(username/email and password)."
-            )
+        # Credentials are validated lazily in ``_ensure_login`` rather than here
+        # so that construction (e.g. during discovery) never fails; other
+        # transports behave the same way.
 
         # A stable app-instance UUID reused for the lifetime of the transport.
         self._terminal_uuid: str = str(uuid.uuid4()).upper()
@@ -122,6 +121,14 @@ class DlklapTransport(BaseTransport):
         # connection-scoped, so hs0/hs1/hs2/request must all reuse this client.
         self._lock_client: httpx.AsyncClient | None = None
 
+        # Standard kasa HttpClient, exposed for interface/cleanup compliance
+        # and to honour DeviceConfig.http_client. NOTE: the DLKLAP handshake
+        # and app requests deliberately use self._lock_client (raw httpx)
+        # instead -- the raw 33-byte handshake0 body must not be re-encoded,
+        # and the connection-scoped TP_SESSIONID cookie requires every request
+        # to share a single client, so app traffic cannot be routed here.
+        self._http_client = HttpClient(config=self._config)
+
         _LOGGER.debug("Created DLKLAP transport for %s", self._host)
         self._base_url = f"http://{self._host}:{self._port}"
 
@@ -136,8 +143,19 @@ class DlklapTransport(BaseTransport):
 
     @property
     def credentials_hash(self) -> str | None:
-        """DLKLAP authenticates via the cloud; no reusable local hash."""
-        return None
+        """Return a stable, non-null credentials hash.
+
+        DLKLAP authenticates against the TP-Link cloud rather than with a
+        local KLAP-style auth hash. Returning ``None`` here, however, would
+        make :meth:`SmartDevice.update` reject the device up front -- its guard
+        raises when both ``credentials`` and ``credentials_hash`` are ``None``
+        -- which is inconsistent with the KLAP/AES transports that always
+        expose a non-null hash derived from the (possibly empty) credentials.
+        The real credential requirement is enforced later in ``_ensure_login``.
+        """
+        username = self._credentials.username if self._credentials else ""
+        password = self._credentials.password if self._credentials else ""
+        return _sha256(f"{username}:{password}".encode()).hex()
 
     async def send(self, request: str) -> dict[str, Any]:
         """Encrypt ``request``, POST to /app/request, return the decrypted dict.
@@ -167,9 +185,13 @@ class DlklapTransport(BaseTransport):
     async def close(self) -> None:
         """Close the HTTP client and reset internal state."""
         await self.reset()
-        client, self._lock_client = self._lock_client, None
+        client = getattr(self, "_lock_client", None)
+        self._lock_client = None
         if client is not None:
             await client.aclose()
+        http_client = getattr(self, "_http_client", None)
+        if http_client is not None:
+            await http_client.close()
 
     async def reset(self) -> None:
         """Reset handshake/session state (keeps the cloud token)."""
@@ -224,7 +246,11 @@ class DlklapTransport(BaseTransport):
         if self._token and self._account_id:
             return
         _LOGGER.debug("DLKLAP cloud login")
-        assert self._credentials is not None
+        if not self._credentials or not self._credentials.username:
+            raise AuthenticationError(
+                "DLKLAP requires TP-Link cloud credentials "
+                "(username/email and password)."
+            )
         async with httpx.AsyncClient(timeout=READ_TIMEOUT, verify=True) as client:
             resp = await client.post(
                 CLOUD_LOGIN_URL,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ dependencies = [
   "cryptography>=1.9",
   "aiohttp>=3",
   "tzdata>=2024.2 ; platform_system == 'Windows'",
-  "mashumaro>=3.20"
+  "mashumaro>=3.20",
+  "httpx",
+  "cryptography"
 ]
 
 classifiers = [

--- a/tests/device_fixtures.py
+++ b/tests/device_fixtures.py
@@ -153,6 +153,8 @@ THERMOSTATS_SMART = {"KE100"}
 
 VACUUMS_SMART = {"RV20"}
 
+LOCKS_SMART = {"DL100"}
+
 WITH_EMETER_IOT = {"EP25", "HS110", "HS300", "KP115", "KP125", *BULBS_IOT}
 WITH_EMETER_SMART = {"P110", "P110M", "P115", "KP125M", "EP25", "P304M", "S515D"}
 WITH_EMETER = {*WITH_EMETER_IOT, *WITH_EMETER_SMART}
@@ -171,6 +173,7 @@ ALL_DEVICES_SMART = (
     .union(SWITCHES_SMART)
     .union(THERMOSTATS_SMART)
     .union(VACUUMS_SMART)
+    .union(LOCKS_SMART)
 )
 ALL_DEVICES = ALL_DEVICES_IOT.union(ALL_DEVICES_SMART)
 
@@ -357,6 +360,9 @@ hubs_smart = parametrize(
 sensors_smart = parametrize(
     "sensors smart", model_filter=SENSORS_SMART, protocol_filter={"SMART.CHILD"}
 )
+locks_smart = parametrize(
+    "locks smart", model_filter=LOCKS_SMART, protocol_filter={"SMART"}
+)
 thermostats_smart = parametrize(
     "thermostats smart", model_filter=THERMOSTATS_SMART, protocol_filter={"SMART.CHILD"}
 )
@@ -404,6 +410,7 @@ def check_categories():
         + dimmers_smart.args[1]
         + hubs_smart.args[1]
         + sensors_smart.args[1]
+        + locks_smart.args[1]
         + thermostats_smart.args[1]
         + chime_smart.args[1]
         + camera_smartcam.args[1]

--- a/tests/fixtures/smart/DL100(US)_1.0_1.0.17.json
+++ b/tests/fixtures/smart/DL100(US)_1.0_1.0.17.json
@@ -27,36 +27,8 @@
             }
         ]
     },
-    "get_device_info": {
-        "device_id": "0000000000000000000000000000000000000000",
-        "fw_ver": "1.0.17 Build 260417 Rel.082002",
-        "hw_ver": "1.0",
-        "type": "SMART.TAPOLOCK",
-        "model": "DL100",
-        "mac": "50-3D-D1-00-00-00",
-        "hw_id": "00000000000000000000000000000000",
-        "fw_id": "00000000000000000000000000000000",
-        "oem_id": "00000000000000000000000000000000",
-        "ip": "127.0.0.123",
-        "time_diff": -480,
-        "region": "America/Los_Angeles",
-        "lang": "en_US",
-        "nickname": "I01BU0tFRF9OQU1FIw==",
-        "ssid": "I01BU0tFRF9TU0lEIw==",
-        "rssi": -40,
-        "signal_level": 3,
-        "lock_status": 0,
-        "battery_percentage": 81,
-        "at_low_battery": false,
-        "wifi_mode_status": 1,
-        "overheated": false
-    },
-    "get_device_time": {
-        "timestamp": 1782000000,
-        "time_diff": -480,
-        "region": "America/Los_Angeles"
-    },
     "discovery_result": {
+        "error_code": 0,
         "result": {
             "device_id": "0000000000000000000000000000000000000000",
             "device_model": "DL100(US)",
@@ -74,10 +46,38 @@
             "obd_src": "tplink",
             "owner": "00000000000000000000000000000000",
             "protocol_version": 1
-        },
-        "error_code": 0
+        }
     },
     "get_connect_cloud_state": {
         "status": 0
+    },
+    "get_device_info": {
+        "at_low_battery": false,
+        "battery_percentage": 81,
+        "device_id": "0000000000000000000000000000000000000000",
+        "fw_id": "00000000000000000000000000000000",
+        "fw_ver": "1.0.17 Build 260417 Rel.082002",
+        "hw_id": "00000000000000000000000000000000",
+        "hw_ver": "1.0",
+        "ip": "127.0.0.123",
+        "lang": "en_US",
+        "lock_status": 0,
+        "mac": "50-3D-D1-00-00-00",
+        "model": "DL100",
+        "nickname": "I01BU0tFRF9OQU1FIw==",
+        "oem_id": "00000000000000000000000000000000",
+        "overheated": false,
+        "region": "America/Los_Angeles",
+        "rssi": -40,
+        "signal_level": 3,
+        "ssid": "I01BU0tFRF9TU0lEIw==",
+        "time_diff": -480,
+        "type": "SMART.TAPOLOCK",
+        "wifi_mode_status": 1
+    },
+    "get_device_time": {
+        "region": "America/Los_Angeles",
+        "time_diff": -480,
+        "timestamp": 1782000000
     }
 }

--- a/tests/fixtures/smart/DL100(US)_1.0_1.0.17.json
+++ b/tests/fixtures/smart/DL100(US)_1.0_1.0.17.json
@@ -1,0 +1,100 @@
+{
+    "component_nego": {
+        "component_list": [
+            {
+                "id": "device",
+                "ver_code": 2
+            },
+            {
+                "id": "device_local_time",
+                "ver_code": 1
+            },
+            {
+                "id": "time",
+                "ver_code": 1
+            },
+            {
+                "id": "firmware",
+                "ver_code": 1
+            },
+            {
+                "id": "wireless",
+                "ver_code": 1
+            },
+            {
+                "id": "cloud_connect",
+                "ver_code": 1
+            }
+        ]
+    },
+    "get_device_info": {
+        "device_id": "80473DD74D40D2C6EBFBB08CACA3AE8524BAA697",
+        "fw_ver": "1.0.17 Build 260417 Rel.082002",
+        "hw_ver": "1.0",
+        "type": "SMART.TAPOLOCK",
+        "model": "DL100",
+        "mac": "50-3D-D1-A9-30-F6",
+        "hw_id": "00000000000000000000000000000000",
+        "fw_id": "00000000000000000000000000000000",
+        "oem_id": "00000000000000000000000000000000",
+        "ip": "127.0.0.123",
+        "time_diff": -480,
+        "region": "America/Los_Angeles",
+        "lang": "en_US",
+        "nickname": "RnJvbnQgRG9vcg==",
+        "ssid": "RG9udEJhcmtBdE5pZ2h0XzVH",
+        "rssi": -40,
+        "signal_level": 3,
+        "lock_status": 0,
+        "battery_percentage": 81,
+        "at_low_battery": false,
+        "wifi_mode_status": 1,
+        "overheated": false
+    },
+    "getDeviceInfo": {
+        "device_id": "80473DD74D40D2C6EBFBB08CACA3AE8524BAA697",
+        "fw_ver": "1.0.17 Build 260417 Rel.082002",
+        "hw_ver": "1.0",
+        "type": "SMART.TAPOLOCK",
+        "model": "DL100",
+        "mac": "50-3D-D1-A9-30-F6",
+        "ip": "127.0.0.123",
+        "nickname": "RnJvbnQgRG9vcg==",
+        "ssid": "RG9udEJhcmtBdE5pZ2h0XzVH",
+        "rssi": -40,
+        "signal_level": 3,
+        "lock_status": 0,
+        "battery_percentage": 81,
+        "at_low_battery": false,
+        "wifi_mode_status": 1
+    },
+    "get_device_time": {
+        "timestamp": 1782000000,
+        "time_diff": -480,
+        "region": "America/Los_Angeles"
+    },
+    "discovery_result": {
+        "result": {
+            "device_id": "80473DD74D40D2C6EBFBB08CACA3AE8524BAA697",
+            "device_model": "DL100(US)",
+            "device_name": "DL100",
+            "device_type": "SMART.TAPOLOCK",
+            "factory_default": false,
+            "ip": "127.0.0.123",
+            "is_support_iot_cloud": true,
+            "mac": "50-3D-D1-A9-30-F6",
+            "mgt_encrypt_schm": {
+                "encrypt_type": "DLKLAP",
+                "http_port": 80,
+                "is_support_https": false
+            },
+            "obd_src": "tplink",
+            "owner": "00000000000000000000000000000000",
+            "protocol_version": 1
+        },
+        "error_code": 0
+    },
+    "get_connect_cloud_state": {
+        "status": 0
+    }
+}

--- a/tests/fixtures/smart/DL100(US)_1.0_1.0.17.json
+++ b/tests/fixtures/smart/DL100(US)_1.0_1.0.17.json
@@ -28,12 +28,12 @@
         ]
     },
     "get_device_info": {
-        "device_id": "80473DD74D40D2C6EBFBB08CACA3AE8524BAA697",
+        "device_id": "0000000000000000000000000000000000000000",
         "fw_ver": "1.0.17 Build 260417 Rel.082002",
         "hw_ver": "1.0",
         "type": "SMART.TAPOLOCK",
         "model": "DL100",
-        "mac": "50-3D-D1-A9-30-F6",
+        "mac": "50-3D-D1-00-00-00",
         "hw_id": "00000000000000000000000000000000",
         "fw_id": "00000000000000000000000000000000",
         "oem_id": "00000000000000000000000000000000",
@@ -41,8 +41,8 @@
         "time_diff": -480,
         "region": "America/Los_Angeles",
         "lang": "en_US",
-        "nickname": "RnJvbnQgRG9vcg==",
-        "ssid": "RG9udEJhcmtBdE5pZ2h0XzVH",
+        "nickname": "I01BU0tFRF9OQU1FIw==",
+        "ssid": "I01BU0tFRF9TU0lEIw==",
         "rssi": -40,
         "signal_level": 3,
         "lock_status": 0,
@@ -51,23 +51,6 @@
         "wifi_mode_status": 1,
         "overheated": false
     },
-    "getDeviceInfo": {
-        "device_id": "80473DD74D40D2C6EBFBB08CACA3AE8524BAA697",
-        "fw_ver": "1.0.17 Build 260417 Rel.082002",
-        "hw_ver": "1.0",
-        "type": "SMART.TAPOLOCK",
-        "model": "DL100",
-        "mac": "50-3D-D1-A9-30-F6",
-        "ip": "127.0.0.123",
-        "nickname": "RnJvbnQgRG9vcg==",
-        "ssid": "RG9udEJhcmtBdE5pZ2h0XzVH",
-        "rssi": -40,
-        "signal_level": 3,
-        "lock_status": 0,
-        "battery_percentage": 81,
-        "at_low_battery": false,
-        "wifi_mode_status": 1
-    },
     "get_device_time": {
         "timestamp": 1782000000,
         "time_diff": -480,
@@ -75,14 +58,14 @@
     },
     "discovery_result": {
         "result": {
-            "device_id": "80473DD74D40D2C6EBFBB08CACA3AE8524BAA697",
+            "device_id": "0000000000000000000000000000000000000000",
             "device_model": "DL100(US)",
-            "device_name": "DL100",
+            "device_name": "#MASKED_NAME#",
             "device_type": "SMART.TAPOLOCK",
             "factory_default": false,
             "ip": "127.0.0.123",
             "is_support_iot_cloud": true,
-            "mac": "50-3D-D1-A9-30-F6",
+            "mac": "50-3D-D1-00-00-00",
             "mgt_encrypt_schm": {
                 "encrypt_type": "DLKLAP",
                 "http_port": 80,

--- a/tests/smart/modules/test_lock.py
+++ b/tests/smart/modules/test_lock.py
@@ -10,7 +10,6 @@ Polarity is intentionally counterintuitive and must NOT be inverted:
 
 from __future__ import annotations
 
-import pytest
 from pytest_mock import MockerFixture
 
 from kasa.smart import SmartDevice
@@ -108,7 +107,7 @@ async def test_lock_command_omits_owner_forbidden_fields(
 
 @lock_iter
 async def test_battery(dev: SmartDevice):
-    """battery / battery_low read from sysinfo (DL100 lacks battery_detect)."""
+    """Battery / battery_low read from sysinfo (DL100 lacks battery_detect)."""
     lock = dev.modules.get(LOCK_MODULE)
     assert lock is not None
     assert lock.battery == 81

--- a/tests/smart/modules/test_lock.py
+++ b/tests/smart/modules/test_lock.py
@@ -34,9 +34,9 @@ LOCK_MODULE = "Lock"
 def _set_lock_status(dev: SmartDevice, value: int) -> None:
     """Flip the device's reported lock_status in the fake transport fixture.
 
-    Updates both the snake_case sysinfo used by SmartDevice.update() and the
-    camelCase getDeviceInfo used by the Lock module's QUERY so is_locked reflects
-    the change regardless of which the module reads.
+    Updates lock_status in every device-info key present in the transport's
+    info dict (get_device_info and, if present, getDeviceInfo) so that
+    is_locked reflects the change after the next update() call.
     """
     info = dev.protocol._transport.info
     for key in ("get_device_info", "getDeviceInfo"):

--- a/tests/smart/modules/test_lock.py
+++ b/tests/smart/modules/test_lock.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 from pytest_mock import MockerFixture
 
+from kasa import Module
 from kasa.smart import SmartDevice
 
 from ...device_fixtures import parametrize
+from ...fakeprotocol_smart import FakeSmartTransport
 
 # The DL100 has no dedicated component for the lock; the module loads off the
 # `lock_status` sysinfo key (SYSINFO_LOOKUP_KEYS=["lock_status"]), so we select
@@ -25,9 +27,10 @@ lock_iter = parametrize(
     protocol_filter={"SMART"},
 )
 
-# The Lock module is registered by class name; use the string key unless a
-# Module.Lock constant was added to the Module enum.
-LOCK_MODULE = "Lock"
+# Module.Lock is now a typed ModuleName[Lock], so use it instead of the bare
+# string key. This gives static checkers the concrete Lock type back from
+# dev.modules.get()/[] instead of the base SmartModule.
+LOCK_MODULE = Module.Lock
 
 
 def _set_lock_status(dev: SmartDevice, value: int) -> None:
@@ -37,7 +40,9 @@ def _set_lock_status(dev: SmartDevice, value: int) -> None:
     info dict (get_device_info and, if present, getDeviceInfo) so that
     is_locked reflects the change after the next update() call.
     """
-    info = dev.protocol._transport.info
+    transport = dev.protocol._transport
+    assert isinstance(transport, FakeSmartTransport)
+    info = transport.info
     for key in ("get_device_info", "getDeviceInfo"):
         if key in info:
             info[key]["lock_status"] = value
@@ -64,12 +69,12 @@ async def test_is_locked_polarity(dev: SmartDevice):
     # Fixture ships lock_status=0 (bolt extended = LOCKED).
     _set_lock_status(dev, 0)
     await dev.update()
-    assert dev.modules.get(LOCK_MODULE).is_locked is True
+    assert lock.is_locked is True
 
     # Retract the bolt -> UNLOCKED.
     _set_lock_status(dev, 1)
     await dev.update()
-    assert dev.modules.get(LOCK_MODULE).is_locked is False
+    assert lock.is_locked is False
 
 
 @lock_iter

--- a/tests/smart/modules/test_lock.py
+++ b/tests/smart/modules/test_lock.py
@@ -1,0 +1,124 @@
+"""Tests for the Lock module (SMART.TAPOLOCK / DL100).
+
+Mirrors the structure of tests/smart/modules/test_childlock.py (setter + boolean
+state) and test_contact.py (simple sysinfo-key sensor).
+
+Polarity is intentionally counterintuitive and must NOT be inverted:
+    lock_status == 0  -> bolt extended  -> LOCKED   (is_locked is True)
+    lock_status == 1  -> bolt retracted -> UNLOCKED (is_locked is False)
+"""
+
+from __future__ import annotations
+
+import pytest
+from pytest_mock import MockerFixture
+
+from kasa.smart import SmartDevice
+
+from ...device_fixtures import parametrize
+
+# The DL100 has no dedicated component for the lock; the module loads off the
+# `lock_status` sysinfo key (SYSINFO_LOOKUP_KEYS=["lock_status"]), so we select
+# the fixture by model rather than component_filter.
+lock_iter = parametrize(
+    "has lock",
+    model_filter={"DL100"},
+    protocol_filter={"SMART"},
+)
+
+# The Lock module is registered by class name; use the string key unless a
+# Module.Lock constant was added to the Module enum.
+LOCK_MODULE = "Lock"
+
+
+def _set_lock_status(dev: SmartDevice, value: int) -> None:
+    """Flip the device's reported lock_status in the fake transport fixture.
+
+    Updates both the snake_case sysinfo used by SmartDevice.update() and the
+    camelCase getDeviceInfo used by the Lock module's QUERY so is_locked reflects
+    the change regardless of which the module reads.
+    """
+    info = dev.protocol._transport.info
+    for key in ("get_device_info", "getDeviceInfo"):
+        if key in info:
+            info[key]["lock_status"] = value
+
+
+@lock_iter
+async def test_lock_module_loaded(dev: SmartDevice):
+    """Lock module loads whenever lock_status is present in sysinfo."""
+    lock = dev.modules.get(LOCK_MODULE)
+    assert lock is not None
+    assert "lock_status" in dev.sys_info
+
+
+@lock_iter
+async def test_is_locked_polarity(dev: SmartDevice):
+    """lock_status 0 -> True (LOCKED), 1 -> False (UNLOCKED). Do not invert.
+
+    Drives real data through the fake transport + update() rather than patching
+    module internals, so it stays correct no matter where is_locked reads from.
+    """
+    lock = dev.modules.get(LOCK_MODULE)
+    assert lock is not None
+
+    # Fixture ships lock_status=0 (bolt extended = LOCKED).
+    _set_lock_status(dev, 0)
+    await dev.update()
+    assert dev.modules.get(LOCK_MODULE).is_locked is True
+
+    # Retract the bolt -> UNLOCKED.
+    _set_lock_status(dev, 1)
+    await dev.update()
+    assert dev.modules.get(LOCK_MODULE).is_locked is False
+
+
+@lock_iter
+async def test_lock_sends_setlockstatus(dev: SmartDevice, mocker: MockerFixture):
+    """lock()/unlock() send setLockStatus with the correct owner params."""
+    lock = dev.modules.get(LOCK_MODULE)
+    assert lock is not None
+    call = mocker.patch.object(lock, "call", new_callable=mocker.AsyncMock)
+
+    await lock.lock()
+    call.assert_called_with(
+        "setLockStatus", {"lock_status": 0, "sa_user_id": "local_1"}
+    )
+
+    await lock.unlock()
+    call.assert_called_with(
+        "setLockStatus", {"lock_status": 1, "sa_user_id": "local_1"}
+    )
+
+
+@lock_iter
+async def test_lock_command_omits_owner_forbidden_fields(
+    dev: SmartDevice, mocker: MockerFixture
+):
+    """Owner path must NOT include shared-user fields."""
+    lock = dev.modules.get(LOCK_MODULE)
+    assert lock is not None
+    call = mocker.patch.object(lock, "call", new_callable=mocker.AsyncMock)
+
+    await lock.lock()
+    _method, params = call.call_args.args
+    for forbidden in ("tplink_account", "access_info", "lock_type", "unlock_type"):
+        assert forbidden not in params
+
+
+@lock_iter
+async def test_battery(dev: SmartDevice):
+    """battery / battery_low read from sysinfo (DL100 lacks battery_detect)."""
+    lock = dev.modules.get(LOCK_MODULE)
+    assert lock is not None
+    assert lock.battery == 81
+    assert lock.battery_low is False
+
+
+@lock_iter
+async def test_battery_features_present(dev: SmartDevice):
+    """battery_level and battery_low features are exposed by the Lock module."""
+    lock = dev.modules.get(LOCK_MODULE)
+    assert lock is not None
+    assert "battery_level" in dev.features
+    assert "battery_low" in dev.features

--- a/tests/transports/test_dlklaptransport.py
+++ b/tests/transports/test_dlklaptransport.py
@@ -1,0 +1,530 @@
+"""Unit tests for :mod:`kasa.transports.dlklaptransport`.
+
+DLKLAP is almost entirely network I/O (cloud login, device-id resolution,
+handshake0/1/2, encrypted /app/request), so nothing in it runs under the
+normal fixture-driven test suite. These tests mock ``httpx`` at the
+``AsyncClient`` boundary and drive the *real* handshake + crypto code paths.
+
+The fake "device" side deliberately reuses the transport's own ``_sha256`` and
+``_DlklapSession`` so the handshake proof and the AES-CBC/MAC round-trip are
+correct by construction (no reimplementation of crypto to drift out of sync).
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from kasa.credentials import Credentials
+from kasa.deviceconfig import (
+    DeviceConfig,
+    DeviceConnectionParameters,
+    DeviceEncryptionType,
+    DeviceFamily,
+)
+from kasa.exceptions import AuthenticationError, KasaException, _RetryableError
+from kasa.transports.dlklaptransport import (
+    SESSION_COOKIE_NAME,
+    DlklapTransport,
+    _DlklapSession,
+    _sha256,
+)
+
+# NOTE: the transport never inspects device_family/encryption_type, so any
+# valid combination works here. Swap these for the lock's real family/encryption
+# if you prefer the fixture to mirror production wiring exactly.
+_CONNECTION_TYPE = DeviceConnectionParameters(
+    device_family=DeviceFamily.SmartTapoPlug,
+    encryption_type=DeviceEncryptionType.Klap,
+    https=False,
+)
+
+
+def _make_config(*, username: str | None = "user@example.com") -> DeviceConfig:
+    credentials = (
+        Credentials(username, "correct horse battery staple")
+        if username is not None
+        else None
+    )
+    return DeviceConfig(
+        host="127.0.0.1",
+        credentials=credentials,
+        connection_type=_CONNECTION_TYPE,
+    )
+
+
+def _make_transport(**kwargs) -> DlklapTransport:
+    return DlklapTransport(config=_make_config(**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Fake httpx layer
+# ---------------------------------------------------------------------------
+
+
+class FakeResponse:
+    """Minimal stand-in for :class:`httpx.Response`."""
+
+    def __init__(
+        self,
+        status_code: int = 200,
+        *,
+        content: bytes = b"",
+        text: str | None = None,
+        json_data: dict | None = None,
+        headers: dict | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self._content = content
+        self._text = text
+        self._json = json_data
+        self.headers = headers or {}
+
+    @property
+    def content(self) -> bytes:
+        return self._content
+
+    @property
+    def text(self) -> str:
+        return self._text if self._text is not None else self._content.decode()
+
+    def json(self) -> dict:
+        assert self._json is not None
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError(
+                f"HTTP {self.status_code}",
+                request=httpx.Request("POST", "http://device/"),
+                response=httpx.Response(self.status_code),
+            )
+
+
+class FakeBackend:
+    """Stateful fake cloud + lock device with per-test error injection knobs."""
+
+    def __init__(self) -> None:
+        self.token = "cloud-token"
+        self.account_id = "ACCOUNT123"
+        self.device_id = "DEVICE123"
+        self.control_key: str | None = "K" * 64
+        self.secret = "c2VjcmV0" * 30  # arbitrary base64-ish blob
+        self.remote_seed = bytes(range(16))
+        self.response_payload = {"error_code": 0, "result": {"foo": "bar"}}
+
+        # Captured during handshake1 so /app/request can build a matching session.
+        self.local_seed: bytes | None = None
+        # Persistent device-side session, created at handshake1 and advanced in
+        # lockstep with the transport so multi-request sequences stay aligned.
+        self.device_session: _DlklapSession | None = None
+
+        # Error-injection knobs.
+        self.login_error = False
+        self.device_mode = "single"  # "single" | "none" | "multiple"
+        self.hs0_exc: Exception | None = None
+        self.hs1_mode = "ok"  # "ok" | "badlen" | "badproof" | "nocookie"
+        self.request_status = 200
+        self.request_bad_body = False
+
+    # -- routing ----------------------------------------------------------
+
+    def handle(self, url, *, content, json_body, params, headers) -> FakeResponse:
+        if "tplinkcloud" in url:
+            method = (json_body or {}).get("method")
+            if method == "login":
+                return self._login()
+            if method == "getDeviceList":
+                return self._device_list()
+        if "control-key" in url:
+            return self._control_key()
+        if "handshake0" in url:
+            return self._handshake0()
+        if "handshake1" in url:
+            return self._handshake1(content)
+        if "handshake2" in url:
+            return FakeResponse(200, content=b"")
+        if "/app/request" in url:
+            return self._request()
+        raise AssertionError(f"unexpected URL in fake backend: {url!r}")
+
+    # -- cloud ------------------------------------------------------------
+
+    def _login(self) -> FakeResponse:
+        if self.login_error:
+            return FakeResponse(
+                200, json_data={"error_code": -20601, "msg": "Incorrect password"}
+            )
+        return FakeResponse(
+            200,
+            json_data={
+                "error_code": 0,
+                "result": {"token": self.token, "accountId": self.account_id},
+            },
+        )
+
+    def _device_list(self) -> FakeResponse:
+        lock = {"deviceType": DlklapTransport.DEVICE_TYPE, "deviceId": self.device_id}
+        if self.device_mode == "none":
+            devices = [{"deviceType": "SMART.TAPOPLUG", "deviceId": "PLUG"}]
+        elif self.device_mode == "multiple":
+            devices = [lock, {**lock, "deviceId": "DEVICE456"}]
+        else:
+            devices = [lock, {"deviceType": "SMART.TAPOPLUG", "deviceId": "PLUG"}]
+        return FakeResponse(
+            200, json_data={"error_code": 0, "result": {"deviceList": devices}}
+        )
+
+    def _control_key(self) -> FakeResponse:
+        if self.control_key is None:
+            return FakeResponse(200, json_data={"error_code": 0})
+        return FakeResponse(200, json_data={"controlKey": self.control_key})
+
+    # -- device -----------------------------------------------------------
+
+    def _handshake0(self) -> FakeResponse:
+        if self.hs0_exc is not None:
+            raise self.hs0_exc
+        return FakeResponse(200, text=self.secret)
+
+    def _handshake1(self, content: bytes) -> FakeResponse:
+        local_seed = content[:16]
+        self.local_seed = local_seed
+        if self.hs1_mode == "badlen":
+            return FakeResponse(200, content=b"\x00" * 10)
+        ck = self.control_key.upper().encode("ascii")
+        if self.hs1_mode == "badproof":
+            proof = b"\x00" * 32
+        else:
+            proof = _sha256(local_seed + self.remote_seed + _sha256(ck))
+        body = self.remote_seed + proof
+        headers = {}
+        if self.hs1_mode != "nocookie":
+            headers["set-cookie"] = f"{SESSION_COOKIE_NAME}=abc123; Path=/; HttpOnly"
+        if self.hs1_mode == "ok":
+            # Mirror the transport's session exactly (same seeds -> same seq0).
+            self.device_session = _DlklapSession(
+                local_seed, self.remote_seed, _sha256(ck)
+            )
+        return FakeResponse(200, content=body, headers=headers)
+
+    def _request(self) -> FakeResponse:
+        if self.request_status != 200:
+            return FakeResponse(self.request_status, content=b"")
+        if self.request_bad_body:
+            return FakeResponse(200, content=b"\x00" * 48)
+        # Encrypt with the persistent device session so its sequence number
+        # advances in lockstep with the transport across repeated requests.
+        assert self.device_session is not None
+        payload, _seq = self.device_session.encrypt(
+            json.dumps(self.response_payload).encode()
+        )
+        return FakeResponse(200, content=payload)
+
+
+class FakeAsyncClient:
+    """Stand-in for :class:`httpx.AsyncClient` backed by a shared FakeBackend."""
+
+    def __init__(self, backend: FakeBackend) -> None:
+        self._backend = backend
+        self.closed = False
+
+    async def __aenter__(self) -> "FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        return False
+
+    async def post(
+        self, url, *, content=None, json=None, params=None, headers=None
+    ) -> FakeResponse:
+        return self._backend.handle(
+            url, content=content, json_body=json, params=params, headers=headers
+        )
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def backend() -> FakeBackend:
+    return FakeBackend()
+
+
+@pytest.fixture
+def patch_httpx(mocker, backend):
+    """Patch httpx.AsyncClient so every client shares the one backend.
+
+    ``httpx.Timeout`` and the exception classes are left intact.
+    """
+    mocker.patch(
+        "kasa.transports.dlklaptransport.httpx.AsyncClient",
+        side_effect=lambda *a, **k: FakeAsyncClient(backend),
+    )
+    # Kill the retry backoff sleep so retry paths run instantly.
+    mocker.patch("kasa.transports.dlklaptransport.asyncio.sleep", return_value=None)
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# Pure logic (no network)
+# ---------------------------------------------------------------------------
+
+
+async def test_credentials_hash_ignores_password():
+    """The credentials hash is a non-secret sentinel derived from username only."""
+    t1 = DlklapTransport(
+        config=DeviceConfig(
+            host="127.0.0.1",
+            credentials=Credentials("user@example.com", "password-one"),
+            connection_type=_CONNECTION_TYPE,
+        )
+    )
+    t2 = DlklapTransport(
+        config=DeviceConfig(
+            host="127.0.0.1",
+            credentials=Credentials("user@example.com", "password-two"),
+            connection_type=_CONNECTION_TYPE,
+        )
+    )
+    assert t1.credentials_hash == t2.credentials_hash
+    assert t1.credentials_hash == _sha256(b"user@example.com").hex()
+
+
+async def test_credentials_hash_without_credentials():
+    t = _make_transport(username=None)
+    assert t.credentials_hash == _sha256(b"").hex()
+
+
+async def test_default_port_uses_override():
+    config = DeviceConfig(
+        host="127.0.0.1",
+        credentials=Credentials("u", "p"),
+        connection_type=DeviceConnectionParameters(
+            device_family=DeviceFamily.SmartTapoPlug,
+            encryption_type=DeviceEncryptionType.Klap,
+            https=False,
+            http_port=8080,
+        ),
+    )
+    assert DlklapTransport(config=config).default_port == 8080
+
+
+async def test_default_port_falls_back_to_80():
+    assert _make_transport().default_port == 80
+
+
+async def test_lock_headers_cookie_toggle():
+    t = _make_transport()
+    assert "Cookie" not in t._lock_headers()
+    t._session_cookie = f"{SESSION_COOKIE_NAME}=abc"
+    assert t._lock_headers(with_cookie=True)["Cookie"] == f"{SESSION_COOKIE_NAME}=abc"
+    # No stored cookie -> header omitted even when requested.
+    t._session_cookie = None
+    assert "Cookie" not in t._lock_headers(with_cookie=True)
+
+
+def test_extract_session_cookie():
+    resp = FakeResponse(
+        200,
+        headers={"set-cookie": f"{SESSION_COOKIE_NAME}=xyz; Path=/; HttpOnly"},
+    )
+    assert DlklapTransport._extract_session_cookie(resp) == f"{SESSION_COOKIE_NAME}=xyz"
+    assert DlklapTransport._extract_session_cookie(FakeResponse(200)) is None
+
+
+def test_session_encrypt_decrypt_roundtrip():
+    session = _DlklapSession(b"L" * 16, b"R" * 16, b"M" * 32)
+    plaintext = '{"error_code": 0, "result": {"hello": "world"}}'
+    payload, seq = session.encrypt(plaintext.encode())
+    assert seq == session._seq  # encrypt advanced the sequence
+    # The device echoes at the same seq the request advanced to.
+    assert session.decrypt(payload) == plaintext
+
+
+# ---------------------------------------------------------------------------
+# Happy path through the public API
+# ---------------------------------------------------------------------------
+
+
+async def test_send_happy_path(patch_httpx):
+    backend = patch_httpx
+    transport = _make_transport()
+    result = await transport.send('{"get_device_info": {}}')
+    assert result == backend.response_payload
+    assert transport._handshake_done is True
+    assert transport._token == backend.token
+    assert transport._device_id == backend.device_id
+    await transport.close()
+
+
+async def test_send_reuses_existing_session(patch_httpx, mocker):
+    transport = _make_transport()
+    await transport.send('{"get_device_info": {}}')
+    spy = mocker.spy(transport, "_establish_session")
+    await transport.send('{"get_device_info": {}}')
+    spy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cloud login / device-id resolution
+# ---------------------------------------------------------------------------
+
+
+async def test_ensure_login_requires_credentials():
+    transport = _make_transport(username=None)
+    with pytest.raises(AuthenticationError, match="cloud credentials"):
+        await transport._ensure_login()
+
+
+async def test_ensure_login_cloud_error(patch_httpx):
+    patch_httpx.login_error = True
+    transport = _make_transport()
+    with pytest.raises(AuthenticationError, match="cloud login failed"):
+        await transport._ensure_login()
+
+
+async def test_ensure_login_is_cached(patch_httpx):
+    transport = _make_transport()
+    transport._token = "cached"
+    transport._account_id = "cached-account"
+    await transport._ensure_login()  # returns early, no network
+    assert transport._token == "cached"
+
+
+async def test_ensure_device_id_none(patch_httpx):
+    patch_httpx.device_mode = "none"
+    transport = _make_transport()
+    transport._token = patch_httpx.token
+    with pytest.raises(KasaException, match="No .* device found"):
+        await transport._ensure_device_id()
+
+
+async def test_ensure_device_id_multiple(patch_httpx):
+    patch_httpx.device_mode = "multiple"
+    transport = _make_transport()
+    transport._token = patch_httpx.token
+    with pytest.raises(KasaException, match="Multiple locks"):
+        await transport._ensure_device_id()
+
+
+async def test_ensure_device_id_requires_login():
+    transport = _make_transport()
+    with pytest.raises(KasaException, match="cloud login required"):
+        await transport._ensure_device_id()
+
+
+# ---------------------------------------------------------------------------
+# handshake0 / control-key
+# ---------------------------------------------------------------------------
+
+
+async def test_handshake0_requires_account_id():
+    transport = _make_transport()
+    with pytest.raises(KasaException, match="cloud login required before handshake0"):
+        await transport._handshake0(FakeAsyncClient(FakeBackend()), b"\x00\x00\x00\x00")
+
+
+async def test_handshake0_retries_then_raises(patch_httpx):
+    patch_httpx.hs0_exc = httpx.ConnectError("lock asleep")
+    transport = _make_transport()
+    transport._account_id = patch_httpx.account_id
+    client = transport._get_lock_client()
+    with pytest.raises(_RetryableError, match="handshake0 could not reach"):
+        await transport._handshake0(client, b"\x01\x02\x03\x04")
+
+
+async def test_fetch_control_key_missing(patch_httpx):
+    patch_httpx.control_key = None
+    transport = _make_transport()
+    transport._token = patch_httpx.token
+    transport._device_id = patch_httpx.device_id
+    with pytest.raises(AuthenticationError, match="did not return a controlKey"):
+        await transport._fetch_control_key("secret", b"\x01\x02\x03\x04")
+
+
+async def test_fetch_control_key_requires_login():
+    transport = _make_transport()
+    with pytest.raises(KasaException, match="login and device id required"):
+        await transport._fetch_control_key("secret", b"\x01\x02\x03\x04")
+
+
+# ---------------------------------------------------------------------------
+# handshake1 error branches
+# ---------------------------------------------------------------------------
+
+
+async def test_handshake1_wrong_length(patch_httpx):
+    patch_httpx.hs1_mode = "badlen"
+    transport = _make_transport()
+    client = transport._get_lock_client()
+    with pytest.raises(KasaException, match="expected 48"):
+        await transport._handshake1(client, patch_httpx.control_key)
+
+
+async def test_handshake1_proof_mismatch(patch_httpx):
+    patch_httpx.hs1_mode = "badproof"
+    transport = _make_transport()
+    client = transport._get_lock_client()
+    with pytest.raises(AuthenticationError, match="server proof mismatch"):
+        await transport._handshake1(client, patch_httpx.control_key)
+
+
+async def test_handshake1_missing_cookie(patch_httpx):
+    patch_httpx.hs1_mode = "nocookie"
+    transport = _make_transport()
+    client = transport._get_lock_client()
+    with pytest.raises(KasaException, match=SESSION_COOKIE_NAME):
+        await transport._handshake1(client, patch_httpx.control_key)
+
+
+# ---------------------------------------------------------------------------
+# Encrypted request error branches / retry
+# ---------------------------------------------------------------------------
+
+
+async def test_send_403_forces_rehandshake_then_fails(patch_httpx):
+    patch_httpx.request_status = 403
+    transport = _make_transport()
+    with pytest.raises(KasaException, match="failed after retry"):
+        await transport.send('{"get_device_info": {}}')
+
+
+async def test_send_non_200(patch_httpx):
+    patch_httpx.request_status = 500
+    transport = _make_transport()
+    with pytest.raises(KasaException, match="responded with 500"):
+        await transport.send('{"get_device_info": {}}')
+
+
+async def test_send_decrypt_failure(patch_httpx):
+    patch_httpx.request_bad_body = True
+    transport = _make_transport()
+    with pytest.raises(KasaException, match="decrypting response"):
+        await transport.send('{"get_device_info": {}}')
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+async def test_reset_clears_session_state(patch_httpx):
+    transport = _make_transport()
+    await transport.send('{"get_device_info": {}}')
+    assert transport._session is not None
+    await transport.reset()
+    assert transport._session is None
+    assert transport._session_cookie is None
+    assert transport._handshake_done is False
+
+
+async def test_close_closes_lock_client(patch_httpx):
+    transport = _make_transport()
+    await transport.send('{"get_device_info": {}}')
+    lock_client = transport._lock_client
+    await transport.close()
+    assert transport._lock_client is None
+    assert lock_client.closed is True

--- a/tests/transports/test_dlklaptransport.py
+++ b/tests/transports/test_dlklaptransport.py
@@ -107,7 +107,7 @@ class FakeBackend:
     """Stateful fake cloud + lock device with per-test error injection knobs."""
 
     def __init__(self) -> None:
-        self.token = "cloud-token"
+        self.token = "cloud-token"  # noqa: S105 - fake cloud token for tests
         self.account_id = "ACCOUNT123"
         self.device_id = "DEVICE123"
         self.control_key: str | None = "K" * 64
@@ -194,6 +194,7 @@ class FakeBackend:
         self.local_seed = local_seed
         if self.hs1_mode == "badlen":
             return FakeResponse(200, content=b"\x00" * 10)
+        assert self.control_key is not None
         ck = self.control_key.upper().encode("ascii")
         if self.hs1_mode == "badproof":
             proof = b"\x00" * 32
@@ -231,7 +232,7 @@ class FakeAsyncClient:
         self._backend = backend
         self.closed = False
 
-    async def __aenter__(self) -> "FakeAsyncClient":
+    async def __aenter__(self) -> FakeAsyncClient:
         return self
 
     async def __aexit__(self, *exc) -> bool:
@@ -388,10 +389,10 @@ async def test_ensure_login_cloud_error(patch_httpx):
 
 async def test_ensure_login_is_cached(patch_httpx):
     transport = _make_transport()
-    transport._token = "cached"
+    transport._token = "cached"  # noqa: S105 - not a real secret
     transport._account_id = "cached-account"
     await transport._ensure_login()  # returns early, no network
-    assert transport._token == "cached"
+    assert transport._token == "cached"  # noqa: S105 - not a real secret
 
 
 async def test_ensure_device_id_none(patch_httpx):

--- a/uv.lock
+++ b/uv.lock
@@ -156,6 +156,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
 name = "appdirs"
 version = "1.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -689,6 +702,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1642,6 +1692,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "asyncclick" },
     { name = "cryptography" },
+    { name = "httpx" },
     { name = "mashumaro" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
@@ -1689,7 +1740,9 @@ docs = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3" },
     { name = "asyncclick", specifier = ">=8.1.7" },
+    { name = "cryptography" },
     { name = "cryptography", specifier = ">=1.9" },
+    { name = "httpx" },
     { name = "kasa-crypt", marker = "extra == 'speedups'", specifier = ">=0.2.0" },
     { name = "mashumaro", specifier = ">=3.20" },
     { name = "orjson", marker = "extra == 'speedups'", specifier = ">=3.11.1" },


### PR DESCRIPTION
## Summary

Adds first-class support for the **TP-Link DL100 smart lock** via a new
`DlklapTransport` and a `Lock` SmartModule. Closes #1693.

The DL100 speaks **DLKLAP**, a proprietary KLAP variant that runs over plain
**HTTP :80** and requires a **cloud-assisted `handshake0`** step to mint a
per-session `controlKey` before the usual KLAP handshake1/handshake2 and
AES-128-CBC session encryption. This transport implements that full pipeline
and slots into the existing Transport / Protocol / Device layering.

## What is DLKLAP?

Standard KLAP handshakes are fully local. DLKLAP inserts two cloud round-trips:

1. **Cloud login** (`wap.tplinkcloud.com`) → account token + `accountId`.
2. **`handshake0`** to the lock over HTTP → a 236-char base64 `secret` (this
   also wakes the lock's radio).
3. **control-key exchange** (`*.tplinknbu.com`) binds that `secret` to a
   per-session `controlKey`.
4. **handshake1 / handshake2** then proceed like KLAP, deriving the AES session
   keys (`lsk`/`ldk`/`iv`) used for `/app/request`.

Full protocol write-up is in #1693.

## Changes

- **`kasa/transports/dlklaptransport.py`** — `DlklapTransport(BaseTransport)`
  + `_DlklapSession`. Implements
  `handshake0 → control-key → handshake1 → handshake2 → session-key derivation`,
  session caching, and single-retry re-handshake on failure. Handshakes are
  serialized (`asyncio.Lock`) since a second `handshake0` invalidates the first
  control key (device error `15033`).
- **`kasa/smart/modules/lock.py`** — `Lock(SmartModule)`:
  `is_locked`, `lock()`, `unlock()`, `battery`, `battery_low`.
- **Device/discovery wiring** — `DeviceEncryptionType.Dlklap = "DLKLAP"`,
  `DeviceFamily.SmartTapoLock = "SMART.TAPOLOCK"`, `DeviceType.Lock`, the
  `SMART.DLKLAP → (SmartProtocol, DlklapTransport)` mapping in
  `device_factory.py`, and the `SMART.TAPOLOCK → DeviceType.Lock` mapping in
  `smartdevice.py`.
- **Tests** — `tests/smart/modules/test_lock.py` (mocked, no live device) plus a
  redacted DL100 fixture folded into the parametrized SMART suite.
- **`pyproject.toml`** — adds `httpx` to dependencies.

## Behavior notes for reviewers

- **`httpx` used directly** (not `HttpClient`) in the transport. This is
  deliberate: the 33-byte binary `handshake0` body must be sent verbatim, and
  wrapping middleware re-encodes the `text/plain` payload and breaks the
  handshake. Happy to revisit if there's a preferred integration point.
- **`verify=False` is scoped to a single call.** The control-key host presents
  TP-Link's private CA (not a public root), so TLS verification is disabled for
  that one request only (`# noqa: S501` with a comment). The cloud **login**
  call, which carries the account password, stays fully verified.
- **Battery lives on the `Lock` module** because the DL100 lacks the
  `battery_detect` component, so the generic `BatterySensor` never loads.
- **Lock-status polarity is counterintuitive and verified:** `0 = LOCKED`
  (bolt extended), `1 = UNLOCKED`. Confirmed against decompiled
  `EnumDoorLockStatus` and the live device — not inverted.

## Testing

- **Unit tests:** `pytest tests/smart/modules/test_lock.py` — all pass
  (module presence, `is_locked` polarity, `lock()`/`unlock()` payload with
  owner-forbidden fields excluded, battery).
- **Full suite:** `pytest tests/` — **22,856 passed, 883 skipped, 0 failures**,
  including the `test_devtools.py` fixture round-trip check.
- **Type/lint:** `mypy` clean on the new files; `ruff`/`ruff format` clean.
- **Live device:** verified end-to-end against a real DL100 (fw `1.0.17`) via
  `device_factory.connect()` → `update()` — `is_locked=True` (lock_status 0),
  `battery_level=81`, `battery_low=False`.

## Known limitations / follow-ups

- `_ensure_device_id` can't disambiguate **multiple** locks on one account (the
  cloud device list has no LAN IP), so it picks the sole `SMART.TAPOLOCK`.
  A future config override could address multi-lock setups.
- The DL100 advertises a `speaker` component it doesn't implement
  (`getVolume → UNKNOWN_METHOD_ERROR`); handled gracefully (module marked
  unavailable). Cosmetic device quirk, not a bug.
- This transport requires cloud round-trips (wap.tplinkcloud.com, tplinknbu.com) mid-handshake. The DL100 mints its controlKey via the cloud (there's no local-only path). The correct local-first implementation necessarily includes these minimal cloud round-trips.